### PR TITLE
2837 - additional worker suffix

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -41,3 +41,5 @@ jobs:
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
           gcp-wip: ${{ vars.GCP_WIP }}
           gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
+          service-name: check-performance-data
+          worker-image-suffix: -worker


### PR DESCRIPTION
### Context

Adding a validate infra workflow to detect any changes in SD Infra Terraform 

### Changes proposed in this pull request

Additional configuration of input variable `worker-image-suffix` to manage a second docker image reference.

### Guidance to review

Make a test branch and change `uses: DFE-Digital/github-actions/validate-infra@main` to `uses: DFE-Digital/github-actions/validate-infra@2837-validate-infra-worker-suffix`. 

Add `target-branch: 2837-validate-infra-worker-suffix` to the `with:` section.
 
Run the workflow against your branch.

It must produce a post in the SD Infra Alerts Teams channel with description **Infrastructure Drift Detected in production**.

The drift should not contain a difference due to one of the two docker image strings missing the `-worker suffix`. It's not a problem (it's expected) that the SHA on the end is different.
Expect to see 2 `kubernetes_deployment` resources. 

They should look like:
`"ghcr.io/dfe-digital/check-performance-data:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1" -> "ghcr.io/dfe-digital/check-performance-data:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx2"` 
and
`"ghcr.io/dfe-digital/check-performance-data-worker:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1" -> "ghcr.io/dfe-digital/check-performance-data-worker:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx2"`

not
`"ghcr.io/dfe-digital/check-performance-data:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1" -> "ghcr.io/dfe-digital/check-performance-data:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx2"` 
and
`"ghcr.io/dfe-digital/check-performance-data-worker:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1" -> "ghcr.io/dfe-digital/check-performance-data:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx2"`

### Link to Trello card

https://trello.com/c/EnK8V7zK/2837-validate-infra-check-performance-data

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
