### PR TITLE
Rules engine portal alignment

### DIFF
--- a/src/DfE.CheckPerformanceData.Application/CheckYourPupilData/ICheckYourPupilDataService.cs
+++ b/src/DfE.CheckPerformanceData.Application/CheckYourPupilData/ICheckYourPupilDataService.cs
@@ -33,6 +33,10 @@ public sealed class PupilDto
     public required int Age { get; init; }
     public required string Cypmd_Id { get; init; }
     public required string Upn { get; init; }
+
+    /// <summary>Inclusion status code from the pupil record (e.g. 401). Not required so
+    /// sessions serialised before this field existed still deserialise; 0 = not supplied.</summary>
+    public int Pincl { get; set; }
 }
 
 public record PupilSuggestionDto(Guid Id, string Label);

--- a/src/DfE.CheckPerformanceData.Application/DependencyManager.cs
+++ b/src/DfE.CheckPerformanceData.Application/DependencyManager.cs
@@ -34,6 +34,20 @@ public static class DependencyManager
         services.AddScoped<IJourneyCondition, SchoolIsIndependentCondition>();
         services.AddScoped<IAmendmentRequestsService, AmendmentRequestsService>();
 
+        services.AddRulesEngineDependencies();
+
+        return services;
+    }
+
+    /// <summary>
+    /// The rules-engine subset of the Application layer: pure singletons with no
+    /// repository or external-client dependencies. The RulesEngineWorker host calls
+    /// this instead of <see cref="AddApplicationDependencies"/> — the full set needs
+    /// Persistence repositories, the DfE Sign-in client and the journey blob clients,
+    /// which only the Web host registers.
+    /// </summary>
+    public static IServiceCollection AddRulesEngineDependencies(this IServiceCollection services)
+    {
         services.AddSingleton<IRulesEngine, RulesEngine.RulesEngine>();
         services.AddSingleton<IRuleContextMapper, RuleContextMapper>();
         services.AddSingleton<RuleSetValidator>();

--- a/src/DfE.CheckPerformanceData.Application/Journey/IQuestionFlowService.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/IQuestionFlowService.cs
@@ -11,4 +11,5 @@ public interface IQuestionFlowService
     JourneyNavigation? GetNavigationGuard(QuestionFlowConfig config, RequestState journey, string pageId);
     string BuildContentKey(Guid windowId, JourneyPage page, Dictionary<string, QuestionAnswer> answers, RequestState journey, QuestionFlowConfig config);
     string ResolveRequestType(QuestionFlowConfig config, RequestState journey);
+    string ResolveRequestTypeValue(QuestionFlowConfig config, RequestState journey);
 }

--- a/src/DfE.CheckPerformanceData.Application/Journey/JourneySubmissionContext.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/JourneySubmissionContext.cs
@@ -7,7 +7,14 @@ public sealed class JourneySubmissionContext
 {
     public Guid WindowId { get; init; }
     public required string ReferenceNumber { get; init; }
-    public WhatToChange WhatToChange { get; init; }
+
+    /// <summary>
+    /// The rules-engine contract string: the <c>WhatToChange</c> enum name, suffixed
+    /// with <c>" - {reason option value}"</c> when the flow has a
+    /// <c>useAsRequestType</c> question (e.g. <c>"Remove - pupil-died"</c>).
+    /// Keys of <c>AnswerFieldMap.WhatToChangeToOutcomeKey</c> must match these.
+    /// </summary>
+    public required string WhatToChange { get; init; }
     public required PupilDto Pupil { get; init; }
     public PupilDto? MatchedPupil { get; init; }
     public required CheckingWindowDto CheckingWindow { get; init; }

--- a/src/DfE.CheckPerformanceData.Application/Journey/QuestionAnswer.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/QuestionAnswer.cs
@@ -3,6 +3,14 @@ namespace DfE.CheckPerformanceData.Application.Journey;
 public sealed class QuestionAnswer
 {
     public string? TextValue { get; set; }
+
+    /// <summary>
+    /// For <c>Autocomplete</c> questions: the selected option's stable code
+    /// (e.g. ISO country code), captured from the <c>{field}_code</c> hidden input.
+    /// <see cref="TextValue"/> holds the display name the user saw.
+    /// </summary>
+    public string? CodeValue { get; set; }
+
     public DateAnswer? DateValue { get; set; }
     public List<FileAnswer>? FileValues { get; set; }
 }

--- a/src/DfE.CheckPerformanceData.Application/Journey/QuestionFlowService.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/QuestionFlowService.cs
@@ -107,6 +107,28 @@ public sealed class QuestionFlowService(IQuestionFlowBlobClient blobClient, IMem
         return string.Empty;
     }
 
+    public string ResolveRequestTypeValue(QuestionFlowConfig config, RequestState journey)
+    {
+        // Raw answer value of the first answered UseAsRequestType question in the
+        // visited branch. Deliberately no fallback to unflagged questions: this feeds
+        // the rules engine's WhatToChange contract, so flows without a flagged
+        // question must always produce the bare WhatToChange prefix.
+        foreach (var pageId in journey.QuestionHistory)
+        {
+            var page = GetPage(config, pageId);
+            if (page is null) continue;
+
+            foreach (var question in page.Questions)
+            {
+                if (!question.UseAsRequestType) continue;
+                if (!journey.QuestionAnswers.TryGetValue(question.Id, out var answer)) continue;
+                return answer.TextValue ?? string.Empty;
+            }
+        }
+
+        return string.Empty;
+    }
+
     private static string ResolveAnswerLabel(Question question, QuestionAnswer answer)
     {
         if (question.Type == QuestionType.Radio && answer.TextValue is not null)

--- a/src/DfE.CheckPerformanceData.Application/RequestDecision/IDecisionOutcomeRepository.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestDecision/IDecisionOutcomeRepository.cs
@@ -1,0 +1,14 @@
+using DfE.CheckPerformanceData.Application.RulesEngine;
+
+namespace DfE.CheckPerformanceData.Application.RequestDecision;
+
+/// <summary>
+/// Writes the rules engine's decision back to the <c>ChangeRequests</c> row the
+/// request was submitted from. The update is idempotent so a retried queue
+/// message simply rewrites the same values.
+/// </summary>
+public interface IDecisionOutcomeRepository
+{
+    /// <returns><c>true</c> when a <c>ChangeRequests</c> row was updated.</returns>
+    Task<bool> RecordOutcomeAsync(Guid changeRequestId, Decision decision, CancellationToken token);
+}

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/IRequestQueueClient.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/IRequestQueueClient.cs
@@ -1,0 +1,11 @@
+namespace DfE.CheckPerformanceData.Application.RequestSubmission;
+
+/// <summary>
+/// Sends a submitted <see cref="RequestDocument"/> to the rules-engine queue.
+/// Implemented in Infrastructure (Azure Storage Queue) so the Application layer
+/// stays free of storage SDK types — same pattern as the blob clients.
+/// </summary>
+public interface IRequestQueueClient
+{
+    Task EnqueueRequestAsync(RequestDocument document);
+}

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/IRequestRepository.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/IRequestRepository.cs
@@ -5,6 +5,7 @@ namespace DfE.CheckPerformanceData.Application.RequestSubmission;
 public interface IRequestRepository
 {
     Task<bool> HasConflictingRequestAsync(Guid windowId, string pupilUpn, long organisationUrn, string currentReferenceNumber);
-    Task UpsertAsync(ChangeRequestData data);
+    /// <returns>The Id of the inserted or updated <c>ChangeRequests</c> row.</returns>
+    Task<Guid> UpsertAsync(ChangeRequestData data);
     Task<IReadOnlyList<AmendmentRequestData>> GetAmendmentRequestsAsync(Guid windowId, long organisationUrn);
 }

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestDocument.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestDocument.cs
@@ -36,6 +36,10 @@ public sealed class PupilDetails
     public required string Sex { get; init; }
     public required int Age { get; init; }
     public required string Upn { get; init; }
+
+    /// <summary>Inclusion status code from the pupil record. The rules engine reads
+    /// <c>inclusionFlag</c> from here — it is never asked as a journey question. 0 = not supplied.</summary>
+    public int Pincl { get; init; }
 }
 
 public sealed class AnswerRecord
@@ -43,7 +47,17 @@ public sealed class AnswerRecord
     public required string QuestionId { get; init; }
     public required string QuestionTitle { get; init; }
     public required string Type { get; init; }
+
+    /// <summary>Display value (radio option label, dd/MM/yyyy date) — used in Zendesk ticket descriptions.</summary>
     public string? Value { get; init; }
+
+    /// <summary>
+    /// Engine-facing value: the radio option's stable value, dates as yyyy-MM-dd,
+    /// an Autocomplete answer's code. <c>RuleContextMapper</c> reads this in
+    /// preference to <see cref="Value"/> so UI copy changes cannot affect rules.
+    /// </summary>
+    public string? RawValue { get; init; }
+
     public List<FileRecord>? Files { get; init; }
 }
 

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestDocument.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestDocument.cs
@@ -7,7 +7,14 @@ public class RequestDocument
     public required UserDetails SubmittedBy { get; init; }
     public Guid CheckingWindowId { get; init; }
     public required string CheckingWindowType { get; init; }
