### PR TITLE
Set worker image variable for review app teardown

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Delete Review App
         id: delete-review-app
         uses: DFE-Digital/github-actions/delete-review-app@master
+        env:
+          # terraform destroy still requires every root variable; the value is
+          # never used. See the matching note on the deploy steps in
+          # build-and-deploy.yml.
+          TF_VAR_worker_docker_image: ghcr.io/dfe-digital/check-performance-data-worker:unused
         with:
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
Review app teardown fails: terraform destroy requires worker_docker_image (no default) but delete-review-app.yml never sets it - the deploy
  workflows set it via step env (the workaround for the upstream action dropping worker-sha) and the delete workflow was missed. Surfaced by  
  PR #135 closing; the pr-135 review app is currently orphaned. Value is unused during destroy.