### PR TITLE
feat(2665): onboard perf data - add manual deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -171,7 +171,7 @@ jobs:
         terraform-base: ${{ env.TERRAFORM_BASE }}
         healthcheck: ${{ env.HEALTHCHECK_CMD }}
         teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
-        # service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+        service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
 #        smoke-test: true
 #         db-seed: ${{ inputs.environment == 'review' && 'true' || 'false' }}
 # #        gcp-wip: ${{ vars.GCP_WIP }}
@@ -196,7 +196,7 @@ jobs:
         azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
         azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
         teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
-        # service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
+        service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
 
   deploy_domains_env:
     name: Deploy Domains to ${{ matrix.domain_environment }} environment

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -146,33 +146,33 @@ jobs:
 #        gcp-wip: ${{ vars.GCP_WIP }}
 #        gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
 
-#   manual_deploy:
-#     name: Manual deploy
-#     if: ${{ github.event_name == 'workflow_dispatch' }}
-#     environment:
-#       name: ${{ inputs.environment }}
-#       url: ${{ steps.deploy_manual.outputs.environment_url }}
-#     runs-on: ubuntu-latest
-#     permissions:
-#       id-token: write
-#       pull-requests: write
+  manual_deploy:
+    name: Manual deploy
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ steps.deploy_manual.outputs.environment_url }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pull-requests: write
 
-#     steps:
-#     - name: Deploy app to ${{ inputs.environment }}
-#       id: deploy_manual
-#       uses: DFE-Digital/github-actions/deploy-to-aks@master
-#       with:
-#         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-#         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-#         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-#         environment: ${{ inputs.environment }}
-#         pr-number: ${{ inputs.pull-request-number }}
-#         sha: ${{ inputs.docker-image-tag }}
-#         terraform-base: ${{ env.TERRAFORM_BASE }}
-#         healthcheck: ${{ env.HEALTHCHECK_CMD }}
-        # teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+    steps:
+    - name: Deploy app to ${{ inputs.environment }}
+      id: deploy_manual
+      uses: DFE-Digital/github-actions/deploy-to-aks@master
+      with:
+        azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        environment: ${{ inputs.environment }}
+        pr-number: ${{ inputs.pull-request-number }}
+        sha: ${{ inputs.docker-image-tag }}
+        terraform-base: ${{ env.TERRAFORM_BASE }}
+        healthcheck: ${{ env.HEALTHCHECK_CMD }}
+        teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
         # service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
-#         smoke-test: true
+#        smoke-test: true
 #         db-seed: ${{ inputs.environment == 'review' && 'true' || 'false' }}
 # #        gcp-wip: ${{ vars.GCP_WIP }}
 # #        gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
@@ -195,7 +195,7 @@ jobs:
         azure-client-id:  ${{ secrets.AZURE_CLIENT_ID  }}
         azure-tenant-id:  ${{ secrets.AZURE_TENANT_ID   }}
         azure-subscription-id:  ${{ secrets.AZURE_SUBSCRIPTION_ID   }}
-        # teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+        teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
         # service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
 
   deploy_domains_env:


### PR DESCRIPTION
## Context
This new service Check Performance Data to be onboarded with teacher service

## Changes proposed in this pull request
- enable manual deploy within build&deploy workflow

## Guidance to review
https://github.com/DFE-Digital/check-performance-data/actions/runs/25491946169

<img width="1809" height="571" alt="Screenshot from 2026-05-07 12-13-39" src="https://github.com/user-attachments/assets/b1debada-8f84-44a3-a772-e24b5b77d878" />

<img width="1503" height="238" alt="Screenshot from 2026-05-07 12-13-57" src="https://github.com/user-attachments/assets/6173c4ec-7917-401e-b1c1-a1dab24ef61d" />



## Link to Trello card
https://trello.com/c/tubnhzCp/2665-onboard-check-performance-data

## Checklist
- [x]  Attach to Trello card
- [x]  Rebased main
- [x]  Cleaned commit history
- [ ]  Tested by running locally