-    public required string WhatToChange { get; init; }
+    /// <summary>
+    /// Stable machine code for the requested change: the <c>WhatToChange</c> enum
+    /// name, suffixed with <c>" - {reason option value}"</c> when the flow has a
+    /// <c>useAsRequestType</c> question (e.g. <c>"Remove - pupil-died"</c>). The
+    /// rules engine routes on this via <c>AnswerFieldMap.WhatToChangeToOutcomeKey</c>;
+    /// the display-label twin is <c>ChangeRequest.RequestType</c>.
+    /// </summary>
+    public required string RequestTypeCode { get; init; }
     public required SchoolDetails School { get; init; }
     public required PupilDetails Pupil { get; init; }
     public PupilDetails? MatchedPupil { get; init; }

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestDocument.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestDocument.cs
@@ -2,6 +2,12 @@ namespace DfE.CheckPerformanceData.Application.RequestSubmission;
 
 public class RequestDocument
 {
+    /// <summary>
+    /// Primary key of the <c>ChangeRequests</c> row this document was built from.
+    /// The rules engine worker writes its decision back to that row by this Id.
+    /// </summary>
+    public required Guid ChangeRequestId { get; init; }
+
     public required string ReferenceNumber { get; init; }
     public DateTime SubmittedAt { get; init; }
     public required UserDetails SubmittedBy { get; init; }

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestService.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestService.cs
@@ -138,7 +138,7 @@ public sealed class RequestService(
             },
             CheckingWindowId = context.WindowId,
             CheckingWindowType = context.CheckingWindow.CheckingWindowType.ToString(),
-            WhatToChange = context.WhatToChange,
+            RequestTypeCode = context.WhatToChange,
             School = new SchoolDetails
             {
                 Urn = currentUserService.OrganisationUrn,

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestService.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestService.cs
@@ -40,9 +40,12 @@ public sealed class RequestService(
             History = journey.QuestionHistory
         };
 
-        var document = BuildRequestDocument(context, config);
+        // Upsert first: the document carries the ChangeRequest row's Id so the
+        // rules engine worker can write its decision back to that row.
+        var changeRequestId = await requestRepository.UpsertAsync(
+            BuildChangeRequestData(windowId, journey, RequestStatus.SubmittedUnCommitted, config));
+        var document = BuildRequestDocument(context, config, changeRequestId);
         await requestQueueClient.EnqueueRequestAsync(document);
-        await requestRepository.UpsertAsync(BuildChangeRequestData(windowId, journey, RequestStatus.SubmittedUnCommitted, config));
     }
 
     public async Task ConfirmDataCorrectAsync(Guid windowId, string referenceNumber)
@@ -109,7 +112,7 @@ public sealed class RequestService(
             RequestType = BuildRequestType(journey, config)
         };
 
-    private RequestDocument BuildRequestDocument(JourneySubmissionContext context, QuestionFlowConfig config)
+    private RequestDocument BuildRequestDocument(JourneySubmissionContext context, QuestionFlowConfig config, Guid changeRequestId)
     {
         var pupil = context.Pupil;
         var pupilName = $"{pupil.Firstname} {pupil.Surname}".Trim();
@@ -129,6 +132,7 @@ public sealed class RequestService(
 
         return new RequestDocument
         {
+            ChangeRequestId = changeRequestId,
             ReferenceNumber = context.ReferenceNumber,
             SubmittedAt = DateTime.UtcNow,
             SubmittedBy = new UserDetails

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestService.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestService.cs
@@ -6,10 +6,10 @@ namespace DfE.CheckPerformanceData.Application.RequestSubmission;
 
 public sealed class RequestService(
     IQuestionFlowService flowService,
-    IRequestBlobClient requestBlobClient,
     IDraftBlobClient draftBlobClient,
     IRequestRepository requestRepository,
-    ICurrentUserService currentUserService) : IRequestService
+    ICurrentUserService currentUserService,
+    IRequestQueueClient requestQueueClient) : IRequestService
 {
     private long OrganisationUrnLong => long.Parse(currentUserService.OrganisationUrn);
 
@@ -41,7 +41,7 @@ public sealed class RequestService(
         };
 
         var document = BuildRequestDocument(context, config);
-        await requestBlobClient.SaveRequestAsync(windowId, document);
+        await requestQueueClient.EnqueueRequestAsync(document);
         await requestRepository.UpsertAsync(BuildChangeRequestData(windowId, journey, RequestStatus.SubmittedUnCommitted, config));
     }
 
@@ -153,7 +153,8 @@ public sealed class RequestService(
                 DateOfBirth = pupil.DateOfBirth,
                 Sex = pupil.Sex,
                 Age = pupil.Age,
-                Upn = pupil.Upn
+                Upn = pupil.Upn,
+                Pincl = pupil.Pincl
             },
             MatchedPupil = context.MatchedPupil is { } mp ? new PupilDetails
             {
@@ -164,7 +165,8 @@ public sealed class RequestService(
                 DateOfBirth = mp.DateOfBirth,
                 Sex = mp.Sex,
                 Age = mp.Age,
-                Upn = mp.Upn
+                Upn = mp.Upn,
+                Pincl = mp.Pincl
             } : null,
             Answers = answers
         };
@@ -200,12 +202,21 @@ public sealed class RequestService(
             _ => answer?.TextValue
         };
 
+        var rawValue = question.Type switch
+        {
+            QuestionType.Date when answer?.DateValue is { } d =>
+                $"{d.Year:D4}-{d.Month:D2}-{d.Day:D2}",
+            QuestionType.Autocomplete => answer?.CodeValue ?? answer?.TextValue,
+            _ => answer?.TextValue
+        };
+
         return new AnswerRecord
         {
             QuestionId = question.Id,
             QuestionTitle = title,
             Type = question.Type.ToString(),
-            Value = value
+            Value = value,
+            RawValue = rawValue
         };
     }
 }

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestService.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestService.cs
@@ -32,7 +32,7 @@ public sealed class RequestService(
         {
             WindowId = windowId,
             ReferenceNumber = journey.ReferenceNumber ?? string.Empty,
-            WhatToChange = journey.SelectedWhatToChange.Value,
+            WhatToChange = BuildWhatToChangeValue(journey, config),
             Pupil = journey.SelectedPupil,
             MatchedPupil = journey.MatchedPupil,
             CheckingWindow = journey.CheckingWindow,
@@ -83,6 +83,16 @@ public sealed class RequestService(
         return string.IsNullOrEmpty(detail) ? prefix : $"{prefix} - {detail}";
     }
 
+    // The rules-engine contract: like BuildRequestType but using the stable option
+    // *value* rather than the display label, so UI copy changes cannot break the
+    // engine's WhatToChangeToOutcomeKey routing.
+    private string BuildWhatToChangeValue(RequestState journey, QuestionFlowConfig config)
+    {
+        var prefix = journey.SelectedWhatToChange!.Value.ToString();
+        var detail = flowService.ResolveRequestTypeValue(config, journey);
+        return string.IsNullOrEmpty(detail) ? prefix : $"{prefix} - {detail}";
+    }
+
     private ChangeRequestData BuildChangeRequestData(Guid windowId, RequestState journey, RequestStatus status, QuestionFlowConfig? config) =>
         new()
         {
@@ -128,7 +138,7 @@ public sealed class RequestService(
             },
             CheckingWindowId = context.WindowId,
             CheckingWindowType = context.CheckingWindow.CheckingWindowType.ToString(),
-            WhatToChange = context.WhatToChange.ToString(),
+            WhatToChange = context.WhatToChange,
             School = new SchoolDetails
             {
                 Urn = currentUserService.OrganisationUrn,

--- a/src/DfE.CheckPerformanceData.Application/RulesEngine/AnswerFieldMap.cs
+++ b/src/DfE.CheckPerformanceData.Application/RulesEngine/AnswerFieldMap.cs
@@ -122,7 +122,7 @@ public static class AnswerFieldMap
     };
 
     /// <summary>
-    /// <c>RequestDocument.WhatToChange</c> contract string → canonical outcome key used
+    /// <c>RequestDocument.RequestTypeCode</c> contract string → canonical outcome key used
     /// by <see cref="OutcomeRules.Key"/> in the rules JSON. The contract string is the
     /// <c>WhatToChange</c> enum name, suffixed with <c>" - {option value}"</c> when the
     /// flow config flags a question with <c>useAsRequestType</c> (the Remove flows'

--- a/src/DfE.CheckPerformanceData.Application/RulesEngine/AnswerFieldMap.cs
+++ b/src/DfE.CheckPerformanceData.Application/RulesEngine/AnswerFieldMap.cs
@@ -1,68 +1,125 @@
 namespace DfE.CheckPerformanceData.Application.RulesEngine;
 
 /// <summary>
-/// Maps the producer side's vocabulary (form <c>QuestionId</c>s on the message,
-/// <c>WhatToChange</c> contract strings) onto the engine's canonical names.
-/// Updating either side requires touching only this file.
+/// Maps the producer side's vocabulary (journey question ids and option values on
+/// the message, <c>WhatToChange</c> contract strings) onto the engine's canonical
+/// names. Updating either side requires touching only this file.
+/// <c>QuestionFlowOutcomeKeyAlignmentTests</c> pins the Web flow configs to these
+/// maps in CI.
 /// </summary>
 /// <remarks>
 /// This indirection is deliberate — it is an anti-corruption boundary so the rules
-/// (Application) layer never depends on Web journey-authoring ids. It cannot be
-/// removed by simply renaming the Journey question ids to canonical names, because
-/// the relationship is not 1:1: the same concept resolves to a different canonical
-/// field by key stage (e.g. <c>sat-exams</c> → <c>hasSatExamsAsYear11</c> for KS4
-/// but <c>hasSatExamsAsYear6</c> for KS2), and journey-only questions
-/// (<c>reason</c>, <c>evidence</c>, …) are intentionally projected out (see below).
+/// (Application) layer never depends on Web journey-authoring ids. The relationship
+/// is not 1:1: <c>sat-exams</c> resolves by key stage (<see cref="SatExamsFieldFor"/>),
+/// single-choice radios fan out to several booleans (<see cref="RadioFanOut"/>),
+/// some answers carry journey vocabulary the rules don't use
+/// (<see cref="TranslatedQuestions"/>), and journey-only questions
+/// (<c>reason</c>, <c>evidence</c>, …) are intentionally projected out.
 /// Question ids are also the contract for serialized in-flight draft state, so a
 /// rename would be a breaking change with no migration path.
+///
+/// Fields with no producer source yet — no journey question collects them — stay
+/// <c>Unknown</c> so their rules defer to Scrutiny: <c>isAddBack</c>,
+/// <c>illnessHasSevereProfoundEffect</c>, <c>whereaboutsKnown</c>,
+/// <c>locatedAfterReasonableEfforts</c>.
 /// </remarks>
 public static class AnswerFieldMap
 {
     /// <summary>
     /// <c>Answer.QuestionId</c> on the queue message → canonical field name in
-    /// <see cref="FieldCatalogue"/>. An entry's presence here is what makes the
-    /// mapper consider an answer at all; unmapped answers are silently ignored.
+    /// <see cref="FieldCatalogue"/>, for answers whose value is copied as-is and
+    /// parsed by the field's type. An entry's presence here (or in
+    /// <see cref="RadioFanOut"/>/<see cref="TranslatedQuestions"/>/<see cref="SatExamsQuestionId"/>)
+    /// is what makes the mapper consider an answer at all; unmapped answers are
+    /// silently ignored.
     /// </summary>
     public static readonly IReadOnlyDictionary<string, string> QuestionToField =
         new Dictionary<string, string>(StringComparer.Ordinal)
         {
-            ["inclusion-status-flag"]            = "inclusionFlag",
+            // EAL (Remove - english-not-first-language)
+            ["country-originally-from"]                = "countryOfOrigin",
+            ["date-pupil-started"]                     = "schoolAdmissionDate",
+            ["date-pupil-started-school-in-england"]   = "firstSchoolAdmissionDate",
+            ["date-pupil-arrived-in-england"]          = "dateOfArrivalInEngland",
 
-            ["first-language"]                   = "firstLanguage",
-            ["country-of-origin"]                = "countryOfOrigin",
-            ["is-add-back"]                      = "isAddBack",
-            ["school-admission-date"]            = "schoolAdmissionDate",
-            ["first-school-admission-date"]      = "firstSchoolAdmissionDate",
-            ["date-of-arrival-in-england"]       = "dateOfArrivalInEngland",
+            // Exclusion / removal dates. Two different journey questions feed
+            // dateOfPermanentExclusion: date-pupil-excluded on the "admitted following
+            // permanent exclusion" branch, date-permanently-excluded on the
+            // "permanently excluded from current school" branch.
+            ["date-pupil-excluded"]                    = "dateOfPermanentExclusion",
+            ["date-permanently-excluded"]              = "dateOfPermanentExclusion",
+            ["date-removed-from-roll"]                 = "dateOfRemoval",
 
-            ["date-of-permanent-exclusion"]      = "dateOfPermanentExclusion",
-            ["date-of-removal-from-roll"]        = "dateOfRemoval",
-            ["date-added-to-roll"]               = "dateAddedToRoll",
-
-            ["year-group-change"]                = "yearGroupChange",
-            ["removal-reason-at-school"]         = "removalReasonAtSchool",
-
-            ["social-care-involvement"]          = "hadSocialCareInvolvement",
-            ["recent-police-involvement"]        = "hadRecentPoliceInvolvement",
-            ["detained-in-prison"]               = "hasBeenDetainedInPrison",
-
-            ["sat-exams-y11"]                    = "hasSatExamsAsYear11",
-            ["sat-exams-y6"]                     = "hasSatExamsAsYear6",
-
-            ["terminal-illness"]                 = "hasTerminalIllness",
-            ["critical-illness-12m"]             = "hasCriticalIllness12mPlus",
-            ["recent-life-changing-diagnosis"]   = "hasRecentLifeChangingDiagnosis",
-            ["recent-life-changing-injury"]      = "hasRecentLifeChangingInjury",
-            ["under-investigation-12m"]          = "underInvestigation12mPlus",
-            ["severe-profound-effect"]           = "illnessHasSevereProfoundEffect",
-
-            ["whereabouts-known"]                = "whereaboutsKnown",
-            ["located-reasonable-efforts"]       = "locatedAfterReasonableEfforts",
-
-            ["continuing-ks2-studies"]           = "isContinuingKS2Studies",
-
-            ["pupil-age"]                        = "pupilAge",
+            // Provisional ids for flows not yet authored (KS2 / Post16) — revisit
+            // when those configs exist; the alignment test allowlists them.
+            ["date-added-to-roll"]                     = "dateAddedToRoll",
+            ["removal-reason-at-school"]               = "removalReasonAtSchool",
+            ["continuing-ks2-studies"]                 = "isContinuingKS2Studies",
+            ["pupil-age"]                              = "pupilAge",
         };
+
+    /// <summary>
+    /// Single-choice radio questions the rules model as independent booleans:
+    /// the selected option's field becomes <c>true</c>, every other listed field
+    /// <c>false</c>. An empty answer leaves all fields <c>Unknown</c>.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, IReadOnlyList<(string Field, string TriggerValue)>> RadioFanOut =
+        new Dictionary<string, IReadOnlyList<(string, string)>>(StringComparer.Ordinal)
+        {
+            ["social-care-reason"] =
+            [
+                ("hadSocialCareInvolvement",     "social-care-situation"),
+                ("hadRecentPoliceInvolvement",   "police-involvement"),
+                ("hasBeenDetainedInPrison",      "detained-in-prison"),
+            ],
+            ["life-limiting-illness-health-issue"] =
+            [
+                ("hasTerminalIllness",             "life-limiting"),
+                ("hasCriticalIllness12mPlus",      "twelve-months-critically-ill"),
+                ("hasRecentLifeChangingDiagnosis", "life-changing-illness"),
+                ("hasRecentLifeChangingInjury",    "life-changing-injury"),
+                ("underInvestigation12mPlus",      "investigated"),
+            ],
+        };
+
+    /// <summary>
+    /// Questions whose journey option values translate into a different canonical
+    /// vocabulary. Unlisted raw values resolve to <see cref="FieldValue.Unknown"/>
+    /// (fail safe → Scrutiny); "believed" answers become
+    /// <see cref="FieldValue.Uncertain"/> so <c>isKnownAndCertain</c> rules see them.
+    /// </summary>
+    public static readonly IReadOnlyDictionary<string, (string Field, IReadOnlyDictionary<string, FieldValue> Values)> TranslatedQuestions =
+        new Dictionary<string, (string, IReadOnlyDictionary<string, FieldValue>)>(StringComparer.Ordinal)
+        {
+            ["first-language"] = ("firstLanguage", new Dictionary<string, FieldValue>(StringComparer.Ordinal)
+            {
+                ["english"]          = new FieldValue.Str("ENG"),
+                ["believed-english"] = new FieldValue.Uncertain(new FieldValue.Str("ENG")),
+                ["other"]            = new FieldValue.Str("OTH"),
+                ["believed-other"]   = new FieldValue.Uncertain(new FieldValue.Str("OTH")),
+                // chose-not-to-say / not-known fall through to Unknown.
+            }),
+            ["higher-lower"] = ("yearGroupChange", new Dictionary<string, FieldValue>(StringComparer.Ordinal)
+            {
+                ["higher"] = new FieldValue.Str("Higher"),
+                ["lower"]  = new FieldValue.Str("Lower"),
+            }),
+        };
+
+    /// <summary>
+    /// The journey asks one <c>sat-exams</c> yes/no question; the rules distinguish
+    /// the year-11 and year-6 variants by key stage.
+    /// </summary>
+    public const string SatExamsQuestionId = "sat-exams";
+
+    /// <summary>Canonical field for <see cref="SatExamsQuestionId"/>, or null when the
+    /// key stage has no sat-exams concept (the answer is then ignored).</summary>
+    public static string? SatExamsFieldFor(string keyStage) => keyStage switch
+    {
+        "KS4" => "hasSatExamsAsYear11",
+        "KS2" => "hasSatExamsAsYear6",
+        _ => null,
+    };
 
     /// <summary>
     /// <c>RequestDocument.WhatToChange</c> contract string → canonical outcome key used

--- a/src/DfE.CheckPerformanceData.Application/RulesEngine/AnswerFieldMap.cs
+++ b/src/DfE.CheckPerformanceData.Application/RulesEngine/AnswerFieldMap.cs
@@ -2,11 +2,8 @@ namespace DfE.CheckPerformanceData.Application.RulesEngine;
 
 /// <summary>
 /// Maps the producer side's vocabulary (form <c>QuestionId</c>s on the message,
-/// docx <c>WhatToChange</c> reason strings) onto the engine's canonical names.
-///
-/// At time of writing the Web producer is a stub (<c>HomeController.SendRequest</c>
-/// enqueues a placeholder string) — these are the IDs the producer will target
-/// when it is built out. Updating either side requires touching only this file.
+/// <c>WhatToChange</c> contract strings) onto the engine's canonical names.
+/// Updating either side requires touching only this file.
 /// </summary>
 /// <remarks>
 /// This indirection is deliberate — it is an anti-corruption boundary so the rules
@@ -68,34 +65,42 @@ public static class AnswerFieldMap
         };
 
     /// <summary>
-    /// Docx outcome label (as it appears on a <c>WhatToChange</c> form answer)
-    /// → canonical outcome key used by <see cref="OutcomeRules.Key"/> in the rules JSON.
-    /// Lookup is case-insensitive and tolerant of trailing/leading whitespace.
+    /// <c>RequestDocument.WhatToChange</c> contract string → canonical outcome key used
+    /// by <see cref="OutcomeRules.Key"/> in the rules JSON. The contract string is the
+    /// <c>WhatToChange</c> enum name, suffixed with <c>" - {option value}"</c> when the
+    /// flow config flags a question with <c>useAsRequestType</c> (the Remove flows'
+    /// <c>reason</c> radio). Option *values* are used — not display labels — so UI copy
+    /// changes cannot break routing; <c>QuestionFlowOutcomeKeyAlignmentTests</c> pins
+    /// the flow configs to this map in CI. Lookup is case-insensitive and tolerant of
+    /// trailing/leading whitespace.
+    ///
+    /// Outcomes with no journey flow yet (<c>CompletedKs4Elsewhere</c>,
+    /// <c>AssessmentsDeferred</c>, <c>PupilAddedAfterSummerTerm</c>,
+    /// <c>PupilNotOnJuneList</c>, <c>NotAtEndOf16To18Study</c>, <c>Other</c>) have no
+    /// entry here; add one when the KS2/Post16 flows are authored
+    /// (see <c>SeedRulesValidationTests.PendingJourneyOutcomeKeys</c>).
     /// </summary>
     public static readonly IReadOnlyDictionary<string, string> WhatToChangeToOutcomeKey =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
-            ["Inclusion"]                                                                       = "Inclusion",
-            ["Admitted following permanent exclusion"]                                          = "AdmittedFollowingPermanentExclusion",
-            ["Admitted from abroad with English not first language"]                            = "AdmittedFromAbroadEal",
-            ["Completed KS4 studies this academic year in year 11 at another school or college"]= "CompletedKs4Elsewhere",
-            ["Merge pupils"]                                                                    = "MergePupils",
-            ["Social care involvement - including police/prison"]                               = "SocialCareInvolvement",
-            ["Social care involvement including police/prison"]                                 = "SocialCareInvolvement",
-            ["Terminal/Critical illness"]                                                       = "TerminalCriticalIllness",
-            ["Year group change"]                                                               = "YearGroupChange",
-            ["Deceased"]                                                                        = "Deceased",
-            ["Elective home education"]                                                         = "ElectiveHomeEducation",
-            ["Moved school/Dual registration"]                                                  = "MovedSchoolDualRegistration",
-            ["Not on roll"]                                                                     = "NotOnRoll",
-            ["Permanently excluded from current school"]                                        = "PermanentlyExcludedFromCurrentSchool",
-            ["Permanently left England"]                                                        = "PermanentlyLeftEngland",
-            ["Pupil missing in Education"]                                                      = "PupilMissingInEducation",
-            ["One or more end-of-key stage assessments deferred by a year"]                     = "AssessmentsDeferred",
-            ["Pupil added to school roll after start of summer term"]                           = "PupilAddedAfterSummerTerm",
-            ["Pupil not on June list"]                                                          = "PupilNotOnJuneList",
-            ["Not at end of 16 to 18 study"]                                                    = "NotAtEndOf16To18Study",
-            ["Other"]                                                                           = "Other",
+            ["Merge"]                                  = "MergePupils",
+            ["Include"]                                = "Inclusion",
+
+            // Remove flow reason option values. Note the near-miss pair:
+            // "permanent-exclusion" = admitted *following* a permanent exclusion
+            // elsewhere; "permanently-excluded" = excluded *from the current school*.
+            ["Remove - permanent-exclusion"]           = "AdmittedFollowingPermanentExclusion",
+            ["Remove - english-not-first-language"]    = "AdmittedFromAbroadEal",
+            ["Remove - child-missing-education"]       = "PupilMissingInEducation",
+            ["Remove - pupil-died"]                    = "Deceased",
+            ["Remove - dual-registered-moved"]         = "MovedSchoolDualRegistration",
+            ["Remove - elective-home-education"]       = "ElectiveHomeEducation",
+            ["Remove - not-on-roll"]                   = "NotOnRoll",
+            ["Remove - permanently-excluded"]          = "PermanentlyExcludedFromCurrentSchool",
+            ["Remove - permanently-left-england"]      = "PermanentlyLeftEngland",
+            ["Remove - social-care-involvement"]       = "SocialCareInvolvement",
+            ["Remove - life-limiting-illness"]         = "TerminalCriticalIllness",
+            ["Remove - year-group-change"]             = "YearGroupChange",
         };
 
     /// <summary>

--- a/src/DfE.CheckPerformanceData.Application/RulesEngine/RuleContextMapper.cs
+++ b/src/DfE.CheckPerformanceData.Application/RulesEngine/RuleContextMapper.cs
@@ -8,7 +8,7 @@ namespace DfE.CheckPerformanceData.Application.RulesEngine;
 /// <see cref="RequestDocument"/> into a typed <see cref="RuleContext"/>:
 ///
 /// <list type="bullet">
-///   <item><c>OutcomeKey</c> from <see cref="RequestDocument.WhatToChange"/> via
+///   <item><c>OutcomeKey</c> from <see cref="RequestDocument.RequestTypeCode"/> via
 ///         <see cref="AnswerFieldMap.WhatToChangeToOutcomeKey"/>.</item>
 ///   <item><c>KeyStage</c> from <see cref="RequestDocument.CheckingWindowType"/> via
 ///         <see cref="AnswerFieldMap.NormaliseKeyStage"/>.</item>
@@ -29,13 +29,13 @@ public sealed class RuleContextMapper : IRuleContextMapper
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        var outcomeKey = ResolveOutcomeKey(message.WhatToChange);
+        var outcomeKey = ResolveOutcomeKey(message.RequestTypeCode);
         var keyStage = AnswerFieldMap.NormaliseKeyStage(message.CheckingWindowType);
 
         var fields = new Dictionary<string, FieldValue>(StringComparer.Ordinal)
         {
             ["keyStage"]    = string.IsNullOrEmpty(keyStage) ? FieldValue.Unknown.Instance : new FieldValue.Str(keyStage),
-            ["requestType"] = string.IsNullOrWhiteSpace(message.WhatToChange) ? FieldValue.Unknown.Instance : new FieldValue.Str(message.WhatToChange),
+            ["requestType"] = string.IsNullOrWhiteSpace(message.RequestTypeCode) ? FieldValue.Unknown.Instance : new FieldValue.Str(message.RequestTypeCode),
         };
 
         // Pupil-record fields. Age and Pincl are primitive ints; treat 0 / negative as

--- a/src/DfE.CheckPerformanceData.Application/RulesEngine/RuleContextMapper.cs
+++ b/src/DfE.CheckPerformanceData.Application/RulesEngine/RuleContextMapper.cs
@@ -12,9 +12,11 @@ namespace DfE.CheckPerformanceData.Application.RulesEngine;
 ///         <see cref="AnswerFieldMap.WhatToChangeToOutcomeKey"/>.</item>
 ///   <item><c>KeyStage</c> from <see cref="RequestDocument.CheckingWindowType"/> via
 ///         <see cref="AnswerFieldMap.NormaliseKeyStage"/>.</item>
-///   <item><c>Fields</c> from <c>AnswerRecord[]</c> via
-///         <see cref="AnswerFieldMap.QuestionToField"/>, parsed against the
-///         <see cref="FieldCatalogue"/>'s expected types.</item>
+///   <item><c>pupilAge</c> / <c>inclusionFlag</c> from the pupil record on the message.</item>
+///   <item><c>Fields</c> from <c>AnswerRecord[]</c> via the <see cref="AnswerFieldMap"/>
+///         maps (plain copy, radio fan-out, vocabulary translation, key-stage-resolved
+///         sat-exams), parsed against the <see cref="FieldCatalogue"/>'s expected types.
+///         The engine-facing <c>RawValue</c> is preferred over the display <c>Value</c>.</item>
 /// </list>
 ///
 /// Throws <see cref="RuleContextMappingException"/> when an answer's value is
@@ -36,11 +38,14 @@ public sealed class RuleContextMapper : IRuleContextMapper
             ["requestType"] = string.IsNullOrWhiteSpace(message.WhatToChange) ? FieldValue.Unknown.Instance : new FieldValue.Str(message.WhatToChange),
         };
 
-        // Pupil.Age is a primitive int; treat 0 / negative as "not supplied" so the
-        // engine defers to Scrutiny rather than reading a default value as 0.
-        if (message.Pupil is { Age: > 0 } pupil)
+        // Pupil-record fields. Age and Pincl are primitive ints; treat 0 / negative as
+        // "not supplied" so the engine defers to Scrutiny rather than reading 0.
+        if (message.Pupil is { } pupil)
         {
-            fields["pupilAge"] = new FieldValue.Num(pupil.Age);
+            if (pupil.Age > 0)
+                fields["pupilAge"] = new FieldValue.Num(pupil.Age);
+            if (pupil.Pincl > 0)
+                fields["inclusionFlag"] = new FieldValue.Str(pupil.Pincl.ToString(CultureInfo.InvariantCulture));
         }
 
         if (message.Answers is not null)
@@ -49,25 +54,61 @@ public sealed class RuleContextMapper : IRuleContextMapper
             {
                 if (answer is null) continue;
                 if (string.IsNullOrEmpty(answer.QuestionId)) continue;
-                if (!AnswerFieldMap.QuestionToField.TryGetValue(answer.QuestionId, out var fieldName)) continue;
-                if (!FieldCatalogue.TryGetType(fieldName, out var expectedType))
-                {
-                    // Catalogue and map are out of sync — defensive only; the validator
-                    // and the AnswerFieldMap tests should catch this in CI.
-                    continue;
-                }
-
-                if (string.IsNullOrEmpty(answer.Value))
-                {
-                    fields[fieldName] = FieldValue.Unknown.Instance;
-                    continue;
-                }
-
-                fields[fieldName] = ParseValue(fieldName, expectedType, answer.Value);
+                MapAnswer(answer, keyStage, fields);
             }
         }
 
         return new RuleContext(outcomeKey, keyStage, fields);
+    }
+
+    private static void MapAnswer(AnswerRecord answer, string keyStage, Dictionary<string, FieldValue> fields)
+    {
+        var raw = (answer.RawValue ?? answer.Value)?.Trim();
+
+        // Single-choice radio modelled as independent booleans by the rules.
+        if (AnswerFieldMap.RadioFanOut.TryGetValue(answer.QuestionId, out var fanOut))
+        {
+            foreach (var (field, trigger) in fanOut)
+            {
+                fields[field] = string.IsNullOrEmpty(raw)
+                    ? FieldValue.Unknown.Instance
+                    : new FieldValue.Bool(string.Equals(raw, trigger, StringComparison.Ordinal));
+            }
+            return;
+        }
+
+        // One journey question, two canonical fields — resolved by key stage.
+        if (answer.QuestionId == AnswerFieldMap.SatExamsQuestionId)
+        {
+            var satField = AnswerFieldMap.SatExamsFieldFor(keyStage);
+            if (satField is null) return;
+            fields[satField] = string.IsNullOrEmpty(raw)
+                ? FieldValue.Unknown.Instance
+                : ParseValue(satField, FieldType.Bool, raw);
+            return;
+        }
+
+        // Journey vocabulary → canonical vocabulary (unlisted values fail safe to Unknown).
+        if (AnswerFieldMap.TranslatedQuestions.TryGetValue(answer.QuestionId, out var translated))
+        {
+            fields[translated.Field] = !string.IsNullOrEmpty(raw) && translated.Values.TryGetValue(raw, out var value)
+                ? value
+                : FieldValue.Unknown.Instance;
+            return;
+        }
+
+        // Plain copy, parsed by the catalogue's expected type.
+        if (!AnswerFieldMap.QuestionToField.TryGetValue(answer.QuestionId, out var fieldName)) return;
+        if (!FieldCatalogue.TryGetType(fieldName, out var expectedType))
+        {
+            // Catalogue and map are out of sync — defensive only; the validator
+            // and the AnswerFieldMap tests should catch this in CI.
+            return;
+        }
+
+        fields[fieldName] = string.IsNullOrEmpty(raw)
+            ? FieldValue.Unknown.Instance
+            : ParseValue(fieldName, expectedType, raw);
     }
 
     private static string ResolveOutcomeKey(string? whatToChange)

--- a/src/DfE.CheckPerformanceData.Infrastructure/DfE.CheckPerformanceData.Infrastructure.csproj
+++ b/src/DfE.CheckPerformanceData.Infrastructure/DfE.CheckPerformanceData.Infrastructure.csproj
@@ -13,6 +13,7 @@
 
     <ItemGroup>
       <PackageReference Include="Azure.Storage.Blobs" />
+      <PackageReference Include="Azure.Storage.Queues" />
       <PackageReference Include="Microsoft.AspNetCore.Authentication" />
       <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" />
       <PackageReference Include="Microsoft.AspNetCore.Authentication.Core" />

--- a/src/DfE.CheckPerformanceData.Infrastructure/QueueStorage/RequestQueueClient.cs
+++ b/src/DfE.CheckPerformanceData.Infrastructure/QueueStorage/RequestQueueClient.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using Azure.Storage.Queues;
+using DfE.CheckPerformanceData.Application.RequestSubmission;
+
+namespace DfE.CheckPerformanceData.Infrastructure.QueueStorage;
+
+/// <summary>
+/// Azure Storage Queue implementation of <see cref="IRequestQueueClient"/>.
+/// The injected <see cref="QueueClient"/> must use the same queue name and
+/// message encoding as the RulesEngineWorker's consumer (Base64,
+/// <c>RulesEngineOptions.QueueName</c>); the body is the default
+/// System.Text.Json serialization of <see cref="RequestDocument"/>, which
+/// <c>RequestDocumentParser</c> reads back (round-trip pinned in tests).
+/// </summary>
+public sealed class RequestQueueClient(QueueClient queueClient) : IRequestQueueClient
+{
+    public async Task EnqueueRequestAsync(RequestDocument document)
+    {
+        await queueClient.CreateIfNotExistsAsync();
+        await queueClient.SendMessageAsync(JsonSerializer.Serialize(document));
+    }
+}

--- a/src/DfE.CheckPerformanceData.Infrastructure/RulesEngine/BlobRulesProvider.cs
+++ b/src/DfE.CheckPerformanceData.Infrastructure/RulesEngine/BlobRulesProvider.cs
@@ -81,11 +81,20 @@ public sealed class BlobRulesProvider : IRulesProvider, IHostedService, IAsyncDi
 
     public async ValueTask DisposeAsync()
     {
-        _stopCts?.Cancel();
-        _stopCts?.Dispose();
-        if (_backgroundTask is not null)
+        // Idempotent: the provider is registered both as a singleton and as an
+        // IHostedService factory returning the same instance, so the container
+        // disposes it twice on shutdown.
+        var cts = Interlocked.Exchange(ref _stopCts, null);
+        if (cts is not null)
         {
-            try { await _backgroundTask.ConfigureAwait(false); }
+            cts.Cancel();
+            cts.Dispose();
+        }
+
+        var task = Interlocked.Exchange(ref _backgroundTask, null);
+        if (task is not null)
+        {
+            try { await task.ConfigureAwait(false); }
             catch { /* swallow on dispose */ }
         }
     }
