### PR TITLE
Make rules worker tolerant of transient storage errors at startup

### DIFF
--- a/src/DfE.CheckPerformanceData.RulesEngineWorker/RulesEngineWorker.cs
+++ b/src/DfE.CheckPerformanceData.RulesEngineWorker/RulesEngineWorker.cs
@@ -41,12 +41,23 @@ public sealed class RulesEngineWorker : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await _queueClient.CreateIfNotExistsAsync(cancellationToken: stoppingToken);
+        // Queue creation is inside the loop so a transient storage error at startup
+        // is retried like any other failure rather than escaping ExecuteAsync. An
+        // unhandled exception here would stop the host, and the worker has no
+        // readiness probe, so the pod would crash-loop and the deploy rollout would
+        // time out. Once created, the flag short-circuits the idempotent call.
+        var queueReady = false;
 
         while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
+                if (!queueReady)
+                {
+                    await _queueClient.CreateIfNotExistsAsync(cancellationToken: stoppingToken);
+                    queueReady = true;
+                }
+
                 await PollQueueAsync(stoppingToken);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)

--- a/tests/DfE.CheckPerformanceData.UnitTests/DfE.CheckPerformanceData.Application.UnitTests.csproj
+++ b/tests/DfE.CheckPerformanceData.UnitTests/DfE.CheckPerformanceData.Application.UnitTests.csproj
@@ -35,6 +35,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DfE.CheckPerformanceData.Application\DfE.CheckPerformanceData.Application.csproj" />
     <ProjectReference Include="..\..\src\DfE.CheckPerformanceData.Infrastructure\DfE.CheckPerformanceData.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\DfE.CheckPerformanceData.RulesEngineWorker\DfE.CheckPerformanceData.RulesEngineWorker.csproj" />
     <ProjectReference Include="..\..\src\DfE.CheckPerformanceData.Web\DfE.CheckPerformanceData.Web.csproj" />
   </ItemGroup>
 

--- a/tests/DfE.CheckPerformanceData.UnitTests/Worker/RulesEngineWorkerResilienceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Worker/RulesEngineWorkerResilienceTests.cs
@@ -1,0 +1,70 @@
+using Azure;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using DfE.CheckPerformanceData.Application.RequestDecision;
+using DfE.CheckPerformanceData.Application.RulesEngine;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using WorkerService = DfE.CheckPerformanceData.RulesEngineWorker.RulesEngineWorker;
+using RulesEngineOptions = DfE.CheckPerformanceData.RulesEngineWorker.RulesEngineOptions;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Worker;
+
+public sealed class RulesEngineWorkerResilienceTests
+{
+    private static RulesEngineOptions FastOptions() => new()
+    {
+        QueueName = "rules-queue",
+        MaxMessagesPerPoll = 1,
+        RetryDelayMs = 0,
+        EmptyQueueDelayMs = 0,
+        MaxDequeueCount = 5,
+        VisibilityTimeout = TimeSpan.FromSeconds(30)
+    };
+
+    private static WorkerService CreateWorker(QueueServiceClient serviceClient, RulesEngineOptions options) =>
+        new(
+            Substitute.For<ILogger<WorkerService>>(),
+            serviceClient,
+            Options.Create(options),
+            Substitute.For<IRequestDecisionHandler>(),
+            Substitute.For<IRulesProvider>(),
+            Substitute.For<IRulesEngine>(),
+            Substitute.For<IRuleContextMapper>());
+
+    [Fact]
+    public async Task ExecuteAsync_WhenQueueCreationFailsTransiently_RecoversWithoutTearingDownTheHost()
+    {
+        var queueClient = Substitute.For<QueueClient>();
+        var serviceClient = Substitute.For<QueueServiceClient>();
+        serviceClient.GetQueueClient(Arg.Any<string>()).Returns(queueClient);
+
+        // First create attempt throws a transient storage error; the second succeeds.
+        // The pre-fix code creates the queue once, outside the poll loop, so the
+        // transient throw escapes ExecuteAsync and stops the host (CrashLoopBackOff).
+        queueClient.CreateIfNotExistsAsync(Arg.Any<IDictionary<string, string>>(), Arg.Any<CancellationToken>())
+            .Returns(
+                _ => throw new RequestFailedException(503, "storage temporarily unavailable"),
+                _ => Task.FromResult<Response>(null!));
+
+        var empty = Response.FromValue(Array.Empty<QueueMessage>(), Substitute.For<Response>());
+        queueClient.ReceiveMessagesAsync(Arg.Any<int?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(empty));
+
+        var worker = CreateWorker(serviceClient, FastOptions());
+
+        using var cts = new CancellationTokenSource();
+
+        // Should not throw: a transient startup failure must be retried, not fatal.
+        await worker.StartAsync(cts.Token);
+        await Task.Delay(150);
+        cts.Cancel();
+        await worker.StopAsync(CancellationToken.None);
+
+        // Proves the worker got past the failed creation and reached the queue —
+        // i.e. it recovered rather than crashing on the transient error.
+        await queueClient.Received().ReceiveMessagesAsync(
+            Arg.Any<int?>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
The worker created the queue once before its poll loop. A transient storage error there escaped ExecuteAsync and stopped the host. The worker has no readiness probe (the shared aks/application module only adds probes for web apps), so the pod crash-looped and the review deploy timed out waiting for the rollout (0/1 replicas ready), intermittently.

- Move CreateIfNotExistsAsync inside the poll loop so a startup failure is retried and logged like any other, guarded by a flag so it runs once.
- Reference the worker project from the unit tests and add a regression test proving the worker recovers from a transient queue-creation failure.