### PR TITLE
feat(2665): onboard check perf data - prod checklist

### DIFF
--- a/terraform/application/config/production.tfvars.json
+++ b/terraform/application/config/production.tfvars.json
@@ -2,11 +2,23 @@
     "cluster": "production",
     "namespace": "schoolstandards-production",
     "use_private_storage": true,
+
+    "enable_postgres_high_availability": true,
     "enable_postgres_backup_storage" : true,
+    "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
+    "azure_maintenance_window": {
+        "day_of_week": 0,
+        "start_hour": 3,
+        "start_minute": 0
+    },
     "blob_delete_retention_days": 7,
     "enable_monitoring": true,
-    "replicas": 1,
+    "replicas": 2,
+    "enable_logit": true,
     "external_url": "https://check-performance-data.education.gov.uk/healthcheck",
     "apex_url": "https://check-performance-data.education.gov.uk",
-    "statuscake_contact_groups": [282453]
+    "statuscake_contact_groups": [282453,362348],
+    "azure_capacity": 1,
+    "azure_family": "C",
+    "azure_sku_name": "Standard"
 }

--- a/terraform/application/terraform.tf
+++ b/terraform/application/terraform.tf
@@ -35,3 +35,7 @@ provider "kubernetes" {
     args        = module.cluster_data.kubelogin_args
   }
 }
+
+provider "statuscake" {
+  api_token = module.infrastructure_secrets.map.STATUSCAKE-API-TOKEN
+}

--- a/terraform/domains/environment_domains/config/development.tfvars.json
+++ b/terraform/domains/environment_domains/config/development.tfvars.json
@@ -12,5 +12,8 @@
       "environment_short": "dv",
       "origin_hostname": "check-performance-data-development.test.teacherservices.cloud"
     }
-  }
+  },
+  "rate_limit_max": 1000,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/domains/environment_domains/config/preproduction.tfvars.json
+++ b/terraform/domains/environment_domains/config/preproduction.tfvars.json
@@ -12,5 +12,8 @@
       "environment_short": "pp",
       "origin_hostname": "check-performance-data-preproduction.teacherservices.cloud"
     }
-  }
+  },
+  "rate_limit_max": 1000,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -12,5 +12,8 @@
       "environment_short": "pd",
       "origin_hostname": "check-performance-data-production.teacherservices.cloud"
     }
-  }
+  },
+  "rate_limit_max": 1000,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/domains/environment_domains/config/qa.tfvars.json
+++ b/terraform/domains/environment_domains/config/qa.tfvars.json
@@ -12,5 +12,8 @@
       "environment_short": "qa",
       "origin_hostname": "check-performance-data-qa.test.teacherservices.cloud"
     }
-  }
+  },
+  "rate_limit_max": 1000,
+  "allow_aks": true,
+  "block_ip": true
 }

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -9,4 +9,8 @@ module "domains" {
   environment         = each.value.environment_short
   host_name           = each.value.origin_hostname
   cached_paths        = try(each.value.cached_paths, [])
+  rate_limit_max      = var.rate_limit_max
+  allow_aks           = var.allow_aks
+  block_ip            = var.block_ip
 }
+

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -2,3 +2,23 @@ variable "hosted_zone" {
   type    = map(any)
   default = {}
 }
+
+variable "rate_limit_max" {
+  type        = number
+  default     = null
+  description = "create a block rule that will limit any IP that goes above var.rate_limit_max over a 5 minute period"
+}
+
+variable "allow_aks" {
+  type        = bool
+  nullable    = false
+  default     = false
+  description = "allow all ingress from the aks cluster when a rate limit rule is active"
+}
+
+variable "block_ip" {
+  type        = bool
+  nullable    = false
+  default     = false
+  description = "create a specific IP block rule that is disabled. Makes it easier to add an IP and then enable the rule if required."
+}


### PR DESCRIPTION
## Context
This new service Check Performance Data to be onboarded with teacher service

## Changes proposed in this pull request 
completing prod checklist items:-
- enable postgres HA, instance size, maintenance window
- redis instance sizes, plan
- multiple replicas
- log forwarding 
- statuscake alerting
- rate limiting

## Guidance to review
```
make production terraform-plan CONFIRM_PRODUCTION=yes
```
<img width="1384" height="852" alt="Screenshot from 2026-05-06 10-57-04" src="https://github.com/user-attachments/assets/0291c958-2b33-474c-b015-962ccab4e3f1" />
<img width="1179" height="468" alt="Screenshot from 2026-05-06 10-57-17" src="https://github.com/user-attachments/assets/9754a13b-de31-4a57-bce7-52d044e184a3" />

rate limiting
<img width="1213" height="693" alt="Screenshot from 2026-05-06 12-18-01" src="https://github.com/user-attachments/assets/79743c72-b9c1-4ad4-8ec0-0890f70feab4" />

<img width="1213" height="753" alt="Screenshot from 2026-05-06 12-18-10" src="https://github.com/user-attachments/assets/655a3fbe-2dc1-4ec7-8d92-42d7f688eea9" />

<img width="1179" height="468" alt="Screenshot from 2026-05-06 10-57-17" src="https://github.com/user-attachments/assets/192c23a0-3788-4732-9ff4-1fc1a8d4eaf7" />





## Link to Trello card
https://trello.com/c/tubnhzCp/2665-onboard-check-performance-data

## Checklist
- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [ ]  Tested by running locally