@@ -168,13 +177,20 @@ public sealed class BlobRulesProvider : IRulesProvider, IHostedService, IAsyncDi
             {
                 try
                 {
-                    var raw = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(
+                    // Underscore-prefixed keys are comments by convention (the seed
+                    // file ships a "_comment" string entry), so deserialise loosely
+                    // and keep only the real code → languages entries.
+                    var raw = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(
                         lookupsContent, RulesJson.Options);
                     parsedLookups = raw is null
                         ? Lookups.Empty
-                        : new Lookups(raw.ToDictionary(
-                            kvp => kvp.Key,
-                            kvp => (IReadOnlyList<string>)kvp.Value.ToArray()));
+                        : new Lookups(raw
+                            .Where(kvp => !kvp.Key.StartsWith('_') && kvp.Value.ValueKind == JsonValueKind.Array)
+                            .ToDictionary(
+                                kvp => kvp.Key,
+                                kvp => (IReadOnlyList<string>)kvp.Value.EnumerateArray()
+                                    .Select(e => e.GetString() ?? string.Empty)
+                                    .ToArray()));
                 }
                 catch (JsonException jx)
                 {

--- a/src/DfE.CheckPerformanceData.Persistence/Configurations/ChangeRequestConfiguration.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Configurations/ChangeRequestConfiguration.cs
@@ -51,6 +51,16 @@ internal sealed class ChangeRequestConfiguration : IEntityTypeConfiguration<Chan
             .IsRequired()
             .HasMaxLength(100);
 
+        builder.Property(x => x.Outcome)
+            .HasConversion<string>()
+            .HasMaxLength(20);
+
+        builder.Property(x => x.OutcomeKey)
+            .HasMaxLength(100);
+
+        builder.Property(x => x.MatchedRuleId)
+            .HasMaxLength(100);
+
         builder.HasOne<CheckingWindow>()
             .WithMany()
             .HasForeignKey(x => x.WindowId)

--- a/src/DfE.CheckPerformanceData.Persistence/DependencyManager.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/DependencyManager.cs
@@ -43,6 +43,7 @@ public static class DependencyManager
         services.AddScoped<ILandingPageRepository, LandingPageRepository>();
         services.AddScoped<ICheckYourPupilDataRepository, CheckYourPupilDataRepository>();
         services.AddScoped<IRequestRepository, RequestRepository>();
+        services.AddScoped<Application.RequestDecision.IDecisionOutcomeRepository, DecisionOutcomeRepository>();
         services.AddScoped<ICountryRepository, CountryRepository>();
 
         return services;

--- a/src/DfE.CheckPerformanceData.Persistence/Entities/ChangeRequest.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Entities/ChangeRequest.cs
@@ -1,3 +1,4 @@
+using DfE.CheckPerformanceData.Application.RulesEngine;
 using DfE.CheckPerformanceData.Domain.Enums;
 
 namespace DfE.CheckPerformanceData.Persistence.Entities;
@@ -17,4 +18,10 @@ public class ChangeRequest
     public required string ReferenceNumber { get; init; }
     public required string RequestType { get; init; }
     public string? CrmId { get; init; }
+
+    // Written by the rules engine worker once it has decided on the request;
+    // all three stay null until then.
+    public DecisionStatus? Outcome { get; init; }
+    public string? OutcomeKey { get; init; }
+    public string? MatchedRuleId { get; init; }
 }

--- a/src/DfE.CheckPerformanceData.Persistence/Migrations/20260611090049_AddChangeRequestOutcome.Designer.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Migrations/20260611090049_AddChangeRequestOutcome.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DfE.CheckPerformanceData.Persistence.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace DfE.CheckPerformanceData.Persistence.Migrations
 {
     [DbContext(typeof(PortalDbContext))]
-    partial class PortalDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611090049_AddChangeRequestOutcome")]
+    partial class AddChangeRequestOutcome
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/DfE.CheckPerformanceData.Persistence/Migrations/20260611090049_AddChangeRequestOutcome.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Migrations/20260611090049_AddChangeRequestOutcome.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DfE.CheckPerformanceData.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddChangeRequestOutcome : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MatchedRuleId",
+                table: "ChangeRequests",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Outcome",
+                table: "ChangeRequests",
+                type: "character varying(20)",
+                maxLength: 20,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "OutcomeKey",
+                table: "ChangeRequests",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MatchedRuleId",
+                table: "ChangeRequests");
+
+            migrationBuilder.DropColumn(
+                name: "Outcome",
+                table: "ChangeRequests");
+
+            migrationBuilder.DropColumn(
+                name: "OutcomeKey",
+                table: "ChangeRequests");
+        }
+    }
+}

--- a/src/DfE.CheckPerformanceData.Persistence/Repositories/CheckYourPupilDataRepository.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Repositories/CheckYourPupilDataRepository.cs
@@ -125,6 +125,7 @@ public sealed class CheckYourPupilDataRepository(IPortalDbContext dbContext) : I
             DateOfBirth = p.DateOfBirth,
             Age = p.Age,
             Cypmd_Id = p.Cypmd_Id,
-            Upn = p.Upn
+            Upn = p.Upn,
+            Pincl = p.Pincl
         };
 }

--- a/src/DfE.CheckPerformanceData.Persistence/Repositories/DecisionOutcomeRepository.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Repositories/DecisionOutcomeRepository.cs
@@ -1,0 +1,21 @@
+using DfE.CheckPerformanceData.Application.RequestDecision;
+using DfE.CheckPerformanceData.Application.RulesEngine;
+using DfE.CheckPerformanceData.Persistence.Contexts;
+using Microsoft.EntityFrameworkCore;
+
+namespace DfE.CheckPerformanceData.Persistence.Repositories;
+
+public sealed class DecisionOutcomeRepository(IPortalDbContext db) : IDecisionOutcomeRepository
+{
+    public async Task<bool> RecordOutcomeAsync(Guid changeRequestId, Decision decision, CancellationToken token)
+    {
+        var updated = await db.ChangeRequests
+            .Where(r => r.Id == changeRequestId)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(r => r.Outcome, decision.Status)
+                .SetProperty(r => r.OutcomeKey, decision.OutcomeKey)
+                .SetProperty(r => r.MatchedRuleId, decision.MatchedRuleId), token);
+
+        return updated > 0;
+    }
+}

--- a/src/DfE.CheckPerformanceData.Persistence/Repositories/RequestRepository.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Repositories/RequestRepository.cs
@@ -17,42 +17,51 @@ public sealed class RequestRepository(IPortalDbContext db) : IRequestRepository
             r.OrganisationUrn == organisationUrn &&
             r.ReferenceNumber != currentReferenceNumber);
 
-    public async Task UpsertAsync(ChangeRequestData data)
+    public async Task<Guid> UpsertAsync(ChangeRequestData data)
     {
         var timestamp = DateTime.SpecifyKind(data.Timestamp, DateTimeKind.Unspecified);
 
-        var updated = await db.ChangeRequests
+        // ReferenceNumber is unique, so at most one row matches.
+        var existingId = await db.ChangeRequests
             .Where(r => r.ReferenceNumber == data.ReferenceNumber)
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(r => r.Status, data.Status)
-                .SetProperty(r => r.Submitted, timestamp)
-                .SetProperty(r => r.OrganisationUrn, data.OrganisationUrn)
-                .SetProperty(r => r.PupilUpn, data.PupilUpn)
-                .SetProperty(r => r.PupilFirstname, data.PupilFirstname)
-                .SetProperty(r => r.PupilSurname, data.PupilSurname)
-                .SetProperty(r => r.SubmittedById, data.SubmittedById)
-                .SetProperty(r => r.SubmittedByName, data.SubmittedByName)
-                .SetProperty(r => r.RequestType, data.RequestType));
+            .Select(r => r.Id)
+            .FirstOrDefaultAsync();
 
-        if (updated == 0)
+        if (existingId != Guid.Empty)
         {
-            await db.ChangeRequests.AddAsync(new ChangeRequest
-            {
-                Id = Guid.NewGuid(),
-                WindowId = data.WindowId,
-                ReferenceNumber = data.ReferenceNumber,
-                OrganisationUrn = data.OrganisationUrn,
-                PupilUpn = data.PupilUpn,
-                PupilFirstname = data.PupilFirstname,
-                PupilSurname = data.PupilSurname,
-                Submitted = timestamp,
-                SubmittedById = data.SubmittedById,
-                SubmittedByName = data.SubmittedByName,
-                Status = data.Status,
-                RequestType = data.RequestType
-            });
-            await db.SaveChangesAsync();
+            await db.ChangeRequests
+                .Where(r => r.Id == existingId)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(r => r.Status, data.Status)
+                    .SetProperty(r => r.Submitted, timestamp)
+                    .SetProperty(r => r.OrganisationUrn, data.OrganisationUrn)
+                    .SetProperty(r => r.PupilUpn, data.PupilUpn)
+                    .SetProperty(r => r.PupilFirstname, data.PupilFirstname)
+                    .SetProperty(r => r.PupilSurname, data.PupilSurname)
+                    .SetProperty(r => r.SubmittedById, data.SubmittedById)
+                    .SetProperty(r => r.SubmittedByName, data.SubmittedByName)
+                    .SetProperty(r => r.RequestType, data.RequestType));
+            return existingId;
         }
+
+        var id = Guid.NewGuid();
+        await db.ChangeRequests.AddAsync(new ChangeRequest
+        {
+            Id = id,
+            WindowId = data.WindowId,
+            ReferenceNumber = data.ReferenceNumber,
+            OrganisationUrn = data.OrganisationUrn,
+            PupilUpn = data.PupilUpn,
+            PupilFirstname = data.PupilFirstname,
+            PupilSurname = data.PupilSurname,
+            Submitted = timestamp,
+            SubmittedById = data.SubmittedById,
+            SubmittedByName = data.SubmittedByName,
+            Status = data.Status,
+            RequestType = data.RequestType
+        });
+        await db.SaveChangesAsync();
+        return id;
     }
 
     public async Task<IReadOnlyList<AmendmentRequestData>> GetAmendmentRequestsAsync(

--- a/src/DfE.CheckPerformanceData.RulesEngineWorker/DfE.CheckPerformanceData.RulesEngineWorker.csproj
+++ b/src/DfE.CheckPerformanceData.RulesEngineWorker/DfE.CheckPerformanceData.RulesEngineWorker.csproj
@@ -20,6 +20,7 @@
         <ProjectReference Include="..\DfE.CheckPerformanceData.Application\DfE.CheckPerformanceData.Application.csproj" />
         <ProjectReference Include="..\DfE.CheckPerformanceData.Domain\DfE.CheckPerformanceData.Domain.csproj" />
         <ProjectReference Include="..\DfE.CheckPerformanceData.Infrastructure\DfE.CheckPerformanceData.Infrastructure.csproj" />
+        <ProjectReference Include="..\DfE.CheckPerformanceData.Persistence\DfE.CheckPerformanceData.Persistence.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DfE.CheckPerformanceData.RulesEngineWorker/Program.cs
+++ b/src/DfE.CheckPerformanceData.RulesEngineWorker/Program.cs
@@ -4,13 +4,12 @@ using DfE.CheckPerformanceData.Infrastructure;
 using DfE.CheckPerformanceData.RulesEngineWorker;
 
 var builder = Host.CreateApplicationBuilder(args);
+builder.Configuration.AddUserSecrets<Program>();
 
 builder.Services.Configure<RulesEngineOptions>(builder.Configuration.GetSection("RulesEngineOptions"));
 
 builder.Services.AddSingleton(sp => new QueueServiceClient(builder.Configuration.GetConnectionString("AzureStorage"),
-    new QueueClientOptions(QueueClientOptions.ServiceVersion.V2025_11_05){
-        MessageEncoding = QueueMessageEncoding.Base64
-    }));
+    new QueueClientOptions { MessageEncoding = QueueMessageEncoding.Base64 }));
 
 builder.Services.AddZendeskApiClient(builder.Configuration);
 builder.Services.AddInfrastructureDependencies(builder.Configuration);

--- a/src/DfE.CheckPerformanceData.RulesEngineWorker/Program.cs
+++ b/src/DfE.CheckPerformanceData.RulesEngineWorker/Program.cs
@@ -4,7 +4,6 @@ using DfE.CheckPerformanceData.Infrastructure;
 using DfE.CheckPerformanceData.RulesEngineWorker;
 
 var builder = Host.CreateApplicationBuilder(args);
-builder.Configuration.AddUserSecrets<Program>();
 
 builder.Services.Configure<RulesEngineOptions>(builder.Configuration.GetSection("RulesEngineOptions"));
 

--- a/src/DfE.CheckPerformanceData.RulesEngineWorker/Program.cs
+++ b/src/DfE.CheckPerformanceData.RulesEngineWorker/Program.cs
@@ -1,6 +1,7 @@
 using Azure.Storage.Queues;
 using DfE.CheckPerformanceData.Application;
 using DfE.CheckPerformanceData.Infrastructure;
+using DfE.CheckPerformanceData.Persistence;
 using DfE.CheckPerformanceData.RulesEngineWorker;
 
 var builder = Host.CreateApplicationBuilder(args);
@@ -12,8 +13,13 @@ builder.Services.AddSingleton(sp => new QueueServiceClient(builder.Configuration
 
 builder.Services.AddZendeskApiClient(builder.Configuration);
 builder.Services.AddInfrastructureDependencies(builder.Configuration);
+// Persistence is registered so the worker can write engine decisions back to
+// the ChangeRequests table (IDecisionOutcomeRepository). PortalDbContext needs
+// an ICurrentUserService for audit stamping; the worker supplies a system identity.
+builder.Services.AddSingleton<DfE.CheckPerformanceData.Application.CurrentUser.ICurrentUserService, WorkerCurrentUserService>();
+builder.Services.AddPersistenceDependencies(builder.Configuration);
 // Deliberately not AddApplicationDependencies(): the full Application set needs
-// Persistence repositories and Web-registered clients this host doesn't have.
+// Web-registered clients this host doesn't have.
 builder.Services.AddRulesEngineDependencies();
 builder.Services.AddRulesProvider(builder.Configuration);
 

--- a/src/DfE.CheckPerformanceData.RulesEngineWorker/Program.cs
+++ b/src/DfE.CheckPerformanceData.RulesEngineWorker/Program.cs
@@ -4,7 +4,6 @@ using DfE.CheckPerformanceData.Infrastructure;
 using DfE.CheckPerformanceData.RulesEngineWorker;
 
 var builder = Host.CreateApplicationBuilder(args);
-builder.Configuration.AddUserSecrets<Program>();
 
 builder.Services.Configure<RulesEngineOptions>(builder.Configuration.GetSection("RulesEngineOptions"));
 
@@ -15,7 +14,9 @@ builder.Services.AddSingleton(sp => new QueueServiceClient(builder.Configuration
 
 builder.Services.AddZendeskApiClient(builder.Configuration);
 builder.Services.AddInfrastructureDependencies(builder.Configuration);
-builder.Services.AddApplicationDependencies();
+// Deliberately not AddApplicationDependencies(): the full Application set needs
+// Persistence repositories and Web-registered clients this host doesn't have.
+builder.Services.AddRulesEngineDependencies();
 builder.Services.AddRulesProvider(builder.Configuration);
 
 builder.Services.AddHostedService<RulesEngineWorker>();

--- a/src/DfE.CheckPerformanceData.RulesEngineWorker/RulesEngineWorker.cs
+++ b/src/DfE.CheckPerformanceData.RulesEngineWorker/RulesEngineWorker.cs
@@ -151,9 +151,22 @@ public sealed class RulesEngineWorker : BackgroundService
             "Decision={Status} Outcome={Outcome} Rule={Rule} RulesVersion={Version} Reference={Reference}",
             decision.Status, decision.OutcomeKey, decision.MatchedRuleId, snapshot.Version, parsed.ReferenceNumber);
 
-        // The handler (and its Zendesk dependencies) are scoped, and a hosted
-        // service is a singleton — resolve per message rather than capturing.
+        // The handler (and its Zendesk dependencies) and the outcome repository
+        // are scoped, and a hosted service is a singleton — resolve per message
+        // rather than capturing.
         await using var scope = _scopeFactory.CreateAsyncScope();
+
+        // Record the outcome before ticketing so the decision is on the row even
+        // if Zendesk is down; the idempotent update makes retries harmless.
+        var outcomeRepository = scope.ServiceProvider.GetRequiredService<IDecisionOutcomeRepository>();
+        var rowUpdated = await outcomeRepository.RecordOutcomeAsync(parsed.ChangeRequestId, decision, stoppingToken);
+        if (!rowUpdated)
+        {
+            _logger.LogWarning(
+                "No ChangeRequests row matched Id={ChangeRequestId} for Reference={Reference}; outcome not recorded.",
+                parsed.ChangeRequestId, parsed.ReferenceNumber);
+        }
+
         var handler = scope.ServiceProvider.GetRequiredService<IRequestDecisionHandler>();
         await handler.HandleAsync(parsed, decision, stoppingToken);
     }

--- a/src/DfE.CheckPerformanceData.RulesEngineWorker/RulesEngineWorker.cs
+++ b/src/DfE.CheckPerformanceData.RulesEngineWorker/RulesEngineWorker.cs
@@ -13,7 +13,7 @@ public sealed class RulesEngineWorker : BackgroundService
     private readonly ILogger<RulesEngineWorker> _logger;
     private readonly QueueClient _queueClient;
     private readonly RulesEngineOptions _options;
-    private readonly IRequestDecisionHandler _handler;
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly IRulesProvider _rulesProvider;
     private readonly IRulesEngine _rulesEngine;
     private readonly IRuleContextMapper _contextMapper;
@@ -22,7 +22,7 @@ public sealed class RulesEngineWorker : BackgroundService
         ILogger<RulesEngineWorker> logger,
         QueueServiceClient queueServiceClient,
         IOptions<RulesEngineOptions> options,
-        IRequestDecisionHandler handler,
+        IServiceScopeFactory scopeFactory,
         IRulesProvider rulesProvider,
         IRulesEngine rulesEngine,
         IRuleContextMapper contextMapper)
@@ -33,7 +33,7 @@ public sealed class RulesEngineWorker : BackgroundService
         _options = options.Value;
         _logger = logger;
         _queueClient = queueServiceClient.GetQueueClient(_options.QueueName);
-        _handler = handler;
+        _scopeFactory = scopeFactory;
         _rulesProvider = rulesProvider;
         _rulesEngine = rulesEngine;
         _contextMapper = contextMapper;
@@ -151,7 +151,11 @@ public sealed class RulesEngineWorker : BackgroundService
             "Decision={Status} Outcome={Outcome} Rule={Rule} RulesVersion={Version} Reference={Reference}",
             decision.Status, decision.OutcomeKey, decision.MatchedRuleId, snapshot.Version, parsed.ReferenceNumber);
 
-        await _handler.HandleAsync(parsed, decision, stoppingToken);
+        // The handler (and its Zendesk dependencies) are scoped, and a hosted
+        // service is a singleton — resolve per message rather than capturing.
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var handler = scope.ServiceProvider.GetRequiredService<IRequestDecisionHandler>();
+        await handler.HandleAsync(parsed, decision, stoppingToken);
     }
 }
 

--- a/src/DfE.CheckPerformanceData.RulesEngineWorker/WorkerCurrentUserService.cs
+++ b/src/DfE.CheckPerformanceData.RulesEngineWorker/WorkerCurrentUserService.cs
@@ -1,0 +1,18 @@
+using DfE.CheckPerformanceData.Application.CurrentUser;
+
+namespace DfE.CheckPerformanceData.RulesEngineWorker;
+
+/// <summary>
+/// The worker has no signed-in user; <see cref="ICurrentUserService"/> is needed
+/// only because <c>PortalDbContext</c> stamps audit rows with a UserId on
+/// SaveChanges. Writes made by the worker are attributed to this system identity.
+/// </summary>
+public sealed class WorkerCurrentUserService : ICurrentUserService
+{
+    public string UserId => "rules-engine-worker";
+    public string DisplayName => "Rules Engine Worker";
+    public string OrganisationId => string.Empty;
+    public string OrganisationName => string.Empty;
+    public string OrganisationUrn => string.Empty;
+    public string OrganisationTypeId => string.Empty;
+}

--- a/src/DfE.CheckPerformanceData.RulesEngineWorker/appsettings.json
+++ b/src/DfE.CheckPerformanceData.RulesEngineWorker/appsettings.json
@@ -9,5 +9,27 @@
     "MaxRetryAttempts": 3,
     "BaseDelayMilliseconds": 1000,
     "JitterMilliseconds": 500
+  },
+  "RulesEngineOptions": {
+    "RetryDelayMs": 5000,
+    "QueueName": "change-requests",
+    "MaxMessagesPerPoll": 10,
+    "EmptyQueueDelayMs": 1000,
+    "MaxDequeueCount": 5,
+    "VisibilityTimeout": "00:00:30"
+  },
+  "ZendeskSettings": {
+    "Subdomain": "the subdomain",
+    "Domain": "the domain",
+    "Email": "[PLACE THESE IN YOUR USER SECRETS]",
+    "ApiToken": "[PLACE THESE IN YOUR USER SECRETS]"
+  },
+  "SchoolCheckingExercise": {
+    "TargetViewTitle": "School Checking Exercise",
+    "GroupId": 0,
+    "BrandId": 0,
+    "DecisionStatusCustomFieldId": 0,
+    "OutcomeKeyCustomFieldId": 0,
+    "MatchedRuleIdCustomFieldId": 0
   }
 }

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyController.cs
@@ -552,6 +552,11 @@ public sealed class JourneyController(
                     Year = int.TryParse(Request.Form[$"{fieldName}_year"], out var y) ? y : 0
                 }
             },
+            QuestionType.Autocomplete => new QuestionAnswer
+            {
+                TextValue = Request.Form[fieldName].FirstOrDefault()?.Trim(),
+                CodeValue = Request.Form[$"{fieldName}_code"].FirstOrDefault()?.Trim() is { Length: > 0 } code ? code : null
+            },
             _ => new QuestionAnswer { TextValue = Request.Form[fieldName].FirstOrDefault()?.Trim() }
         };
     }

--- a/src/DfE.CheckPerformanceData.Web/Program.cs
+++ b/src/DfE.CheckPerformanceData.Web/Program.cs
@@ -1,3 +1,4 @@
+using AngleSharp;
 using Azure.Storage.Blobs;
 using Azure.Storage.Queues;
 using DfE.CheckPerformanceData.Application;
@@ -13,6 +14,7 @@ using DfE.CheckPerformanceData.Application.RequestSubmission;
 using DfE.CheckPerformanceData.Application.FileStorage;
 using DfE.CheckPerformanceData.Application.Journey;
 using DfE.CheckPerformanceData.Infrastructure.BlobStorage;
+using DfE.CheckPerformanceData.Infrastructure.QueueStorage;
 using DfE.CheckPerformanceData.Web.Controllers.Journey;
 using DfE.CheckPerformanceData.Web.QuestionFlow;
 using DfE.CheckPerformanceData.Web.Settings;
@@ -147,11 +149,21 @@ try
     builder.Services.AddScoped<IDraftBlobClient, DraftBlobClient>();
 
     builder.Services.AddSingleton(_ => new QueueServiceClient(builder.Configuration.GetConnectionString("AzureStorage"),
-        new QueueClientOptions(QueueClientOptions.ServiceVersion.V2025_11_05)
+        new QueueClientOptions
         {
             MessageEncoding = QueueMessageEncoding.Base64
         }));
-    
+
+    builder.Services.AddSingleton<QueueClient>(sp =>
+    {
+        var queueName = builder.Configuration["RulesEngineQueue"]
+            ?? throw new InvalidOperationException(
+                "RulesEngineQueue is not configured; set it to the RulesEngineWorker's queue name (e.g. \"change-requests\").");
+        return sp.GetRequiredService<QueueServiceClient>().GetQueueClient(queueName);
+    });
+    builder.Services.AddScoped<IRequestQueueClient, RequestQueueClient>();
+
+
     builder.Services.AddAntiforgery(options =>
     {
         options.HeaderName = "X-XSRF-TOKEN";

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/RequestSubmission/DecisionOutcomeRepositoryTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/RequestSubmission/DecisionOutcomeRepositoryTests.cs
@@ -1,0 +1,115 @@
+using DfE.CheckPerformanceData.Application.RulesEngine;
+using DfE.CheckPerformanceData.Domain.Enums;
+using DfE.CheckPerformanceData.IntegrationTests.Fixtures;
+using DfE.CheckPerformanceData.Persistence.Entities;
+using DfE.CheckPerformanceData.Persistence.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace DfE.CheckPerformanceData.IntegrationTests.RequestSubmission;
+
+[Collection(nameof(PostgresCollection))]
+public sealed class DecisionOutcomeRepositoryTests(PostgresFixture fixture)
+{
+    private readonly PostgresFixture _fixture = fixture;
+
+    [Fact]
+    public async Task RecordOutcome_WritesDecisionToRow_AndReturnsTrue()
+    {
+        await TruncateAsync();
+        var changeRequestId = await SeedChangeRequestAsync();
+        var decision = new Decision(DecisionStatus.AutoApproved, "PupilDied", "rule-7", []);
+
+        var updated = await new DecisionOutcomeRepository(_fixture.CreateContext())
+            .RecordOutcomeAsync(changeRequestId, decision, CancellationToken.None);
+
+        Assert.True(updated);
+        await using var ctx = _fixture.CreateContext();
+        var row = await ctx.ChangeRequests.SingleAsync(r => r.Id == changeRequestId);
+        Assert.Equal(DecisionStatus.AutoApproved, row.Outcome);
+        Assert.Equal("PupilDied", row.OutcomeKey);
+        Assert.Equal("rule-7", row.MatchedRuleId);
+    }
+
+    [Fact]
+    public async Task RecordOutcome_IsIdempotent_RetryRewritesSameValues()
+    {
+        await TruncateAsync();
+        var changeRequestId = await SeedChangeRequestAsync();
+        var decision = new Decision(DecisionStatus.Scrutiny, "_unknown", "_engine_error", []);
+        var repo = () => new DecisionOutcomeRepository(_fixture.CreateContext());
+
+        await repo().RecordOutcomeAsync(changeRequestId, decision, CancellationToken.None);
+        var secondAttempt = await repo().RecordOutcomeAsync(changeRequestId, decision, CancellationToken.None);
+
+        Assert.True(secondAttempt);
+        await using var ctx = _fixture.CreateContext();
+        var row = await ctx.ChangeRequests.SingleAsync(r => r.Id == changeRequestId);
+        Assert.Equal(DecisionStatus.Scrutiny, row.Outcome);
+    }
+
+    [Fact]
+    public async Task RecordOutcome_WhenNoRowMatches_ReturnsFalse()
+    {
+        await TruncateAsync();
+        var decision = new Decision(DecisionStatus.AutoRejected, "k", "r", []);
+
+        var updated = await new DecisionOutcomeRepository(_fixture.CreateContext())
+            .RecordOutcomeAsync(Guid.NewGuid(), decision, CancellationToken.None);
+
+        Assert.False(updated);
+    }
+
+    [Fact]
+    public async Task UnprocessedRow_HasNullOutcomeColumns()
+    {
+        await TruncateAsync();
+        var changeRequestId = await SeedChangeRequestAsync();
+
+        await using var ctx = _fixture.CreateContext();
+        var row = await ctx.ChangeRequests.SingleAsync(r => r.Id == changeRequestId);
+        Assert.Null(row.Outcome);
+        Assert.Null(row.OutcomeKey);
+        Assert.Null(row.MatchedRuleId);
+    }
+
+    private async Task TruncateAsync()
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"TRUNCATE ""ChangeRequests"" CASCADE;";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<Guid> SeedChangeRequestAsync()
+    {
+        await using var ctx = _fixture.CreateContext();
+        var window = new CheckingWindow
+        {
+            Id = Guid.NewGuid(),
+            Title = "KS4 June",
+            KeyStage = KeyStages.KS4,
+            CheckingWindowType = CheckingWindowType.KS4June,
+            StartDate = DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(-10), DateTimeKind.Unspecified),
+            EndDate = DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(20), DateTimeKind.Unspecified)
+        };
+        ctx.CheckingWindows.Add(window);
+
+        var changeRequest = new ChangeRequest
+        {
+            Id = Guid.NewGuid(),
+            WindowId = window.Id,
+            OrganisationUrn = 100000,
+            Submitted = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
+            SubmittedById = Guid.NewGuid(),
+            SubmittedByName = "Test User",
+            Status = RequestStatus.SubmittedUnCommitted,
+            ReferenceNumber = $"REF-{Guid.NewGuid():N}",
+            RequestType = "Remove"
+        };
+        ctx.ChangeRequests.Add(changeRequest);
+        await ctx.SaveChangesAsync();
+        return changeRequest.Id;
+    }
+}

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/RequestSubmission/RequestRepositoryUpsertTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/RequestSubmission/RequestRepositoryUpsertTests.cs
@@ -1,0 +1,89 @@
+using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Domain.Enums;
+using DfE.CheckPerformanceData.IntegrationTests.Fixtures;
+using DfE.CheckPerformanceData.Persistence.Entities;
+using DfE.CheckPerformanceData.Persistence.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace DfE.CheckPerformanceData.IntegrationTests.RequestSubmission;
+
+[Collection(nameof(PostgresCollection))]
+public sealed class RequestRepositoryUpsertTests(PostgresFixture fixture)
+{
+    private readonly PostgresFixture _fixture = fixture;
+
+    [Fact]
+    public async Task Upsert_Insert_ReturnsIdOfNewRow()
+    {
+        await TruncateAsync();
+        var windowId = await SeedWindowAsync();
+
+        var id = await new RequestRepository(_fixture.CreateContext())
+            .UpsertAsync(Data(windowId, "REF-INS-1"));
+
+        await using var ctx = _fixture.CreateContext();
+        var row = await ctx.ChangeRequests.SingleAsync(r => r.ReferenceNumber == "REF-INS-1");
+        Assert.Equal(row.Id, id);
+    }
+
+    [Fact]
+    public async Task Upsert_Update_ReturnsIdOfExistingRow_AndDoesNotInsert()
+    {
+        await TruncateAsync();
+        var windowId = await SeedWindowAsync();
+        var firstId = await new RequestRepository(_fixture.CreateContext())
+            .UpsertAsync(Data(windowId, "REF-UPD-1", RequestStatus.InProgress));
+
+        var secondId = await new RequestRepository(_fixture.CreateContext())
+            .UpsertAsync(Data(windowId, "REF-UPD-1", RequestStatus.SubmittedUnCommitted));
+
+        Assert.Equal(firstId, secondId);
+        await using var ctx = _fixture.CreateContext();
+        var row = await ctx.ChangeRequests.SingleAsync(r => r.ReferenceNumber == "REF-UPD-1");
+        Assert.Equal(RequestStatus.SubmittedUnCommitted, row.Status);
+    }
+
+    private static ChangeRequestData Data(
+        Guid windowId, string referenceNumber, RequestStatus status = RequestStatus.SubmittedUnCommitted) =>
+        new()
+        {
+            WindowId = windowId,
+            ReferenceNumber = referenceNumber,
+            OrganisationUrn = 100000,
+            PupilUpn = "UPN1",
+            PupilFirstname = "Jane",
+            PupilSurname = "Smith",
+            Timestamp = DateTime.UtcNow,
+            SubmittedById = Guid.NewGuid(),
+            SubmittedByName = "Test User",
+            Status = status,
+            RequestType = "Remove"
+        };
+
+    private async Task TruncateAsync()
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"TRUNCATE ""ChangeRequests"" CASCADE;";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<Guid> SeedWindowAsync()
+    {
+        await using var ctx = _fixture.CreateContext();
+        var window = new CheckingWindow
+        {
+            Id = Guid.NewGuid(),
+            Title = "KS4 June",
+            KeyStage = KeyStages.KS4,
+            CheckingWindowType = CheckingWindowType.KS4June,
+            StartDate = DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(-10), DateTimeKind.Unspecified),
+            EndDate = DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(20), DateTimeKind.Unspecified)
+        };
+        ctx.CheckingWindows.Add(window);
+        await ctx.SaveChangesAsync();
+        return window.Id;
+    }
+}

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/RulesEngineEndToEndTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/RulesEngineEndToEndTests.cs
@@ -196,9 +196,15 @@ public sealed class RulesEngineEndToEndTests
         var rulesProvider = Substitute.For<IRulesProvider>();
         rulesProvider.Current.Returns(Snapshot);
 
-        // The worker resolves the (scoped) handler per message via the scope factory.
+        // The worker resolves the (scoped) handler and outcome repository per
+        // message via the scope factory. The outcome write is covered by
+        // DecisionOutcomeRepositoryTests; here a stub keeps the pipeline DB-free.
+        var outcomes = Substitute.For<IDecisionOutcomeRepository>();
+        outcomes.RecordOutcomeAsync(Arg.Any<Guid>(), Arg.Any<Decision>(), Arg.Any<CancellationToken>())
+            .Returns(true);
         var services = new ServiceCollection();
         services.AddScoped(_ => handler);
+        services.AddScoped(_ => outcomes);
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
         return new WorkerHost.RulesEngineWorker(
@@ -279,6 +285,7 @@ public sealed class RulesEngineEndToEndTests
 
                 return $$"""
                     {
+                      "ChangeRequestId": "11111111-2222-3333-4444-555555555555",
                       "CheckingWindowId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
                       "CheckingWindowType": "{{CheckingWindowType}}",
                       "RequestTypeCode": "{{RequestTypeCode}}",

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/RulesEngineEndToEndTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/RulesEngineEndToEndTests.cs
@@ -62,10 +62,10 @@ public sealed class RulesEngineEndToEndTests
 
     private static IEnumerable<OutcomeScenario> BuildScenarios()
     {
-        // WhatToChange carries the producer's contract string: the WhatToChange enum
-        // name, plus " - {reason option value}" where the flow has a useAsRequestType
-        // question. Question ids and answer values mirror the authored flow configs
-        // (see AnswerFieldMap and Web/Data/QuestionFlows).
+        // RequestTypeCode carries the producer's contract string: the WhatToChange
+        // enum name, plus " - {reason option value}" where the flow has a
+        // useAsRequestType question. Question ids and answer values mirror the
+        // authored flow configs (see AnswerFieldMap and Web/Data/QuestionFlows).
         yield return new("Inclusion-AutoApproved", "Include", "KS4",
             Answers: [],
             DecisionStatus.AutoApproved, "INC-ACC",
@@ -259,7 +259,7 @@ public sealed class RulesEngineEndToEndTests
 
     public sealed record OutcomeScenario(
         string Name,
-        string WhatToChange,
+        string RequestTypeCode,
         string CheckingWindowType,
         (string QuestionId, string Value)[] Answers,
         DecisionStatus ExpectedStatus,
@@ -281,7 +281,7 @@ public sealed class RulesEngineEndToEndTests
                     {
                       "CheckingWindowId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
                       "CheckingWindowType": "{{CheckingWindowType}}",
-                      "WhatToChange": "{{WhatToChange}}",
+                      "RequestTypeCode": "{{RequestTypeCode}}",
                       "School": { "Urn": "123456", "Name": "Test School" },
                       "SubmittedBy": { "UserId": "u1", "DisplayName": "Alice" },
                       "Pupil": { "Id": "p1", "CypmdId": "c1", "Firstname": "Bob", "Surname": "Smith", "DateOfBirth": "01/01/2010", "Sex": "M", "Age": {{PupilAge}}, "Upn": "UPN1", "Pincl": {{PupilPincl}} },

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/RulesEngineEndToEndTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/RulesEngineEndToEndTests.cs
@@ -61,27 +61,26 @@ public sealed class RulesEngineEndToEndTests
 
     private static IEnumerable<OutcomeScenario> BuildScenarios()
     {
-        yield return new("Inclusion-AutoApproved", "Inclusion", "KS4",
+        // WhatToChange carries the producer's contract string: the WhatToChange enum
+        // name, plus " - {reason option value}" where the flow has a useAsRequestType
+        // question (see AnswerFieldMap.WhatToChangeToOutcomeKey).
+        yield return new("Inclusion-AutoApproved", "Include", "KS4",
             Answers: [("inclusion-status-flag", "402")],
             DecisionStatus.AutoApproved, "INC-ACC");
 
-        yield return new("AdmittedFollowingPermanentExclusion-PreCutoff", "Admitted following permanent exclusion", "KS4",
+        yield return new("AdmittedFollowingPermanentExclusion-PreCutoff", "Remove - permanent-exclusion", "KS4",
             Answers: [("date-of-permanent-exclusion", "2022-01-01")],
             DecisionStatus.AutoRejected, "AFE-PRE2023");
 
-        yield return new("AdmittedFromAbroadEal-FirstLanguageEnglish", "Admitted from abroad with English not first language", "KS4",
+        yield return new("AdmittedFromAbroadEal-FirstLanguageEnglish", "Remove - english-not-first-language", "KS4",
             Answers: [("first-language", "ENG")],
             DecisionStatus.AutoRejected, "EAL-REJ-ENG");
 
-        yield return new("CompletedKs4Elsewhere-Default", "Completed KS4 studies this academic year in year 11 at another school or college", "KS4",
-            Answers: [],
-            DecisionStatus.Scrutiny, "CKS4-DEF");
-
-        yield return new("MergePupils-Default", "Merge pupils", "KS4",
+        yield return new("MergePupils-Default", "Merge", "KS4",
             Answers: [],
             DecisionStatus.Scrutiny, "MRG-DEF");
 
-        yield return new("SocialCareInvolvement-Ks4AllFlagsFalse", "Social care involvement - including police/prison", "KS4",
+        yield return new("SocialCareInvolvement-Ks4AllFlagsFalse", "Remove - social-care-involvement", "KS4",
             Answers:
             [
                 ("social-care-involvement", "no"),
@@ -90,39 +89,39 @@ public sealed class RulesEngineEndToEndTests
             ],
             DecisionStatus.AutoRejected, "SCI-KS4-REJ");
 
-        yield return new("TerminalCriticalIllness-TerminalIsScrutiny", "Terminal/Critical illness", "KS4",
+        yield return new("TerminalCriticalIllness-TerminalIsScrutiny", "Remove - life-limiting-illness", "KS4",
             Answers: [("terminal-illness", "yes")],
             DecisionStatus.Scrutiny, "TCI-TERM-SCR");
 
-        yield return new("YearGroupChange-Lower", "Year group change", "KS4",
+        yield return new("YearGroupChange-Lower", "Remove - year-group-change", "KS4",
             Answers: [("year-group-change", "Lower")],
             DecisionStatus.AutoApproved, "YGC-LOWER");
 
-        yield return new("Deceased-AutoApproved", "Deceased", "KS4",
+        yield return new("Deceased-AutoApproved", "Remove - pupil-died", "KS4",
             Answers: [],
             DecisionStatus.AutoApproved, "DEC-1");
 
-        yield return new("ElectiveHomeEducation-Ks4PostCutoff", "Elective home education", "KS4",
+        yield return new("ElectiveHomeEducation-Ks4PostCutoff", "Remove - elective-home-education", "KS4",
             Answers: [("date-of-removal-from-roll", "2025-02-01")],
             DecisionStatus.AutoRejected, "EHE-KS4");
 
-        yield return new("MovedSchoolDualRegistration-Default", "Moved school/Dual registration", "KS4",
+        yield return new("MovedSchoolDualRegistration-Default", "Remove - dual-registered-moved", "KS4",
             Answers: [],
             DecisionStatus.Scrutiny, "MSD-DEF");
 
-        yield return new("NotOnRoll-NonPost16", "Not on roll", "KS4",
+        yield return new("NotOnRoll-NonPost16", "Remove - not-on-roll", "KS4",
             Answers: [],
             DecisionStatus.AutoApproved, "NOR-NONPOST16");
 
-        yield return new("PermanentlyExcludedFromCurrentSchool-Ks4PostCutoff", "Permanently excluded from current school", "KS4",
+        yield return new("PermanentlyExcludedFromCurrentSchool-Ks4PostCutoff", "Remove - permanently-excluded", "KS4",
             Answers: [("date-of-permanent-exclusion", "2025-02-01")],
             DecisionStatus.AutoRejected, "PEX-KS4");
 
-        yield return new("PermanentlyLeftEngland-Ks4PostCutoff", "Permanently left England", "KS4",
+        yield return new("PermanentlyLeftEngland-Ks4PostCutoff", "Remove - permanently-left-england", "KS4",
             Answers: [("date-of-removal-from-roll", "2025-06-01")],
             DecisionStatus.AutoRejected, "PLE-KS4");
 
-        yield return new("PupilMissingInEducation-WhereaboutsUnknown", "Pupil missing in Education", "KS4",
+        yield return new("PupilMissingInEducation-WhereaboutsUnknown", "Remove - child-missing-education", "KS4",
             Answers:
             [
                 ("whereabouts-known", "no"),
@@ -130,30 +129,49 @@ public sealed class RulesEngineEndToEndTests
             ],
             DecisionStatus.AutoRejected, "PMIE-REJ");
 
-        yield return new("AssessmentsDeferred-NotContinuing", "One or more end-of-key stage assessments deferred by a year", "KS2",
-            Answers: [("continuing-ks2-studies", "no")],
-            DecisionStatus.AutoRejected, "ASD-REJ");
-
-        yield return new("PupilAddedAfterSummerTerm-Before", "Pupil added to school roll after start of summer term", "KS4",
-            Answers: [("date-added-to-roll", "2024-01-01")],
-            DecisionStatus.AutoRejected, "PAS-REJ");
-
-        yield return new("PupilNotOnJuneList-Default", "Pupil not on June list", "KS4",
+        // Per the "always Scrutiny on doubt" policy: a reason the AnswerFieldMap
+        // cannot route must surface to a human, not be dropped.
+        yield return new("UnroutedWhatToChange-FallsToScrutiny", "Remove - some-future-reason", "KS4",
             Answers: [],
-            DecisionStatus.Scrutiny, "PNJL-DEF");
+            DecisionStatus.Scrutiny, "_unmatched_outcome");
+    }
 
-        yield return new OutcomeScenario(
-            Name: "NotAtEndOf16To18Study-Under18",
-            WhatToChange: "Not at end of 16 to 18 study",
-            CheckingWindowType: "Post16",
-            Answers: [],
-            ExpectedStatus: DecisionStatus.AutoApproved,
-            ExpectedRuleId: "N16-LT18",
-            PupilAge: 16);
+    // --- pending outcomes (no journey flow yet) -----------------------------
 
-        yield return new("Other-Default", "Other", "KS4",
-            Answers: [],
-            DecisionStatus.Scrutiny, "OTH-DEF");
+    /// <summary>
+    /// Outcomes seeded in rules.json whose journey flows are not authored yet, so no
+    /// producer contract string routes to them (see
+    /// <c>SeedRulesValidationTests.PendingJourneyOutcomeKeys</c>). Their rule branches
+    /// are still exercised against the seed by driving the engine directly; move a
+    /// scenario up into <see cref="BuildScenarios"/> when its flow exists.
+    /// </summary>
+    public static TheoryData<string, string, DecisionStatus, string> PendingOutcomeScenarios() => new()
+    {
+        { "CompletedKs4Elsewhere",   "KS4",    DecisionStatus.Scrutiny,     "CKS4-DEF" },
+        { "AssessmentsDeferred",     "KS2",    DecisionStatus.AutoRejected, "ASD-REJ"  },
+        { "PupilAddedAfterSummerTerm", "KS4",  DecisionStatus.AutoRejected, "PAS-REJ"  },
+        { "PupilNotOnJuneList",      "KS4",    DecisionStatus.Scrutiny,     "PNJL-DEF" },
+        { "NotAtEndOf16To18Study",   "Post16", DecisionStatus.AutoApproved, "N16-LT18" },
+        { "Other",                   "KS4",    DecisionStatus.Scrutiny,     "OTH-DEF"  },
+    };
+
+    [Theory]
+    [MemberData(nameof(PendingOutcomeScenarios))]
+    public void Engine_RoutesPendingOutcome_ToExpectedDecision(
+        string outcomeKey, string keyStage, DecisionStatus expectedStatus, string expectedRuleId)
+    {
+        var ctx = new RuleContext(outcomeKey, keyStage, new Dictionary<string, FieldValue>
+        {
+            ["keyStage"]              = new FieldValue.Str(keyStage),
+            ["isContinuingKS2Studies"] = new FieldValue.Bool(false),
+            ["dateAddedToRoll"]       = new FieldValue.Date(new DateOnly(2024, 1, 1)),
+            ["pupilAge"]              = new FieldValue.Num(16),
+        });
+
+        var decision = new RulesEngineImpl().Evaluate(Snapshot.Rules, ctx, Snapshot.Lookups);
+
+        Assert.Equal(expectedStatus, decision.Status);
+        Assert.Equal(expectedRuleId, decision.MatchedRuleId);
     }
 
     // --- wiring ------------------------------------------------------------

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/RulesEngineEndToEndTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/RulesEngineEndToEndTests.cs
@@ -4,6 +4,7 @@ using DfE.CheckPerformanceData.Application.RequestDecision;
 using DfE.CheckPerformanceData.Application.RulesEngine;
 using DfE.CheckPerformanceData.Application.RequestSubmission;
 using DfE.CheckPerformanceData.Application.RulesEngine.Json;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -63,38 +64,42 @@ public sealed class RulesEngineEndToEndTests
     {
         // WhatToChange carries the producer's contract string: the WhatToChange enum
         // name, plus " - {reason option value}" where the flow has a useAsRequestType
-        // question (see AnswerFieldMap.WhatToChangeToOutcomeKey).
+        // question. Question ids and answer values mirror the authored flow configs
+        // (see AnswerFieldMap and Web/Data/QuestionFlows).
         yield return new("Inclusion-AutoApproved", "Include", "KS4",
-            Answers: [("inclusion-status-flag", "402")],
-            DecisionStatus.AutoApproved, "INC-ACC");
+            Answers: [],
+            DecisionStatus.AutoApproved, "INC-ACC",
+            PupilPincl: 402); // inclusionFlag comes from the pupil record, not an answer
 
         yield return new("AdmittedFollowingPermanentExclusion-PreCutoff", "Remove - permanent-exclusion", "KS4",
-            Answers: [("date-of-permanent-exclusion", "2022-01-01")],
+            Answers: [("date-pupil-excluded", "2022-01-01")],
             DecisionStatus.AutoRejected, "AFE-PRE2023");
 
         yield return new("AdmittedFromAbroadEal-FirstLanguageEnglish", "Remove - english-not-first-language", "KS4",
-            Answers: [("first-language", "ENG")],
+            Answers: [("first-language", "english")],
             DecisionStatus.AutoRejected, "EAL-REJ-ENG");
 
         yield return new("MergePupils-Default", "Merge", "KS4",
             Answers: [],
             DecisionStatus.Scrutiny, "MRG-DEF");
 
-        yield return new("SocialCareInvolvement-Ks4AllFlagsFalse", "Remove - social-care-involvement", "KS4",
+        // The journey collects one social-care reason radio, so the rules' "all three
+        // flags false" branch can never fire from journey data; the sat-exams
+        // disjunct is the reachable auto-reject path.
+        yield return new("SocialCareInvolvement-Ks4SatExams", "Remove - social-care-involvement", "KS4",
             Answers:
             [
-                ("social-care-involvement", "no"),
-                ("recent-police-involvement", "no"),
-                ("detained-in-prison", "no"),
+                ("social-care-reason", "police-involvement"),
+                ("sat-exams", "yes"),
             ],
             DecisionStatus.AutoRejected, "SCI-KS4-REJ");
 
         yield return new("TerminalCriticalIllness-TerminalIsScrutiny", "Remove - life-limiting-illness", "KS4",
-            Answers: [("terminal-illness", "yes")],
+            Answers: [("life-limiting-illness-health-issue", "life-limiting")],
             DecisionStatus.Scrutiny, "TCI-TERM-SCR");
 
         yield return new("YearGroupChange-Lower", "Remove - year-group-change", "KS4",
-            Answers: [("year-group-change", "Lower")],
+            Answers: [("higher-lower", "lower")],
             DecisionStatus.AutoApproved, "YGC-LOWER");
 
         yield return new("Deceased-AutoApproved", "Remove - pupil-died", "KS4",
@@ -102,7 +107,7 @@ public sealed class RulesEngineEndToEndTests
             DecisionStatus.AutoApproved, "DEC-1");
 
         yield return new("ElectiveHomeEducation-Ks4PostCutoff", "Remove - elective-home-education", "KS4",
-            Answers: [("date-of-removal-from-roll", "2025-02-01")],
+            Answers: [("date-removed-from-roll", "2025-02-01")],
             DecisionStatus.AutoRejected, "EHE-KS4");
 
         yield return new("MovedSchoolDualRegistration-Default", "Remove - dual-registered-moved", "KS4",
@@ -114,20 +119,18 @@ public sealed class RulesEngineEndToEndTests
             DecisionStatus.AutoApproved, "NOR-NONPOST16");
 
         yield return new("PermanentlyExcludedFromCurrentSchool-Ks4PostCutoff", "Remove - permanently-excluded", "KS4",
-            Answers: [("date-of-permanent-exclusion", "2025-02-01")],
+            Answers: [("date-permanently-excluded", "2025-02-01")],
             DecisionStatus.AutoRejected, "PEX-KS4");
 
         yield return new("PermanentlyLeftEngland-Ks4PostCutoff", "Remove - permanently-left-england", "KS4",
-            Answers: [("date-of-removal-from-roll", "2025-06-01")],
+            Answers: [("date-removed-from-roll", "2025-06-01")],
             DecisionStatus.AutoRejected, "PLE-KS4");
 
-        yield return new("PupilMissingInEducation-WhereaboutsUnknown", "Remove - child-missing-education", "KS4",
-            Answers:
-            [
-                ("whereabouts-known", "no"),
-                ("located-reasonable-efforts", "no"),
-            ],
-            DecisionStatus.AutoRejected, "PMIE-REJ");
+        // The authored flow asks why-removed + date, not the whereabouts questions
+        // the PMIE-REJ rule reads, so journey submissions always land in Scrutiny.
+        yield return new("PupilMissingInEducation-DefaultsToScrutiny", "Remove - child-missing-education", "KS4",
+            Answers: [("why-removed", "no-agreed-leave-or-reason")],
+            DecisionStatus.Scrutiny, "PMIE-DEF");
 
         // Per the "always Scrutiny on doubt" policy: a reason the AnswerFieldMap
         // cannot route must surface to a human, not be dropped.
@@ -193,11 +196,16 @@ public sealed class RulesEngineEndToEndTests
         var rulesProvider = Substitute.For<IRulesProvider>();
         rulesProvider.Current.Returns(Snapshot);
 
+        // The worker resolves the (scoped) handler per message via the scope factory.
+        var services = new ServiceCollection();
+        services.AddScoped(_ => handler);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
         return new WorkerHost.RulesEngineWorker(
             NullLogger<WorkerHost.RulesEngineWorker>.Instance,
             queueServiceClient,
             options,
-            handler,
+            scopeFactory,
             rulesProvider,
             new RulesEngineImpl(),
             new RuleContextMapper());
@@ -256,14 +264,18 @@ public sealed class RulesEngineEndToEndTests
         (string QuestionId, string Value)[] Answers,
         DecisionStatus ExpectedStatus,
         string ExpectedRuleId,
-        int PupilAge = 12)
+        int PupilAge = 12,
+        int PupilPincl = 0)
     {
         public string MessageJson
         {
             get
             {
+                // The producer writes the engine-facing value to RawValue and the
+                // display label to Value; the mapper must prefer RawValue, so the
+                // scenarios put a deliberately useless label in Value.
                 var answersJson = string.Join(",\n      ", Answers.Select(a =>
-                    $"{{ \"QuestionId\": \"{a.QuestionId}\", \"QuestionTitle\": \"{a.QuestionId}\", \"Type\": \"text\", \"Value\": \"{a.Value}\" }}"));
+                    $"{{ \"QuestionId\": \"{a.QuestionId}\", \"QuestionTitle\": \"{a.QuestionId}\", \"Type\": \"text\", \"Value\": \"display label\", \"RawValue\": \"{a.Value}\" }}"));
 
                 return $$"""
                     {
@@ -272,7 +284,7 @@ public sealed class RulesEngineEndToEndTests
                       "WhatToChange": "{{WhatToChange}}",
                       "School": { "Urn": "123456", "Name": "Test School" },
                       "SubmittedBy": { "UserId": "u1", "DisplayName": "Alice" },
-                      "Pupil": { "Id": "p1", "CypmdId": "c1", "Firstname": "Bob", "Surname": "Smith", "DateOfBirth": "01/01/2010", "Sex": "M", "Age": {{PupilAge}}, "Upn": "UPN1" },
+                      "Pupil": { "Id": "p1", "CypmdId": "c1", "Firstname": "Bob", "Surname": "Smith", "DateOfBirth": "01/01/2010", "Sex": "M", "Age": {{PupilAge}}, "Upn": "UPN1", "Pincl": {{PupilPincl}} },
                       "Answers": [
                           {{answersJson}}
                       ],

--- a/tests/DfE.CheckPerformanceData.UnitTests/Infrastructure/RequestQueueClientTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Infrastructure/RequestQueueClientTests.cs
@@ -51,6 +51,7 @@ public sealed class RequestQueueClientTests
 
     private static RequestDocument Document() => new()
     {
+        ChangeRequestId = Guid.NewGuid(),
         ReferenceNumber = "REF-1",
         SubmittedAt = DateTime.UtcNow,
         SubmittedBy = new UserDetails { UserId = "u", DisplayName = "A" },

--- a/tests/DfE.CheckPerformanceData.UnitTests/Infrastructure/RequestQueueClientTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Infrastructure/RequestQueueClientTests.cs
@@ -45,7 +45,7 @@ public sealed class RequestQueueClientTests
         Assert.NotNull(body);
         var parsed = RequestDocumentParser.Parse(body!);
         Assert.NotNull(parsed);
-        Assert.Equal("Remove - pupil-died", parsed!.WhatToChange);
+        Assert.Equal("Remove - pupil-died", parsed!.RequestTypeCode);
         Assert.Equal(402, parsed.Pupil.Pincl);
     }
 
@@ -56,7 +56,7 @@ public sealed class RequestQueueClientTests
         SubmittedBy = new UserDetails { UserId = "u", DisplayName = "A" },
         CheckingWindowId = Guid.NewGuid(),
         CheckingWindowType = "KS4June",
-        WhatToChange = "Remove - pupil-died",
+        RequestTypeCode = "Remove - pupil-died",
         School = new SchoolDetails { Urn = "1", Name = "S" },
         Pupil = new PupilDetails
         {

--- a/tests/DfE.CheckPerformanceData.UnitTests/Infrastructure/RequestQueueClientTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Infrastructure/RequestQueueClientTests.cs
@@ -1,0 +1,68 @@
+using Azure;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Infrastructure.QueueStorage;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Infrastructure;
+
+public sealed class RequestQueueClientTests
+{
+    private readonly QueueClient _queueClient = Substitute.For<QueueClient>();
+    private readonly RequestQueueClient _sut;
+
+    public RequestQueueClientTests()
+    {
+        _sut = new RequestQueueClient(_queueClient);
+    }
+
+    [Fact]
+    public async Task EnqueueRequestAsync_CreatesQueueBeforeSending()
+    {
+        // Same pattern as the blob clients: CreateIfNotExists before every write,
+        // so a fresh storage account doesn't 404 the first submission.
+        var callOrder = new List<string>();
+        _queueClient.CreateIfNotExistsAsync()
+            .Returns(_ => { callOrder.Add("create"); return Task.FromResult<Response>(null!); });
+        _queueClient.SendMessageAsync(Arg.Any<string>())
+            .Returns(_ => { callOrder.Add("send"); return Task.FromResult(Substitute.For<Response<SendReceipt>>()); });
+
+        await _sut.EnqueueRequestAsync(Document());
+
+        Assert.Equal(["create", "send"], callOrder);
+    }
+
+    [Fact]
+    public async Task EnqueueRequestAsync_SendsBody_TheWorkerParserCanRead()
+    {
+        string? body = null;
+        _queueClient.SendMessageAsync(Arg.Do<string>(b => body = b))
+            .Returns(Task.FromResult(Substitute.For<Response<SendReceipt>>()));
+
+        await _sut.EnqueueRequestAsync(Document());
+
+        Assert.NotNull(body);
+        var parsed = RequestDocumentParser.Parse(body!);
+        Assert.NotNull(parsed);
+        Assert.Equal("Remove - pupil-died", parsed!.WhatToChange);
+        Assert.Equal(402, parsed.Pupil.Pincl);
+    }
+
+    private static RequestDocument Document() => new()
+    {
+        ReferenceNumber = "REF-1",
+        SubmittedAt = DateTime.UtcNow,
+        SubmittedBy = new UserDetails { UserId = "u", DisplayName = "A" },
+        CheckingWindowId = Guid.NewGuid(),
+        CheckingWindowType = "KS4June",
+        WhatToChange = "Remove - pupil-died",
+        School = new SchoolDetails { Urn = "1", Name = "S" },
+        Pupil = new PupilDetails
+        {
+            Id = "p", CypmdId = "c", Firstname = "B", Surname = "S",
+            DateOfBirth = "01/01/2010", Sex = "M", Age = 15, Upn = "U", Pincl = 402
+        },
+        Answers = []
+    };
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerTests.cs
@@ -328,6 +328,34 @@ public class JourneyControllerTests
         Assert.Null(remaining.MatchedPupilLabel);
     }
 
+    // ── PagePost — Autocomplete code capture ─────────────────────────────────
+
+    [Fact]
+    public async Task PagePost_AutocompleteQuestion_CapturesCodeValueAlongsideDisplayName()
+    {
+        var page = new JourneyPage
+        {
+            Id = "country-page",
+            Questions = [new Question { Id = "country-originally-from", Type = QuestionType.Autocomplete, Title = "Country" }]
+        };
+        _flowService.GetPage(Config, "country-page").Returns(page);
+        _flowService.GetNextPageId(Config, "country-page", Arg.Any<Dictionary<string, QuestionAnswer>>()).Returns((string?)null);
+        _journeyService.ValidateAnswer(Arg.Any<Question>(), Arg.Any<QuestionAnswer>(), Arg.Any<string>(), Arg.Any<string?>())
+            .Returns((string?)null);
+        SetupSession(ValidSession(history: ["country-page"]));
+        _httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+        {
+            ["q_country_originally_from"] = "France",
+            ["q_country_originally_from_code"] = "FR"
+        });
+
+        await _sut.PagePost(WindowId, "country-page", fromSummary: false);
+
+        var saved = _session.GetRequestState(WindowId).QuestionAnswers["country-originally-from"];
+        Assert.Equal("France", saved.TextValue);
+        Assert.Equal("FR", saved.CodeValue);
+    }
+
     // ── SaveDraft ────────────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/QuestionFlowServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/QuestionFlowServiceTests.cs
@@ -279,6 +279,90 @@ public class QuestionFlowServiceTests
         Assert.Equal(string.Empty, _sut.ResolveRequestType(_config, journey));
     }
 
+    // ── ResolveRequestTypeValue ─────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveRequestTypeValue_WhenUseAsRequestTypeQuestion_ReturnsItsRawValue()
+    {
+        var config = new QuestionFlowConfig
+        {
+            FirstPageId = "reason",
+            Pages = [
+                new JourneyPage
+                {
+                    Id = "reason",
+                    Questions = [new Question { Id = "reason", Type = QuestionType.Radio, Title = "Reason",
+                        UseAsRequestType = true,
+                        Options = [new QuestionOption { Value = "social-care-involvement", Label = "Social care involvement" }] }]
+                }
+            ]
+        };
+        var journey = MakeJourney(
+            history: ["reason"],
+            answers: new() { ["reason"] = new() { TextValue = "social-care-involvement" } });
+
+        Assert.Equal("social-care-involvement", _sut.ResolveRequestTypeValue(config, journey));
+    }
+
+    [Fact]
+    public void ResolveRequestTypeValue_WhenNoUseAsRequestTypeQuestion_ReturnsEmpty_NoFallback()
+    {
+        // Unlike ResolveRequestType (display), the contract value must not fall back to
+        // the first answered question — flows without a flagged question are bare-prefix.
+        var config = new QuestionFlowConfig
+        {
+            FirstPageId = "reason",
+            Pages = [
+                new JourneyPage
+                {
+                    Id = "reason",
+                    Questions = [new Question { Id = "reason", Type = QuestionType.Radio, Title = "Reason",
+                        Options = [new QuestionOption { Value = "other", Label = "Other reason" }] }]
+                }
+            ]
+        };
+        var journey = MakeJourney(
+            history: ["reason"],
+            answers: new() { ["reason"] = new() { TextValue = "other" } });
+
+        Assert.Equal(string.Empty, _sut.ResolveRequestTypeValue(config, journey));
+    }
+
+    [Fact]
+    public void ResolveRequestTypeValue_WhenFlaggedQuestionUnanswered_ReturnsEmpty()
+    {
+        var config = new QuestionFlowConfig
+        {
+            FirstPageId = "p1",
+            Pages = [
+                new JourneyPage
+                {
+                    Id = "p1",
+                    Questions = [
+                        new Question { Id = "q-flag", Type = QuestionType.Radio, Title = "Flagged",
+                            UseAsRequestType = true,
+                            Options = [new QuestionOption { Value = "x", Label = "X" }] },
+                        new Question { Id = "q-other", Type = QuestionType.Radio, Title = "Other",
+                            Options = [new QuestionOption { Value = "y", Label = "Y" }] }
+                    ]
+                }
+            ]
+        };
+        var journey = MakeJourney(
+            history: ["p1"],
+            answers: new() { ["q-other"] = new() { TextValue = "y" } });
+
+        Assert.Equal(string.Empty, _sut.ResolveRequestTypeValue(config, journey));
+    }
+
+    [Fact]
+    public void ResolveRequestTypeValue_WhenNoAnswers_ReturnsEmptyString()
+    {
+        var journey = MakeJourney(history: ["reason"]);
+
+        Assert.Equal(string.Empty, _sut.ResolveRequestTypeValue(_config, journey));
+    }
+
     // ── GetConfigAsync ──────────────────────────────────────────────────────
 
     [Fact]

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/RequestServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/RequestServiceTests.cs
@@ -339,25 +339,25 @@ public class RequestServiceTests
     }
 
     [Fact]
-    public async Task ConfirmRequestAsync_WhatToChange_IncludesReasonValue_WhenFlowResolvesOne()
+    public async Task ConfirmRequestAsync_RequestTypeCode_IncludesReasonValue_WhenFlowResolvesOne()
     {
         var (journey, config) = MakeSubmission();
         _flowService.ResolveRequestTypeValue(config, Arg.Any<RequestState>()).Returns("pupil-died");
 
         var doc = await CaptureDocument(journey, config);
 
-        Assert.Equal("Remove - pupil-died", doc.WhatToChange);
+        Assert.Equal("Remove - pupil-died", doc.RequestTypeCode);
     }
 
     [Fact]
-    public async Task ConfirmRequestAsync_WhatToChange_IsBarePrefix_WhenFlowResolvesNoValue()
+    public async Task ConfirmRequestAsync_RequestTypeCode_IsBarePrefix_WhenFlowResolvesNoValue()
     {
         var (journey, config) = MakeSubmission();
         _flowService.ResolveRequestTypeValue(config, Arg.Any<RequestState>()).Returns(string.Empty);
 
         var doc = await CaptureDocument(journey, config);
 
-        Assert.Equal("Remove", doc.WhatToChange);
+        Assert.Equal("Remove", doc.RequestTypeCode);
     }
 
     [Fact]

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/RequestServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/RequestServiceTests.cs
@@ -131,19 +131,33 @@ public class RequestServiceTests
     }
 
     [Fact]
-    public async Task ConfirmRequestAsync_SavesRepositoryAfterEnqueue()
+    public async Task ConfirmRequestAsync_UpsertsChangeRequestBeforeEnqueue()
     {
+        // The document must carry the ChangeRequest row's Id, so the row has to
+        // exist before the document is enqueued.
         var (journey, config) = MakeSubmission();
         SetupConfig(config);
         var callOrder = new List<string>();
         _requestQueue.EnqueueRequestAsync(Arg.Any<RequestDocument>())
             .Returns(_ => { callOrder.Add("enqueue"); return Task.CompletedTask; });
         _requestRepository.UpsertAsync(Arg.Any<ChangeRequestData>())
-            .Returns(_ => { callOrder.Add("db"); return Task.CompletedTask; });
+            .Returns(_ => { callOrder.Add("db"); return Guid.NewGuid(); });
 
         await _sut.ConfirmRequestAsync(WindowId, journey);
 
-        Assert.Equal(["enqueue", "db"], callOrder);
+        Assert.Equal(["db", "enqueue"], callOrder);
+    }
+
+    [Fact]
+    public async Task ConfirmRequestAsync_DocumentCarriesChangeRequestIdReturnedByUpsert()
+    {
+        var changeRequestId = Guid.Parse("99999999-8888-7777-6666-555555555555");
+        _requestRepository.UpsertAsync(Arg.Any<ChangeRequestData>()).Returns(changeRequestId);
+        var (journey, config) = MakeSubmission();
+
+        var doc = await CaptureDocument(journey, config);
+
+        Assert.Equal(changeRequestId, doc.ChangeRequestId);
     }
 
     [Fact]
@@ -482,7 +496,7 @@ public class RequestServiceTests
         _draftBlobClient.SaveDraftAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<RequestState>())
             .Returns(_ => { callOrder.Add("blob"); return Task.CompletedTask; });
         _requestRepository.UpsertAsync(Arg.Any<ChangeRequestData>())
-            .Returns(_ => { callOrder.Add("db"); return Task.CompletedTask; });
+            .Returns(_ => { callOrder.Add("db"); return Guid.NewGuid(); });
 
         await _sut.SaveDraftAsync(WindowId, journey, RequestStatus.InProgress);
 

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/RequestServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/RequestServiceTests.cs
@@ -261,6 +261,28 @@ public class RequestServiceTests
     }
 
     [Fact]
+    public async Task ConfirmRequestAsync_WhatToChange_IncludesReasonValue_WhenFlowResolvesOne()
+    {
+        var (journey, config) = MakeSubmission();
+        _flowService.ResolveRequestTypeValue(config, Arg.Any<RequestState>()).Returns("pupil-died");
+
+        var doc = await CaptureDocument(journey, config);
+
+        Assert.Equal("Remove - pupil-died", doc.WhatToChange);
+    }
+
+    [Fact]
+    public async Task ConfirmRequestAsync_WhatToChange_IsBarePrefix_WhenFlowResolvesNoValue()
+    {
+        var (journey, config) = MakeSubmission();
+        _flowService.ResolveRequestTypeValue(config, Arg.Any<RequestState>()).Returns(string.Empty);
+
+        var doc = await CaptureDocument(journey, config);
+
+        Assert.Equal("Remove", doc.WhatToChange);
+    }
+
+    [Fact]
     public async Task ConfirmRequestAsync_SavesDocumentToBlobStorage()
     {
         var (journey, config) = MakeSubmission();

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/RequestServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/RequestServiceTests.cs
@@ -13,10 +13,10 @@ public class RequestServiceTests
     private static readonly Guid WindowId = Guid.Parse("22222222-2222-2222-2222-222222222222");
 
     private readonly IQuestionFlowService _flowService = Substitute.For<IQuestionFlowService>();
-    private readonly IRequestBlobClient _blobClient = Substitute.For<IRequestBlobClient>();
     private readonly IDraftBlobClient _draftBlobClient = Substitute.For<IDraftBlobClient>();
     private readonly IRequestRepository _requestRepository = Substitute.For<IRequestRepository>();
     private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IRequestQueueClient _requestQueue = Substitute.For<IRequestQueueClient>();
     private readonly RequestService _sut;
 
     public RequestServiceTests()
@@ -25,7 +25,7 @@ public class RequestServiceTests
         _currentUser.DisplayName.Returns("Test User");
         _currentUser.OrganisationUrn.Returns("100000");
         _currentUser.OrganisationName.Returns("Test School");
-        _sut = new RequestService(_flowService, _blobClient, _draftBlobClient, _requestRepository, _currentUser);
+        _sut = new RequestService(_flowService, _draftBlobClient, _requestRepository, _currentUser, _requestQueue);
     }
 
     // ── ConfirmRequestAsync — guard checks ──────────────────────────────────
@@ -64,7 +64,7 @@ public class RequestServiceTests
         await Assert.ThrowsAsync<DuplicateRequestException>(() =>
             _sut.ConfirmRequestAsync(WindowId, journey));
 
-        await _blobClient.DidNotReceive().SaveRequestAsync(Arg.Any<Guid>(), Arg.Any<RequestDocument>());
+        await _requestQueue.DidNotReceive().EnqueueRequestAsync(Arg.Any<RequestDocument>());
         await _requestRepository.DidNotReceive().UpsertAsync(Arg.Any<ChangeRequestData>());
     }
 
@@ -107,6 +107,19 @@ public class RequestServiceTests
     }
 
     [Fact]
+    public async Task ConfirmRequestAsync_MapsPupilPincl()
+    {
+        // The rules engine derives inclusionFlag from the pupil record's Pincl —
+        // it is never asked as a journey question.
+        var (journey, config) = MakeSubmission();
+        journey.SelectedPupil!.Pincl = 402;
+
+        var doc = await CaptureDocument(journey, config);
+
+        Assert.Equal(402, doc.Pupil.Pincl);
+    }
+
+    [Fact]
     public async Task ConfirmRequestAsync_SavesChangeRequestToRepository()
     {
         var (journey, config) = MakeSubmission();
@@ -118,19 +131,19 @@ public class RequestServiceTests
     }
 
     [Fact]
-    public async Task ConfirmRequestAsync_SavesRepositoryAfterBlob()
+    public async Task ConfirmRequestAsync_SavesRepositoryAfterEnqueue()
     {
         var (journey, config) = MakeSubmission();
         SetupConfig(config);
         var callOrder = new List<string>();
-        _blobClient.SaveRequestAsync(Arg.Any<Guid>(), Arg.Any<RequestDocument>())
-            .Returns(_ => { callOrder.Add("blob"); return Task.CompletedTask; });
+        _requestQueue.EnqueueRequestAsync(Arg.Any<RequestDocument>())
+            .Returns(_ => { callOrder.Add("enqueue"); return Task.CompletedTask; });
         _requestRepository.UpsertAsync(Arg.Any<ChangeRequestData>())
             .Returns(_ => { callOrder.Add("db"); return Task.CompletedTask; });
 
         await _sut.ConfirmRequestAsync(WindowId, journey);
 
-        Assert.Equal(["blob", "db"], callOrder);
+        Assert.Equal(["enqueue", "db"], callOrder);
     }
 
     [Fact]
@@ -249,6 +262,71 @@ public class RequestServiceTests
     }
 
     [Fact]
+    public async Task ConfirmRequestAsync_RadioAnswer_RawValueIsOptionValue()
+    {
+        var question = new Question
+        {
+            Id = "reason",
+            Type = QuestionType.Radio,
+            Title = "Reason",
+            Options = [new QuestionOption { Value = "opt-1", Label = "Opted Out" }]
+        };
+        var config = MakeConfig([new JourneyPage { Id = "reason", Questions = [question] }]);
+        var journey = ValidJourney(
+            history: ["reason"],
+            answers: new() { ["reason"] = new QuestionAnswer { TextValue = "opt-1" } });
+
+        var doc = await CaptureDocument(journey, config);
+
+        Assert.Equal("opt-1", doc.Answers[0].RawValue);
+        Assert.Equal("Opted Out", doc.Answers[0].Value);
+    }
+
+    [Fact]
+    public async Task ConfirmRequestAsync_DateAnswer_RawValueIsIsoDate()
+    {
+        var question = MakeQuestion(QuestionType.Date, id: "dob");
+        var config = MakeConfig([new JourneyPage { Id = "dob", Questions = [question] }]);
+        var journey = ValidJourney(
+            history: ["dob"],
+            answers: new() { ["dob"] = new QuestionAnswer { DateValue = new DateAnswer { Day = 5, Month = 3, Year = 2010 } } });
+
+        var doc = await CaptureDocument(journey, config);
+
+        Assert.Equal("2010-03-05", doc.Answers[0].RawValue);
+        Assert.Equal("05/03/2010", doc.Answers[0].Value);
+    }
+
+    [Fact]
+    public async Task ConfirmRequestAsync_AutocompleteAnswer_RawValueIsCode()
+    {
+        var question = MakeQuestion(QuestionType.Autocomplete, id: "country");
+        var config = MakeConfig([new JourneyPage { Id = "country", Questions = [question] }]);
+        var journey = ValidJourney(
+            history: ["country"],
+            answers: new() { ["country"] = new QuestionAnswer { TextValue = "France", CodeValue = "FR" } });
+
+        var doc = await CaptureDocument(journey, config);
+
+        Assert.Equal("FR", doc.Answers[0].RawValue);
+        Assert.Equal("France", doc.Answers[0].Value);
+    }
+
+    [Fact]
+    public async Task ConfirmRequestAsync_FreeTextAnswer_RawValueIsText()
+    {
+        var question = MakeQuestion(QuestionType.FreeText, id: "notes");
+        var config = MakeConfig([new JourneyPage { Id = "notes", Questions = [question] }]);
+        var journey = ValidJourney(
+            history: ["notes"],
+            answers: new() { ["notes"] = new QuestionAnswer { TextValue = "Some detail" } });
+
+        var doc = await CaptureDocument(journey, config);
+
+        Assert.Equal("Some detail", doc.Answers[0].RawValue);
+    }
+
+    [Fact]
     public async Task ConfirmRequestAsync_PupilNameTemplate_IsResolved()
     {
         var question = new Question { Id = "q1", Type = QuestionType.FreeText, Title = "Notes for {pupilName}" };
@@ -283,14 +361,14 @@ public class RequestServiceTests
     }
 
     [Fact]
-    public async Task ConfirmRequestAsync_SavesDocumentToBlobStorage()
+    public async Task ConfirmRequestAsync_SendsDocumentToRulesEngineQueue()
     {
         var (journey, config) = MakeSubmission();
         SetupConfig(config);
 
         await _sut.ConfirmRequestAsync(WindowId, journey);
 
-        await _blobClient.Received(1).SaveRequestAsync(WindowId, Arg.Any<RequestDocument>());
+        await _requestQueue.Received(1).EnqueueRequestAsync(Arg.Any<RequestDocument>());
     }
 
     // ── SaveDraftAsync ──────────────────────────────────────────────────────
@@ -450,7 +528,7 @@ public class RequestServiceTests
     {
         SetupConfig(config);
         RequestDocument? captured = null;
-        await _blobClient.SaveRequestAsync(WindowId, Arg.Do<RequestDocument>(d => captured = d));
+        await _requestQueue.EnqueueRequestAsync(Arg.Do<RequestDocument>(d => captured = d));
 
         await _sut.ConfirmRequestAsync(WindowId, journey);
 

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/BlobRulesProviderTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/BlobRulesProviderTests.cs
@@ -93,6 +93,27 @@ public sealed class BlobRulesProviderTests
     }
 
     [Fact]
+    public async Task RefreshAsync_LookupsWithUnderscoreCommentKeys_ParsesAndSkipsThem()
+    {
+        // The seed country-languages.json carries a "_comment" string entry by
+        // convention; the provider must skip underscore-prefixed keys, not reject
+        // the whole document.
+        var (sut, reader, _) = Build();
+        reader.FetchAsync(RulesBlobName, null, Arg.Any<CancellationToken>())
+              .Returns(RulesBlobFetch.Success(ValidRulesJson, "etag-rules-1"));
+        reader.FetchAsync(LookupsBlobName, null, Arg.Any<CancellationToken>())
+              .Returns(RulesBlobFetch.Success(
+                  """{ "_comment": "ISO code -> official languages", "AU": ["English"] }""",
+                  "etag-lookups-1"));
+
+        await sut.RefreshAsync(CancellationToken.None);
+
+        Assert.Equal(RulesHealth.Healthy, sut.Current.Health);
+        Assert.True(sut.Current.Lookups.CountryHasOfficialLanguage("AU", "English"));
+        Assert.False(sut.Current.Lookups.CountryHasOfficialLanguage("_comment", "English"));
+    }
+
+    [Fact]
     public async Task RefreshAsync_BothErrors_KeepsColdFallback_DoesNotUpgradeHealth()
     {
         var (sut, reader, _) = Build();
@@ -294,6 +315,20 @@ public sealed class BlobRulesProviderTests
 
         Assert.Equal(RulesHealth.Healthy, sut.Current.Health);
         Assert.Equal("v2.0", sut.Current.Version);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CalledTwice_DoesNotThrow()
+    {
+        // The provider is registered both as a singleton and as an IHostedService
+        // factory returning the same instance, so the container disposes it twice
+        // on shutdown — DisposeAsync must be idempotent.
+        var (sut, _, _) = Build();
+        await sut.StartAsync(CancellationToken.None);
+        await sut.StopAsync(CancellationToken.None);
+
+        await sut.DisposeAsync();
+        await sut.DisposeAsync();
     }
 
     // --- helpers ---

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/QuestionFlowOutcomeKeyAlignmentTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/QuestionFlowOutcomeKeyAlignmentTests.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.RulesEngine;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.RulesEngine;
+
+/// <summary>
+/// Pins the Web question-flow configs to <see cref="AnswerFieldMap.WhatToChangeToOutcomeKey"/>:
+/// every <c>WhatToChange</c> contract string a flow can produce — the bare flow prefix,
+/// or <c>"{prefix} - {reason option value}"</c> for each option of a
+/// <c>useAsRequestType</c> question — must route to an outcome key. A reason option
+/// added (or a value renamed) without a matching map entry would otherwise silently
+/// send every such request to <c>_unknown</c>/Scrutiny.
+/// </summary>
+public sealed class QuestionFlowOutcomeKeyAlignmentTests
+{
+    // Mirrors QuestionFlowBlobClient's deserialization options.
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public static TheoryData<string> FlowFiles()
+    {
+        var data = new TheoryData<string>();
+        foreach (var file in Directory.GetFiles(LocateFlowsDirectory(), "*.json").Order())
+            data.Add(Path.GetFileName(file));
+        return data;
+    }
+
+    [Fact]
+    public void FlowConfigsExist()
+    {
+        Assert.NotEmpty(Directory.GetFiles(LocateFlowsDirectory(), "*.json"));
+    }
+
+    [Theory]
+    [MemberData(nameof(FlowFiles))]
+    public void EveryContractString_RoutesToAnOutcomeKey(string fileName)
+    {
+        var path = Path.Combine(LocateFlowsDirectory(), fileName);
+        var config = JsonSerializer.Deserialize<QuestionFlowConfig>(File.ReadAllText(path), JsonOptions);
+        Assert.NotNull(config);
+
+        var prefix = fileName.Split('_')[0];
+
+        var flagged = config.Pages
+            .SelectMany(p => p.Questions)
+            .Where(q => q.UseAsRequestType)
+            .ToList();
+
+        if (flagged.Count == 0)
+        {
+            AssertRoutable(prefix);
+            return;
+        }
+
+        foreach (var question in flagged)
+        {
+            Assert.True(question.Options is { Count: > 0 },
+                $"{fileName}: useAsRequestType question '{question.Id}' must be a Radio with options.");
+
+            foreach (var option in question.Options!)
+                AssertRoutable($"{prefix} - {option.Value}");
+        }
+    }
+
+    private static void AssertRoutable(string contract) =>
+        Assert.True(AnswerFieldMap.WhatToChangeToOutcomeKey.ContainsKey(contract),
+            $"WhatToChange '{contract}' has no entry in AnswerFieldMap.WhatToChangeToOutcomeKey — " +
+            "every request for it would resolve to _unknown and fall to Scrutiny.");
+
+    private static string LocateFlowsDirectory()
+    {
+        // Walk up from the test assembly to find the repo's Web question-flow configs.
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName,
+                "src", "DfE.CheckPerformanceData.Web", "Data", "QuestionFlows");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException(
+            "Could not locate src/DfE.CheckPerformanceData.Web/Data/QuestionFlows from " +
+            AppContext.BaseDirectory);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/QuestionFlowOutcomeKeyAlignmentTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/QuestionFlowOutcomeKeyAlignmentTests.cs
@@ -72,6 +72,87 @@ public sealed class QuestionFlowOutcomeKeyAlignmentTests
             $"WhatToChange '{contract}' has no entry in AnswerFieldMap.WhatToChangeToOutcomeKey — " +
             "every request for it would resolve to _unknown and fall to Scrutiny.");
 
+    // ── Question id / option value alignment ────────────────────────────────
+
+    /// <summary>
+    /// Question ids the AnswerFieldMap consumes whose flows are not authored yet
+    /// (KS2 / Post16). Remove an id when its flow config exists so the test below
+    /// guards it.
+    /// </summary>
+    private static readonly string[] PendingFlowQuestionIds =
+    [
+        "date-added-to-roll",
+        "removal-reason-at-school",
+        "continuing-ks2-studies",
+        "pupil-age",
+    ];
+
+    [Fact]
+    public void EveryMappedQuestionId_ExistsInAnAuthoredFlow()
+    {
+        var flowQuestionIds = AllFlowQuestions().Select(q => q.Question.Id).ToHashSet(StringComparer.Ordinal);
+
+        var consumedIds = AnswerFieldMap.QuestionToField.Keys
+            .Concat(AnswerFieldMap.RadioFanOut.Keys)
+            .Concat(AnswerFieldMap.TranslatedQuestions.Keys)
+            .Append(AnswerFieldMap.SatExamsQuestionId)
+            .Except(PendingFlowQuestionIds, StringComparer.Ordinal);
+
+        foreach (var id in consumedIds)
+        {
+            Assert.True(flowQuestionIds.Contains(id),
+                $"AnswerFieldMap consumes question id '{id}' but no authored flow config asks it — " +
+                "its canonical field would always be Unknown.");
+        }
+    }
+
+    [Fact]
+    public void EveryFanOutTriggerValue_ExistsOnItsFlowQuestion()
+    {
+        foreach (var (questionId, fanOut) in AnswerFieldMap.RadioFanOut)
+        foreach (var (field, trigger) in fanOut)
+        {
+            AssertOptionValueExists(questionId, trigger,
+                $"RadioFanOut field '{field}' triggers on '{trigger}'");
+        }
+    }
+
+    [Fact]
+    public void EveryTranslatedValue_ExistsOnItsFlowQuestion()
+    {
+        foreach (var (questionId, (field, values)) in AnswerFieldMap.TranslatedQuestions)
+        foreach (var raw in values.Keys)
+        {
+            AssertOptionValueExists(questionId, raw,
+                $"TranslatedQuestions field '{field}' maps raw value '{raw}'");
+        }
+    }
+
+    private static void AssertOptionValueExists(string questionId, string optionValue, string mapDescription)
+    {
+        var questions = AllFlowQuestions()
+            .Where(q => q.Question.Id == questionId)
+            .ToList();
+
+        Assert.True(questions.Count > 0,
+            $"{mapDescription}, but no authored flow asks question '{questionId}'.");
+        Assert.True(questions.Any(q => q.Question.Options?.Any(o => o.Value == optionValue) == true),
+            $"{mapDescription}, but question '{questionId}' has no option with value '{optionValue}' " +
+            $"in any authored flow — that mapping can never fire.");
+    }
+
+    private static IEnumerable<(string File, Question Question)> AllFlowQuestions()
+    {
+        var dir = LocateFlowsDirectory();
+        foreach (var file in Directory.GetFiles(dir, "*.json").Order())
+        {
+            var config = JsonSerializer.Deserialize<QuestionFlowConfig>(File.ReadAllText(file), JsonOptions)!;
+            foreach (var page in config.Pages)
+            foreach (var question in page.Questions)
+                yield return (Path.GetFileName(file), question);
+        }
+    }
+
     private static string LocateFlowsDirectory()
     {
         // Walk up from the test assembly to find the repo's Web question-flow configs.

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RequestDecisionHandlerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RequestDecisionHandlerTests.cs
@@ -239,6 +239,7 @@ public sealed class RequestDecisionHandlerTests
 
     private static RequestDocument NewMessage(string whatToChange, params AnswerRecord[] answers) => new()
     {
+        ChangeRequestId = Guid.NewGuid(),
         ReferenceNumber = "REF",
         CheckingWindowId = Guid.NewGuid(),
         CheckingWindowType = "KS4",

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RequestDecisionHandlerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RequestDecisionHandlerTests.cs
@@ -242,7 +242,7 @@ public sealed class RequestDecisionHandlerTests
         ReferenceNumber = "REF",
         CheckingWindowId = Guid.NewGuid(),
         CheckingWindowType = "KS4",
-        WhatToChange = whatToChange,
+        RequestTypeCode = whatToChange,
         SubmittedAt = DateTime.UtcNow,
         SubmittedBy = new UserDetails { UserId = "u", DisplayName = "x" },
         School = new SchoolDetails { Urn = "1", Name = "Test School" },

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RequestDocumentParserTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RequestDocumentParserTests.cs
@@ -18,6 +18,7 @@ public sealed class RequestDocumentParserTests
         // pin that the worker-side parser reads that exact wire format back.
         var doc = new RequestDocument
         {
+            ChangeRequestId = Guid.Parse("99999999-8888-7777-6666-555555555555"),
             ReferenceNumber = "REF-RT",
             SubmittedAt = new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc),
             SubmittedBy = new UserDetails { UserId = "u1", DisplayName = "Alice" },
@@ -56,6 +57,7 @@ public sealed class RequestDocumentParserTests
     {
         const string json = """
             {
+              "ChangeRequestId": "11111111-2222-3333-4444-555555555555",
               "CheckingWindowId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
               "CheckingWindowType": "KS4",
               "RequestTypeCode": "Deceased",
@@ -86,6 +88,7 @@ public sealed class RequestDocumentParserTests
         // The producer serialises PascalCase; this confirms case-insensitive parsing.
         const string json = """
             {
+              "changerequestid": "11111111-2222-3333-4444-555555555555",
               "checkingwindowtype": "KS2",
               "requesttypecode": "Elective home education",
               "referencenumber": "REF-2",
@@ -100,6 +103,51 @@ public sealed class RequestDocumentParserTests
 
         Assert.NotNull(parsed);
         Assert.Equal("Elective home education", parsed!.RequestTypeCode);
+    }
+
+    [Fact]
+    public void Parse_ChangeRequestId_RoundTrips()
+    {
+        // The worker updates ChangeRequests by this Id, so it must survive the wire.
+        const string json = """
+            {
+              "ChangeRequestId": "99999999-8888-7777-6666-555555555555",
+              "CheckingWindowId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+              "CheckingWindowType": "KS4",
+              "RequestTypeCode": "Deceased",
+              "ReferenceNumber": "REF-001",
+              "School": { "Urn": "123456", "Name": "Test School" },
+              "SubmittedBy": { "UserId": "u1", "DisplayName": "Alice" },
+              "Pupil": { "Id": "p1", "CypmdId": "c1", "Firstname": "Bob", "Surname": "Smith", "DateOfBirth": "01/01/2010", "Sex": "M", "Age": 15, "Upn": "UPN1" },
+              "Answers": []
+            }
+            """;
+
+        var parsed = RequestDocumentParser.Parse(json);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(Guid.Parse("99999999-8888-7777-6666-555555555555"), parsed!.ChangeRequestId);
+    }
+
+    [Fact]
+    public void Parse_MissingChangeRequestId_ReturnsNull()
+    {
+        // Pre-release contract: ChangeRequestId is required; a document without it
+        // is unparseable and goes through poison-message handling.
+        const string json = """
+            {
+              "CheckingWindowId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+              "CheckingWindowType": "KS4",
+              "RequestTypeCode": "Deceased",
+              "ReferenceNumber": "REF-001",
+              "School": { "Urn": "123456", "Name": "Test School" },
+              "SubmittedBy": { "UserId": "u1", "DisplayName": "Alice" },
+              "Pupil": { "Id": "p1", "CypmdId": "c1", "Firstname": "Bob", "Surname": "Smith", "DateOfBirth": "01/01/2010", "Sex": "M", "Age": 15, "Upn": "UPN1" },
+              "Answers": []
+            }
+            """;
+
+        Assert.Null(RequestDocumentParser.Parse(json));
     }
 
     [Fact]

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RequestDocumentParserTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RequestDocumentParserTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using DfE.CheckPerformanceData.Application.RequestSubmission;
 
 namespace DfE.CheckPerformanceData.Application.UnitTests.RulesEngine;
@@ -10,6 +11,46 @@ namespace DfE.CheckPerformanceData.Application.UnitTests.RulesEngine;
 /// </summary>
 public sealed class RequestDocumentParserTests
 {
+    [Fact]
+    public void Parse_RoundTripsDocument_SerializedWithDefaultOptions()
+    {
+        // RequestService enqueues with bare JsonSerializer.Serialize(document) —
+        // pin that the worker-side parser reads that exact wire format back.
+        var doc = new RequestDocument
+        {
+            ReferenceNumber = "REF-RT",
+            SubmittedAt = new DateTime(2026, 6, 10, 9, 0, 0, DateTimeKind.Utc),
+            SubmittedBy = new UserDetails { UserId = "u1", DisplayName = "Alice" },
+            CheckingWindowId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+            CheckingWindowType = "KS4June",
+            WhatToChange = "Remove - pupil-died",
+            School = new SchoolDetails { Urn = "123456", Name = "Test School" },
+            Pupil = new PupilDetails
+            {
+                Id = "p1", CypmdId = "c1", Firstname = "Bob", Surname = "Smith",
+                DateOfBirth = "01/01/2010", Sex = "M", Age = 15, Upn = "UPN1", Pincl = 402
+            },
+            Answers =
+            [
+                new AnswerRecord
+                {
+                    QuestionId = "date-removed-from-roll", QuestionTitle = "When?",
+                    Type = "Date", Value = "15/02/2025", RawValue = "2025-02-15"
+                }
+            ]
+        };
+
+        var parsed = RequestDocumentParser.Parse(JsonSerializer.Serialize(doc));
+
+        Assert.NotNull(parsed);
+        Assert.Equal("Remove - pupil-died", parsed!.WhatToChange);
+        Assert.Equal("REF-RT", parsed.ReferenceNumber);
+        Assert.Equal(402, parsed.Pupil.Pincl);
+        Assert.Single(parsed.Answers);
+        Assert.Equal("2025-02-15", parsed.Answers[0].RawValue);
+        Assert.Equal("15/02/2025", parsed.Answers[0].Value);
+    }
+
     [Fact]
     public void Parse_ValidMessage_ReturnsDocument()
     {

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RequestDocumentParserTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RequestDocumentParserTests.cs
@@ -23,7 +23,7 @@ public sealed class RequestDocumentParserTests
             SubmittedBy = new UserDetails { UserId = "u1", DisplayName = "Alice" },
             CheckingWindowId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
             CheckingWindowType = "KS4June",
-            WhatToChange = "Remove - pupil-died",
+            RequestTypeCode = "Remove - pupil-died",
             School = new SchoolDetails { Urn = "123456", Name = "Test School" },
             Pupil = new PupilDetails
             {
@@ -43,7 +43,7 @@ public sealed class RequestDocumentParserTests
         var parsed = RequestDocumentParser.Parse(JsonSerializer.Serialize(doc));
 
         Assert.NotNull(parsed);
-        Assert.Equal("Remove - pupil-died", parsed!.WhatToChange);
+        Assert.Equal("Remove - pupil-died", parsed!.RequestTypeCode);
         Assert.Equal("REF-RT", parsed.ReferenceNumber);
         Assert.Equal(402, parsed.Pupil.Pincl);
         Assert.Single(parsed.Answers);
@@ -58,7 +58,7 @@ public sealed class RequestDocumentParserTests
             {
               "CheckingWindowId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
               "CheckingWindowType": "KS4",
-              "WhatToChange": "Deceased",
+              "RequestTypeCode": "Deceased",
               "ReferenceNumber": "REF-001",
               "SubmittedAt": "2026-05-14T10:00:00Z",
               "School": { "Urn": "123456", "Name": "Test School" },
@@ -73,7 +73,7 @@ public sealed class RequestDocumentParserTests
         var parsed = RequestDocumentParser.Parse(json);
 
         Assert.NotNull(parsed);
-        Assert.Equal("Deceased", parsed!.WhatToChange);
+        Assert.Equal("Deceased", parsed!.RequestTypeCode);
         Assert.Equal("KS4", parsed.CheckingWindowType);
         Assert.Equal("REF-001", parsed.ReferenceNumber);
         Assert.Single(parsed.Answers);
@@ -87,7 +87,7 @@ public sealed class RequestDocumentParserTests
         const string json = """
             {
               "checkingwindowtype": "KS2",
-              "whattochange": "Elective home education",
+              "requesttypecode": "Elective home education",
               "referencenumber": "REF-2",
               "school": { "urn": "9", "name": "S" },
               "submittedby": { "userid": "u", "displayname": "x" },
@@ -99,7 +99,7 @@ public sealed class RequestDocumentParserTests
         var parsed = RequestDocumentParser.Parse(json);
 
         Assert.NotNull(parsed);
-        Assert.Equal("Elective home education", parsed!.WhatToChange);
+        Assert.Equal("Elective home education", parsed!.RequestTypeCode);
     }
 
     [Fact]
@@ -113,7 +113,7 @@ public sealed class RequestDocumentParserTests
     {
         // Pupil is required; omitting it must not yield a half-built document.
         const string json = """
-            { "CheckingWindowType": "KS4", "WhatToChange": "Deceased", "ReferenceNumber": "R", "Answers": [] }
+            { "CheckingWindowType": "KS4", "RequestTypeCode": "Deceased", "ReferenceNumber": "R", "Answers": [] }
             """;
 
         Assert.Null(RequestDocumentParser.Parse(json));

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RuleContextMapperTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RuleContextMapperTests.cs
@@ -10,15 +10,18 @@ public sealed class RuleContextMapperTests
     // --- OutcomeKey ---
 
     [Theory]
-    [InlineData("Deceased",                                                   "Deceased")]
-    [InlineData("Elective home education",                                    "ElectiveHomeEducation")]
-    [InlineData("  Elective home education  ",                                "ElectiveHomeEducation")]
-    [InlineData("elective home education",                                    "ElectiveHomeEducation")] // case-insensitive
-    [InlineData("Permanently left England",                                   "PermanentlyLeftEngland")]
-    [InlineData("Social care involvement - including police/prison",          "SocialCareInvolvement")]
-    [InlineData("Social care involvement including police/prison",            "SocialCareInvolvement")] // dash-less variant
-    [InlineData("Pupil missing in Education",                                 "PupilMissingInEducation")]
-    [InlineData("Not at end of 16 to 18 study",                               "NotAtEndOf16To18Study")]
+    [InlineData("Merge",                                    "MergePupils")]
+    [InlineData("Include",                                  "Inclusion")]
+    [InlineData("Remove - pupil-died",                      "Deceased")]
+    [InlineData("Remove - elective-home-education",         "ElectiveHomeEducation")]
+    [InlineData("  Remove - elective-home-education  ",     "ElectiveHomeEducation")] // whitespace-tolerant
+    [InlineData("remove - ELECTIVE-HOME-EDUCATION",         "ElectiveHomeEducation")] // case-insensitive
+    [InlineData("Remove - permanently-left-england",        "PermanentlyLeftEngland")]
+    [InlineData("Remove - social-care-involvement",         "SocialCareInvolvement")]
+    [InlineData("Remove - child-missing-education",         "PupilMissingInEducation")]
+    [InlineData("Remove - life-limiting-illness",           "TerminalCriticalIllness")]
+    [InlineData("Remove - permanent-exclusion",             "AdmittedFollowingPermanentExclusion")]
+    [InlineData("Remove - permanently-excluded",            "PermanentlyExcludedFromCurrentSchool")]
     public void Maps_KnownWhatToChange_ToOutcomeKey(string whatToChange, string expected)
     {
         var msg = NewMessage(whatToChange);
@@ -59,7 +62,7 @@ public sealed class RuleContextMapperTests
     [InlineData("",          "")]      // unrecognised → empty
     public void Maps_CheckingWindowType_ToCanonicalKeyStage(string raw, string expected)
     {
-        var msg = NewMessage("Deceased", checkingWindowType: raw);
+        var msg = NewMessage("Remove - pupil-died", checkingWindowType: raw);
 
         var ctx = _sut.Map(msg);
 
@@ -71,7 +74,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void Maps_StringAnswer_ToFieldValueStr()
     {
-        var msg = NewMessage("Inclusion", answers: new[]
+        var msg = NewMessage("Include", answers: new[]
         {
             Answer("inclusion-status-flag", "402")
         });
@@ -84,7 +87,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void Maps_BoolAnswer_ToFieldValueBool()
     {
-        var msg = NewMessage("Terminal/Critical illness", answers: new[]
+        var msg = NewMessage("Remove - life-limiting-illness", answers: new[]
         {
             Answer("terminal-illness", "true"),
             Answer("critical-illness-12m", "yes"),
@@ -103,7 +106,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void Maps_DateAnswer_ToFieldValueDate()
     {
-        var msg = NewMessage("Elective home education", answers: new[]
+        var msg = NewMessage("Remove - elective-home-education", answers: new[]
         {
             Answer("date-of-removal-from-roll", "2025-02-15")
         });
@@ -116,7 +119,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void Maps_IsoDateTimeAnswer_TruncatesToDate()
     {
-        var msg = NewMessage("Elective home education", answers: new[]
+        var msg = NewMessage("Remove - elective-home-education", answers: new[]
         {
             Answer("date-of-removal-from-roll", "2025-02-15T13:45:00Z")
         });
@@ -129,7 +132,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void Throws_OnMalformedDate()
     {
-        var msg = NewMessage("Elective home education", answers: new[]
+        var msg = NewMessage("Remove - elective-home-education", answers: new[]
         {
             Answer("date-of-removal-from-roll", "not-a-date")
         });
@@ -141,7 +144,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void Throws_OnMalformedBool()
     {
-        var msg = NewMessage("Terminal/Critical illness", answers: new[]
+        var msg = NewMessage("Remove - life-limiting-illness", answers: new[]
         {
             Answer("terminal-illness", "maybe")
         });
@@ -153,7 +156,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void EmptyAnswerValue_BecomesUnknown()
     {
-        var msg = NewMessage("Terminal/Critical illness", answers: new[]
+        var msg = NewMessage("Remove - life-limiting-illness", answers: new[]
         {
             Answer("terminal-illness", "")
         });
@@ -166,7 +169,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void MissingAnswer_BecomesUnknown()
     {
-        var msg = NewMessage("Terminal/Critical illness", answers: Array.Empty<AnswerRecord>());
+        var msg = NewMessage("Remove - life-limiting-illness", answers: Array.Empty<AnswerRecord>());
 
         var ctx = _sut.Map(msg);
 
@@ -176,7 +179,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void UnmappedQuestionId_IsSilentlyIgnored()
     {
-        var msg = NewMessage("Inclusion", answers: new[]
+        var msg = NewMessage("Include", answers: new[]
         {
             Answer("some-extra-question", "value"),
             Answer("inclusion-status-flag", "402"),
@@ -191,7 +194,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void PupilAge_IsRead_FromPupilObject_WhenPositive()
     {
-        var msg = NewMessage("Not at end of 16 to 18 study", pupilAge: 17);
+        var msg = NewMessage("Remove - year-group-change", pupilAge: 17);
 
         var ctx = _sut.Map(msg);
 
@@ -202,7 +205,7 @@ public sealed class RuleContextMapperTests
     public void PupilAge_IsUnknown_WhenZero()
     {
         // 0 is the default for int — treat it as "not supplied" to keep Scrutiny defaults safe.
-        var msg = NewMessage("Not at end of 16 to 18 study", pupilAge: 0);
+        var msg = NewMessage("Remove - year-group-change", pupilAge: 0);
 
         var ctx = _sut.Map(msg);
 
@@ -212,7 +215,7 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void PupilAgeAnswer_OverridesPupilObject_WhenBothPresent()
     {
-        var msg = NewMessage("Not at end of 16 to 18 study", pupilAge: 17, answers: new[]
+        var msg = NewMessage("Remove - year-group-change", pupilAge: 17, answers: new[]
         {
             Answer("pupil-age", "18")
         });
@@ -225,12 +228,12 @@ public sealed class RuleContextMapperTests
     [Fact]
     public void EnvelopeFields_AreAlwaysPopulated()
     {
-        var msg = NewMessage("Deceased", checkingWindowType: "KS4");
+        var msg = NewMessage("Remove - pupil-died", checkingWindowType: "KS4");
 
         var ctx = _sut.Map(msg);
 
-        Assert.Equal(new FieldValue.Str("KS4"),     ctx.GetField("keyStage"));
-        Assert.Equal(new FieldValue.Str("Deceased"), ctx.GetField("requestType"));
+        Assert.Equal(new FieldValue.Str("KS4"),                 ctx.GetField("keyStage"));
+        Assert.Equal(new FieldValue.Str("Remove - pupil-died"), ctx.GetField("requestType"));
     }
 
     [Fact]

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RuleContextMapperTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RuleContextMapperTests.cs
@@ -69,46 +69,47 @@ public sealed class RuleContextMapperTests
         Assert.Equal(expected, ctx.KeyStage);
     }
 
-    // --- Field projection ---
+    // --- Field projection: plain mapped questions ---
 
-    [Fact]
-    public void Maps_StringAnswer_ToFieldValueStr()
-    {
-        var msg = NewMessage("Include", answers: new[]
-        {
-            Answer("inclusion-status-flag", "402")
-        });
-
-        var ctx = _sut.Map(msg);
-
-        Assert.Equal(new FieldValue.Str("402"), ctx.GetField("inclusionFlag"));
-    }
-
-    [Fact]
-    public void Maps_BoolAnswer_ToFieldValueBool()
-    {
-        var msg = NewMessage("Remove - life-limiting-illness", answers: new[]
-        {
-            Answer("terminal-illness", "true"),
-            Answer("critical-illness-12m", "yes"),
-            Answer("severe-profound-effect", "1"),
-            Answer("under-investigation-12m", "no"),
-        });
-
-        var ctx = _sut.Map(msg);
-
-        Assert.Equal(new FieldValue.Bool(true),  ctx.GetField("hasTerminalIllness"));
-        Assert.Equal(new FieldValue.Bool(true),  ctx.GetField("hasCriticalIllness12mPlus"));
-        Assert.Equal(new FieldValue.Bool(true),  ctx.GetField("illnessHasSevereProfoundEffect"));
-        Assert.Equal(new FieldValue.Bool(false), ctx.GetField("underInvestigation12mPlus"));
-    }
-
-    [Fact]
-    public void Maps_DateAnswer_ToFieldValueDate()
+    [Theory]
+    [InlineData("date-removed-from-roll",                 "dateOfRemoval")]
+    [InlineData("date-permanently-excluded",              "dateOfPermanentExclusion")]
+    [InlineData("date-pupil-excluded",                    "dateOfPermanentExclusion")]
+    [InlineData("date-pupil-started",                     "schoolAdmissionDate")]
+    [InlineData("date-pupil-started-school-in-england",   "firstSchoolAdmissionDate")]
+    [InlineData("date-pupil-arrived-in-england",          "dateOfArrivalInEngland")]
+    public void Maps_JourneyDateQuestion_ToCanonicalDateField(string questionId, string field)
     {
         var msg = NewMessage("Remove - elective-home-education", answers: new[]
         {
-            Answer("date-of-removal-from-roll", "2025-02-15")
+            Answer(questionId, "2025-02-15")
+        });
+
+        var ctx = _sut.Map(msg);
+
+        Assert.Equal(new FieldValue.Date(new DateOnly(2025, 2, 15)), ctx.GetField(field));
+    }
+
+    [Fact]
+    public void Maps_CountryAnswer_ToCountryOfOrigin()
+    {
+        // The producer puts the autocomplete's ISO code in RawValue.
+        var msg = NewMessage("Remove - english-not-first-language", answers: new[]
+        {
+            new AnswerRecord { QuestionId = "country-originally-from", QuestionTitle = "t", Type = "Autocomplete", Value = "France", RawValue = "FR" }
+        });
+
+        var ctx = _sut.Map(msg);
+
+        Assert.Equal(new FieldValue.Str("FR"), ctx.GetField("countryOfOrigin"));
+    }
+
+    [Fact]
+    public void RawValue_TakesPrecedenceOverDisplayValue()
+    {
+        var msg = NewMessage("Remove - elective-home-education", answers: new[]
+        {
+            new AnswerRecord { QuestionId = "date-removed-from-roll", QuestionTitle = "t", Type = "Date", Value = "15/02/2025", RawValue = "2025-02-15" }
         });
 
         var ctx = _sut.Map(msg);
@@ -121,7 +122,7 @@ public sealed class RuleContextMapperTests
     {
         var msg = NewMessage("Remove - elective-home-education", answers: new[]
         {
-            Answer("date-of-removal-from-roll", "2025-02-15T13:45:00Z")
+            Answer("date-removed-from-roll", "2025-02-15T13:45:00Z")
         });
 
         var ctx = _sut.Map(msg);
@@ -134,7 +135,7 @@ public sealed class RuleContextMapperTests
     {
         var msg = NewMessage("Remove - elective-home-education", answers: new[]
         {
-            Answer("date-of-removal-from-roll", "not-a-date")
+            Answer("date-removed-from-roll", "not-a-date")
         });
 
         var ex = Assert.Throws<RuleContextMappingException>(() => _sut.Map(msg));
@@ -142,28 +143,204 @@ public sealed class RuleContextMapperTests
     }
 
     [Fact]
-    public void Throws_OnMalformedBool()
+    public void UnmappedQuestionId_IsSilentlyIgnored()
+    {
+        var msg = NewMessage("Remove - elective-home-education", answers: new[]
+        {
+            Answer("some-extra-question", "value"),
+            Answer("date-removed-from-roll", "2025-02-15"),
+        });
+
+        var ctx = _sut.Map(msg);
+
+        Assert.Equal(new FieldValue.Date(new DateOnly(2025, 2, 15)), ctx.GetField("dateOfRemoval"));
+        // No exception; the extra question is just ignored.
+    }
+
+    // --- Field projection: inclusionFlag from the pupil record ---
+
+    [Fact]
+    public void InclusionFlag_IsRead_FromPupilPincl()
+    {
+        var msg = NewMessage("Include", pupilPincl: 402);
+
+        var ctx = _sut.Map(msg);
+
+        Assert.Equal(new FieldValue.Str("402"), ctx.GetField("inclusionFlag"));
+    }
+
+    [Fact]
+    public void InclusionFlag_IsUnknown_WhenPinclNotSupplied()
+    {
+        var msg = NewMessage("Include", pupilPincl: 0);
+
+        var ctx = _sut.Map(msg);
+
+        Assert.IsType<FieldValue.Unknown>(ctx.GetField("inclusionFlag"));
+    }
+
+    // --- Field projection: translated radio vocabularies ---
+
+    [Theory]
+    [InlineData("english",          "ENG", false)]
+    [InlineData("believed-english", "ENG", true)]
+    [InlineData("other",            "OTH", false)]
+    [InlineData("believed-other",   "OTH", true)]
+    public void Maps_FirstLanguage_ToEngOthVocabulary(string raw, string expected, bool uncertain)
+    {
+        var msg = NewMessage("Remove - english-not-first-language", answers: new[]
+        {
+            Answer("first-language", raw)
+        });
+
+        var ctx = _sut.Map(msg);
+
+        FieldValue expectedValue = uncertain
+            ? new FieldValue.Uncertain(new FieldValue.Str(expected))
+            : new FieldValue.Str(expected);
+        Assert.Equal(expectedValue, ctx.GetField("firstLanguage"));
+    }
+
+    [Theory]
+    [InlineData("chose-not-to-say")]
+    [InlineData("not-known")]
+    [InlineData("hand-crafted-nonsense")]
+    public void Maps_FirstLanguage_UnknownishValues_ToUnknown(string raw)
+    {
+        var msg = NewMessage("Remove - english-not-first-language", answers: new[]
+        {
+            Answer("first-language", raw)
+        });
+
+        var ctx = _sut.Map(msg);
+
+        Assert.IsType<FieldValue.Unknown>(ctx.GetField("firstLanguage"));
+    }
+
+    [Theory]
+    [InlineData("lower",  "Lower")]
+    [InlineData("higher", "Higher")]
+    public void Maps_HigherLower_ToYearGroupChange(string raw, string expected)
+    {
+        var msg = NewMessage("Remove - year-group-change", answers: new[]
+        {
+            Answer("higher-lower", raw)
+        });
+
+        var ctx = _sut.Map(msg);
+
+        Assert.Equal(new FieldValue.Str(expected), ctx.GetField("yearGroupChange"));
+    }
+
+    // --- Field projection: single-radio fan-out to booleans ---
+
+    [Fact]
+    public void SocialCareReason_FansOut_ToThreeBooleans()
+    {
+        var msg = NewMessage("Remove - social-care-involvement", answers: new[]
+        {
+            Answer("social-care-reason", "police-involvement")
+        });
+
+        var ctx = _sut.Map(msg);
+
+        Assert.Equal(new FieldValue.Bool(false), ctx.GetField("hadSocialCareInvolvement"));
+        Assert.Equal(new FieldValue.Bool(true),  ctx.GetField("hadRecentPoliceInvolvement"));
+        Assert.Equal(new FieldValue.Bool(false), ctx.GetField("hasBeenDetainedInPrison"));
+    }
+
+    [Fact]
+    public void LifeLimitingIllnessHealthIssue_FansOut_ToIllnessBooleans()
     {
         var msg = NewMessage("Remove - life-limiting-illness", answers: new[]
         {
-            Answer("terminal-illness", "maybe")
+            Answer("life-limiting-illness-health-issue", "life-limiting")
+        });
+
+        var ctx = _sut.Map(msg);
+
+        Assert.Equal(new FieldValue.Bool(true),  ctx.GetField("hasTerminalIllness"));
+        Assert.Equal(new FieldValue.Bool(false), ctx.GetField("hasCriticalIllness12mPlus"));
+        Assert.Equal(new FieldValue.Bool(false), ctx.GetField("hasRecentLifeChangingDiagnosis"));
+        Assert.Equal(new FieldValue.Bool(false), ctx.GetField("hasRecentLifeChangingInjury"));
+        Assert.Equal(new FieldValue.Bool(false), ctx.GetField("underInvestigation12mPlus"));
+        // No journey question collects this — stays Unknown so rules defer to Scrutiny.
+        Assert.IsType<FieldValue.Unknown>(ctx.GetField("illnessHasSevereProfoundEffect"));
+    }
+
+    [Fact]
+    public void FanOutAnswer_WithEmptyValue_LeavesFieldsUnknown()
+    {
+        var msg = NewMessage("Remove - social-care-involvement", answers: new[]
+        {
+            Answer("social-care-reason", "")
+        });
+
+        var ctx = _sut.Map(msg);
+
+        Assert.IsType<FieldValue.Unknown>(ctx.GetField("hadSocialCareInvolvement"));
+        Assert.IsType<FieldValue.Unknown>(ctx.GetField("hadRecentPoliceInvolvement"));
+        Assert.IsType<FieldValue.Unknown>(ctx.GetField("hasBeenDetainedInPrison"));
+    }
+
+    // --- Field projection: sat-exams resolves by key stage ---
+
+    [Theory]
+    [InlineData("KS4", "yes", "hasSatExamsAsYear11", true)]
+    [InlineData("KS4", "no",  "hasSatExamsAsYear11", false)]
+    [InlineData("KS2", "yes", "hasSatExamsAsYear6",  true)]
+    [InlineData("KS2", "no",  "hasSatExamsAsYear6",  false)]
+    public void SatExams_MapsToKeyStageSpecificField(string keyStage, string raw, string field, bool expected)
+    {
+        var msg = NewMessage("Remove - social-care-involvement", checkingWindowType: keyStage, answers: new[]
+        {
+            Answer("sat-exams", raw)
+        });
+
+        var ctx = _sut.Map(msg);
+
+        Assert.Equal(new FieldValue.Bool(expected), ctx.GetField(field));
+    }
+
+    [Fact]
+    public void SatExams_OnUnrecognisedKeyStage_IsIgnored()
+    {
+        var msg = NewMessage("Remove - social-care-involvement", checkingWindowType: "Post16", answers: new[]
+        {
+            Answer("sat-exams", "yes")
+        });
+
+        var ctx = _sut.Map(msg);
+
+        Assert.IsType<FieldValue.Unknown>(ctx.GetField("hasSatExamsAsYear11"));
+        Assert.IsType<FieldValue.Unknown>(ctx.GetField("hasSatExamsAsYear6"));
+    }
+
+    // --- Field projection: error and empty handling ---
+
+    [Fact]
+    public void Throws_OnMalformedBool()
+    {
+        var msg = NewMessage("Remove - social-care-involvement", checkingWindowType: "KS4", answers: new[]
+        {
+            Answer("sat-exams", "maybe")
         });
 
         var ex = Assert.Throws<RuleContextMappingException>(() => _sut.Map(msg));
-        Assert.Contains("hasTerminalIllness", ex.Message);
+        Assert.Contains("hasSatExamsAsYear11", ex.Message);
     }
 
     [Fact]
     public void EmptyAnswerValue_BecomesUnknown()
     {
-        var msg = NewMessage("Remove - life-limiting-illness", answers: new[]
+        var msg = NewMessage("Remove - elective-home-education", answers: new[]
         {
-            Answer("terminal-illness", "")
+            Answer("date-removed-from-roll", "")
         });
 
         var ctx = _sut.Map(msg);
 
-        Assert.IsType<FieldValue.Unknown>(ctx.GetField("hasTerminalIllness"));
+        Assert.IsType<FieldValue.Unknown>(ctx.GetField("dateOfRemoval"));
     }
 
     [Fact]
@@ -174,21 +351,6 @@ public sealed class RuleContextMapperTests
         var ctx = _sut.Map(msg);
 
         Assert.IsType<FieldValue.Unknown>(ctx.GetField("hasTerminalIllness"));
-    }
-
-    [Fact]
-    public void UnmappedQuestionId_IsSilentlyIgnored()
-    {
-        var msg = NewMessage("Include", answers: new[]
-        {
-            Answer("some-extra-question", "value"),
-            Answer("inclusion-status-flag", "402"),
-        });
-
-        var ctx = _sut.Map(msg);
-
-        Assert.Equal(new FieldValue.Str("402"), ctx.GetField("inclusionFlag"));
-        // No exception; the extra question is just ignored.
     }
 
     [Fact]
@@ -248,7 +410,8 @@ public sealed class RuleContextMapperTests
         string whatToChange,
         string checkingWindowType = "KS4",
         IEnumerable<AnswerRecord>? answers = null,
-        int pupilAge = 0) =>
+        int pupilAge = 0,
+        int pupilPincl = 0) =>
         new()
         {
             ReferenceNumber    = "REF",
@@ -262,10 +425,11 @@ public sealed class RuleContextMapperTests
             {
                 Id = "p", CypmdId = "c", Firstname = "A", Surname = "B",
                 DateOfBirth = "01/01/2010", Sex = "F", Age = pupilAge, Upn = "UPN",
+                Pincl = pupilPincl,
             },
             Answers            = (answers ?? Array.Empty<AnswerRecord>()).ToList(),
         };
 
     private static AnswerRecord Answer(string id, string value) =>
-        new() { QuestionId = id, QuestionTitle = id, Type = "text", Value = value };
+        new() { QuestionId = id, QuestionTitle = id, Type = "text", Value = value, RawValue = value };
 }

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RuleContextMapperTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RuleContextMapperTests.cs
@@ -414,6 +414,7 @@ public sealed class RuleContextMapperTests
         int pupilPincl = 0) =>
         new()
         {
+            ChangeRequestId    = Guid.NewGuid(),
             ReferenceNumber    = "REF",
             RequestTypeCode    = whatToChange,
             CheckingWindowType = checkingWindowType,

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RuleContextMapperTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/RuleContextMapperTests.cs
@@ -22,7 +22,7 @@ public sealed class RuleContextMapperTests
     [InlineData("Remove - life-limiting-illness",           "TerminalCriticalIllness")]
     [InlineData("Remove - permanent-exclusion",             "AdmittedFollowingPermanentExclusion")]
     [InlineData("Remove - permanently-excluded",            "PermanentlyExcludedFromCurrentSchool")]
-    public void Maps_KnownWhatToChange_ToOutcomeKey(string whatToChange, string expected)
+    public void Maps_KnownRequestTypeCode_ToOutcomeKey(string whatToChange, string expected)
     {
         var msg = NewMessage(whatToChange);
 
@@ -32,7 +32,7 @@ public sealed class RuleContextMapperTests
     }
 
     [Fact]
-    public void Maps_UnknownWhatToChange_ToUnknownSentinel()
+    public void Maps_UnknownRequestTypeCode_ToUnknownSentinel()
     {
         var msg = NewMessage("nonsense reason");
 
@@ -42,7 +42,7 @@ public sealed class RuleContextMapperTests
     }
 
     [Fact]
-    public void Maps_NullWhatToChange_ToUnknownSentinel()
+    public void Maps_NullRequestTypeCode_ToUnknownSentinel()
     {
         var msg = NewMessage(whatToChange: null!);
 
@@ -415,7 +415,7 @@ public sealed class RuleContextMapperTests
         new()
         {
             ReferenceNumber    = "REF",
-            WhatToChange       = whatToChange,
+            RequestTypeCode    = whatToChange,
             CheckingWindowType = checkingWindowType,
             CheckingWindowId   = Guid.NewGuid(),
             SubmittedAt        = DateTime.UtcNow,

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/SeedRulesValidationTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/SeedRulesValidationTests.cs
@@ -68,19 +68,50 @@ public sealed class SeedRulesValidationTests
         }
     }
 
+    /// <summary>
+    /// Outcomes defined in the docx (and seeded in rules.json) whose journey flows
+    /// have not been authored yet, so no WhatToChange contract string can reach them.
+    /// Remove an entry from this list when its flow config gains a reason option —
+    /// the alignment test (<see cref="QuestionFlowOutcomeKeyAlignmentTests"/>) then
+    /// enforces the map entry from the flow side.
+    /// </summary>
+    private static readonly string[] PendingJourneyOutcomeKeys =
+    [
+        "CompletedKs4Elsewhere",
+        "AssessmentsDeferred",
+        "PupilAddedAfterSummerTerm",
+        "PupilNotOnJuneList",
+        "NotAtEndOf16To18Study",
+        "Other",
+    ];
+
     [Fact]
     public void SeedRulesJson_EveryOutcomeMapsToARecognisedWhatToChange()
     {
         // Sanity check: every outcome in the seed has a reverse-route in the
-        // AnswerFieldMap (so an incoming WhatToChange could actually resolve to it).
+        // AnswerFieldMap (so an incoming WhatToChange could actually resolve to it),
+        // except outcomes explicitly parked until their journey flow exists.
         var json = File.ReadAllText(Path.Combine(SeedDir, "rules.json"));
         var parsed = JsonSerializer.Deserialize<RuleSet>(json, RulesJson.Options)!;
 
         var routableKeys = AnswerFieldMap.WhatToChangeToOutcomeKey.Values.ToHashSet();
 
-        foreach (var outcome in parsed.Outcomes)
+        foreach (var outcome in parsed.Outcomes.Where(o => !PendingJourneyOutcomeKeys.Contains(o.Key)))
         {
             Assert.Contains(outcome.Key, routableKeys);
+        }
+    }
+
+    [Fact]
+    public void PendingJourneyOutcomeKeys_AreNotAlsoRoutable()
+    {
+        // If a flow starts routing to one of these, it must be removed from the
+        // pending list so the previous test guards it again.
+        var routableKeys = AnswerFieldMap.WhatToChangeToOutcomeKey.Values.ToHashSet();
+
+        foreach (var pending in PendingJourneyOutcomeKeys)
+        {
+            Assert.DoesNotContain(pending, routableKeys);
         }
     }
 

--- a/tests/DfE.CheckPerformanceData.UnitTests/Worker/RulesEngineWorkerCompositionTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Worker/RulesEngineWorkerCompositionTests.cs
@@ -4,6 +4,7 @@ using DfE.CheckPerformanceData.Application.RequestDecision;
 using DfE.CheckPerformanceData.Application.RequestSubmission;
 using DfE.CheckPerformanceData.Application.RulesEngine;
 using DfE.CheckPerformanceData.Infrastructure;
+using DfE.CheckPerformanceData.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -29,6 +30,7 @@ public sealed class RulesEngineWorkerCompositionTests
         var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
             ["ConnectionStrings:AzureStorage"] = "UseDevelopmentStorage=true",
+            ["ConnectionStrings:Postgres"] = "Host=localhost;Database=cypd;Username=postgres;Password=postgres",
             ["ZendeskSettings:Subdomain"] = "test",
             ["ZendeskSettings:Domain"] = "zendesk",
             ["ZendeskSettings:Email"] = "t@example.com",
@@ -47,6 +49,9 @@ public sealed class RulesEngineWorkerCompositionTests
         services.AddSingleton(_ => new QueueServiceClient(config.GetConnectionString("AzureStorage")));
         services.AddZendeskApiClient(config);
         services.AddInfrastructureDependencies(config);
+        services.AddSingleton<DfE.CheckPerformanceData.Application.CurrentUser.ICurrentUserService,
+            DfE.CheckPerformanceData.RulesEngineWorker.WorkerCurrentUserService>();
+        services.AddPersistenceDependencies(config);
         services.AddRulesEngineDependencies();
         services.AddRulesProvider(config);
         services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService, WorkerService>();
@@ -56,34 +61,21 @@ public sealed class RulesEngineWorkerCompositionTests
             ValidateOnBuild = true,
             ValidateScopes = true
         });
+
+        // ProcessMessageBodyAsync resolves these per message; ValidateOnBuild
+        // does not cover runtime GetRequiredService, so resolve them explicitly.
+        using var scope = provider.CreateScope();
+        scope.ServiceProvider.GetRequiredService<IRequestDecisionHandler>();
+        scope.ServiceProvider.GetRequiredService<IDecisionOutcomeRepository>();
     }
 
     [Fact]
     public async Task ProcessMessageBody_ResolvesHandlerFromScope_AndInvokesIt()
     {
         var handler = Substitute.For<IRequestDecisionHandler>();
-        var rulesProvider = Substitute.For<IRulesProvider>();
-        rulesProvider.Current.Returns(new RulesSnapshot(
-            new RuleSet("v1", DateTimeOffset.UtcNow, []), Lookups.Empty, "v1", DateTimeOffset.UtcNow, RulesHealth.Healthy));
-        var engine = Substitute.For<IRulesEngine>();
-        engine.Evaluate(Arg.Any<RuleSet>(), Arg.Any<RuleContext>(), Arg.Any<Lookups>())
-            .Returns(new Decision(DecisionStatus.Scrutiny, "k", "r", []));
+        var outcomes = Substitute.For<IDecisionOutcomeRepository>();
 
-        var scopedServices = new ServiceCollection();
-        scopedServices.AddScoped<IRequestDecisionHandler>(_ => handler);
-        using var provider = scopedServices.BuildServiceProvider();
-
-        var queueServiceClient = Substitute.For<QueueServiceClient>();
-        queueServiceClient.GetQueueClient(Arg.Any<string>()).Returns(Substitute.For<QueueClient>());
-
-        var worker = new WorkerService(
-            Substitute.For<ILogger<WorkerService>>(),
-            queueServiceClient,
-            Options.Create(new RulesEngineOptions { QueueName = "q", MaxDequeueCount = 1 }),
-            provider.GetRequiredService<IServiceScopeFactory>(),
-            rulesProvider,
-            engine,
-            new RuleContextMapper());
+        var worker = CreateWorker(handler, outcomes, new Decision(DecisionStatus.Scrutiny, "k", "r", []));
 
         await worker.ProcessMessageBodyAsync(MinimalMessageJson, CancellationToken.None);
 
@@ -91,8 +83,76 @@ public sealed class RulesEngineWorkerCompositionTests
             Arg.Any<RequestDocument>(), Arg.Any<Decision>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task ProcessMessageBody_RecordsOutcomeOnChangeRequest_BeforeInvokingHandler()
+    {
+        var decision = new Decision(DecisionStatus.AutoApproved, "PupilDied", "rule-1", []);
+        var callOrder = new List<string>();
+        var handler = Substitute.For<IRequestDecisionHandler>();
+        handler.HandleAsync(Arg.Any<RequestDocument>(), Arg.Any<Decision>(), Arg.Any<CancellationToken>())
+            .Returns(_ => { callOrder.Add("handler"); return Task.CompletedTask; });
+        var outcomes = Substitute.For<IDecisionOutcomeRepository>();
+        outcomes.RecordOutcomeAsync(Arg.Any<Guid>(), Arg.Any<Decision>(), Arg.Any<CancellationToken>())
+            .Returns(_ => { callOrder.Add("outcome"); return true; });
+
+        var worker = CreateWorker(handler, outcomes, decision);
+
+        await worker.ProcessMessageBodyAsync(MinimalMessageJson, CancellationToken.None);
+
+        // The decision must be on the row even if Zendesk is down, so the DB
+        // write comes first; ChangeRequestId comes from the parsed document.
+        Assert.Equal(["outcome", "handler"], callOrder);
+        await outcomes.Received(1).RecordOutcomeAsync(
+            Guid.Parse("11111111-2222-3333-4444-555555555555"), decision, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProcessMessageBody_WhenNoChangeRequestRowMatches_StillInvokesHandler()
+    {
+        var handler = Substitute.For<IRequestDecisionHandler>();
+        var outcomes = Substitute.For<IDecisionOutcomeRepository>();
+        outcomes.RecordOutcomeAsync(Arg.Any<Guid>(), Arg.Any<Decision>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var worker = CreateWorker(handler, outcomes, new Decision(DecisionStatus.Scrutiny, "k", "r", []));
+
+        await worker.ProcessMessageBodyAsync(MinimalMessageJson, CancellationToken.None);
+
+        await handler.Received(1).HandleAsync(
+            Arg.Any<RequestDocument>(), Arg.Any<Decision>(), Arg.Any<CancellationToken>());
+    }
+
+    private static WorkerService CreateWorker(
+        IRequestDecisionHandler handler, IDecisionOutcomeRepository outcomes, Decision decision)
+    {
+        var rulesProvider = Substitute.For<IRulesProvider>();
+        rulesProvider.Current.Returns(new RulesSnapshot(
+            new RuleSet("v1", DateTimeOffset.UtcNow, []), Lookups.Empty, "v1", DateTimeOffset.UtcNow, RulesHealth.Healthy));
+        var engine = Substitute.For<IRulesEngine>();
+        engine.Evaluate(Arg.Any<RuleSet>(), Arg.Any<RuleContext>(), Arg.Any<Lookups>())
+            .Returns(decision);
+
+        var scopedServices = new ServiceCollection();
+        scopedServices.AddScoped<IRequestDecisionHandler>(_ => handler);
+        scopedServices.AddScoped<IDecisionOutcomeRepository>(_ => outcomes);
+        var provider = scopedServices.BuildServiceProvider();
+
+        var queueServiceClient = Substitute.For<QueueServiceClient>();
+        queueServiceClient.GetQueueClient(Arg.Any<string>()).Returns(Substitute.For<QueueClient>());
+
+        return new WorkerService(
+            Substitute.For<ILogger<WorkerService>>(),
+            queueServiceClient,
+            Options.Create(new RulesEngineOptions { QueueName = "q", MaxDequeueCount = 1 }),
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            rulesProvider,
+            engine,
+            new RuleContextMapper());
+    }
+
     private const string MinimalMessageJson = """
         {
+          "ChangeRequestId": "11111111-2222-3333-4444-555555555555",
           "CheckingWindowId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
           "CheckingWindowType": "KS4",
           "RequestTypeCode": "Remove - pupil-died",

--- a/tests/DfE.CheckPerformanceData.UnitTests/Worker/RulesEngineWorkerCompositionTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Worker/RulesEngineWorkerCompositionTests.cs
@@ -1,0 +1,107 @@
+using Azure.Storage.Queues;
+using DfE.CheckPerformanceData.Application;
+using DfE.CheckPerformanceData.Application.RequestDecision;
+using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Application.RulesEngine;
+using DfE.CheckPerformanceData.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using WorkerService = DfE.CheckPerformanceData.RulesEngineWorker.RulesEngineWorker;
+using RulesEngineOptions = DfE.CheckPerformanceData.RulesEngineWorker.RulesEngineOptions;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Worker;
+
+public sealed class RulesEngineWorkerCompositionTests
+{
+    /// <summary>
+    /// Mirrors the worker's Program.cs registrations and builds the provider with
+    /// the same validation the Development host applies. This is the regression
+    /// test for the startup AggregateException: the worker must not drag in
+    /// Application services whose repositories/clients only the Web host registers,
+    /// and its hosted service must not capture scoped services.
+    /// </summary>
+    [Fact]
+    public void WorkerServiceGraph_BuildsWithFullValidation()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:AzureStorage"] = "UseDevelopmentStorage=true",
+            ["ZendeskSettings:Subdomain"] = "test",
+            ["ZendeskSettings:Domain"] = "zendesk",
+            ["ZendeskSettings:Email"] = "t@example.com",
+            ["ZendeskSettings:ApiToken"] = "token",
+            ["SchoolCheckingExercise:TargetViewTitle"] = "View",
+            ["SchoolCheckingExercise:GroupId"] = "1",
+            ["SchoolCheckingExercise:BrandId"] = "1",
+            ["RulesEngineOptions:QueueName"] = "test-queue",
+        }).Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Keep in step with src/DfE.CheckPerformanceData.RulesEngineWorker/Program.cs.
+        services.Configure<RulesEngineOptions>(config.GetSection("RulesEngineOptions"));
+        services.AddSingleton(_ => new QueueServiceClient(config.GetConnectionString("AzureStorage")));
+        services.AddZendeskApiClient(config);
+        services.AddInfrastructureDependencies(config);
+        services.AddRulesEngineDependencies();
+        services.AddRulesProvider(config);
+        services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService, WorkerService>();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateOnBuild = true,
+            ValidateScopes = true
+        });
+    }
+
+    [Fact]
+    public async Task ProcessMessageBody_ResolvesHandlerFromScope_AndInvokesIt()
+    {
+        var handler = Substitute.For<IRequestDecisionHandler>();
+        var rulesProvider = Substitute.For<IRulesProvider>();
+        rulesProvider.Current.Returns(new RulesSnapshot(
+            new RuleSet("v1", DateTimeOffset.UtcNow, []), Lookups.Empty, "v1", DateTimeOffset.UtcNow, RulesHealth.Healthy));
+        var engine = Substitute.For<IRulesEngine>();
+        engine.Evaluate(Arg.Any<RuleSet>(), Arg.Any<RuleContext>(), Arg.Any<Lookups>())
+            .Returns(new Decision(DecisionStatus.Scrutiny, "k", "r", []));
+
+        var scopedServices = new ServiceCollection();
+        scopedServices.AddScoped<IRequestDecisionHandler>(_ => handler);
+        using var provider = scopedServices.BuildServiceProvider();
+
+        var queueServiceClient = Substitute.For<QueueServiceClient>();
+        queueServiceClient.GetQueueClient(Arg.Any<string>()).Returns(Substitute.For<QueueClient>());
+
+        var worker = new WorkerService(
+            Substitute.For<ILogger<WorkerService>>(),
+            queueServiceClient,
+            Options.Create(new RulesEngineOptions { QueueName = "q", MaxDequeueCount = 1 }),
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            rulesProvider,
+            engine,
+            new RuleContextMapper());
+
+        await worker.ProcessMessageBodyAsync(MinimalMessageJson, CancellationToken.None);
+
+        await handler.Received(1).HandleAsync(
+            Arg.Any<RequestDocument>(), Arg.Any<Decision>(), Arg.Any<CancellationToken>());
+    }
+
+    private const string MinimalMessageJson = """
+        {
+          "CheckingWindowId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          "CheckingWindowType": "KS4",
+          "WhatToChange": "Remove - pupil-died",
+          "School": { "Urn": "1", "Name": "S" },
+          "SubmittedBy": { "UserId": "u", "DisplayName": "A" },
+          "Pupil": { "Id": "p", "CypmdId": "c", "Firstname": "B", "Surname": "S", "DateOfBirth": "01/01/2010", "Sex": "M", "Age": 15, "Upn": "U" },
+          "Answers": [],
+          "ReferenceNumber": "REF-1",
+          "SubmittedAt": "2026-06-10T10:00:00Z"
+        }
+        """;
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Worker/RulesEngineWorkerCompositionTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Worker/RulesEngineWorkerCompositionTests.cs
@@ -95,7 +95,7 @@ public sealed class RulesEngineWorkerCompositionTests
         {
           "CheckingWindowId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
           "CheckingWindowType": "KS4",
-          "WhatToChange": "Remove - pupil-died",
+          "RequestTypeCode": "Remove - pupil-died",
           "School": { "Urn": "1", "Name": "S" },
           "SubmittedBy": { "UserId": "u", "DisplayName": "A" },
           "Pupil": { "Id": "p", "CypmdId": "c", "Firstname": "B", "Surname": "S", "DateOfBirth": "01/01/2010", "Sex": "M", "Age": 15, "Upn": "U" },

--- a/tests/DfE.CheckPerformanceData.UnitTests/Worker/RulesEngineWorkerResilienceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Worker/RulesEngineWorkerResilienceTests.cs
@@ -3,6 +3,7 @@ using Azure.Storage.Queues;
 using Azure.Storage.Queues.Models;
 using DfE.CheckPerformanceData.Application.RequestDecision;
 using DfE.CheckPerformanceData.Application.RulesEngine;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -23,15 +24,21 @@ public sealed class RulesEngineWorkerResilienceTests
         VisibilityTimeout = TimeSpan.FromSeconds(30)
     };
 
-    private static WorkerService CreateWorker(QueueServiceClient serviceClient, RulesEngineOptions options) =>
-        new(
+    private static WorkerService CreateWorker(QueueServiceClient serviceClient, RulesEngineOptions options)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped(_ => Substitute.For<IRequestDecisionHandler>());
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        return new WorkerService(
             Substitute.For<ILogger<WorkerService>>(),
             serviceClient,
             Options.Create(options),
-            Substitute.For<IRequestDecisionHandler>(),
+            scopeFactory,
             Substitute.For<IRulesProvider>(),
             Substitute.For<IRulesEngine>(),
             Substitute.For<IRuleContextMapper>());
+    }
 
     [Fact]
     public async Task ExecuteAsync_WhenQueueCreationFailsTransiently_RecoversWithoutTearingDownTheHost()


### PR DESCRIPTION
- Aligned the data that's stored in the Request Document with the Rules engine so they are both talking about the same field names and can select the correct outcome.
- Changed the portal to send to the rules engine queue on submit.
- Various code fixes.
- Updates the changeRequests table when a decision made