### PR TITLE
Header link: Help -> Guidance

### DIFF
--- a/src/DfE.CheckPerformanceData.Web/Views/Shared/_Layout.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Shared/_Layout.cshtml
@@ -82,7 +82,7 @@
                             var selectedWindowId = Context.Session.GetString("SelectedWindowId");
                         }
                         <li class="govuk-service-navigation__item">
-                            <a class="govuk-service-navigation__link" href="/help">Help</a>
+                            <a class="govuk-service-navigation__link" href="/guidance">Guidance</a>
                         </li>
                         @if (User.Identity is { IsAuthenticated: true } && selectedWindowId is not null)
                         {

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/LayoutRenderTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/LayoutRenderTests.cs
@@ -154,6 +154,22 @@ public sealed class LayoutRenderTests
 	}
 
 	[Fact]
+	public void Layout_ServiceNavigation_LinksToGuidance_NotHelp()
+	{
+		// The old service-nav link pointed at /help with the text "Help"; the CMS-migrated
+		// help content lives under /guidance now, so the header link is updated to match.
+		// Pins BOTH the retired href/text (so a regression can't quietly re-introduce it)
+		// AND the new /guidance href + "Guidance" text.
+		var view = ReadLayout();
+
+		Assert.DoesNotContain("href=\"/help\"", view);
+		Assert.DoesNotContain(">Help</a>", view);
+
+		Assert.Contains("href=\"/guidance\"", view);
+		Assert.Contains(">Guidance</a>", view);
+	}
+
+	[Fact]
 	public void Layout_ServiceNavigation_StillReportsAsGdsServiceNavigation()
 	{
 		// We replaced the <govuk-service-navigation> tag helper with hand-rolled markup


### PR DESCRIPTION
Swaps the service-nav "Help" link (href="/help") for "Guidance"
  (href="/guidance"). 

  LayoutRenderTests pins both the retired href/text (regression guard) and the
  new one — the razor source is asserted directly, no MVC test harness.

  ## Test plan
  - [ ] `dotnet test tests/DfE.CheckPerformanceData.UnitTests` — all 20
        LayoutRenderTests pass.
  - [ ] Visit / on a running review app: header link reads "Guidance" and
        routes to /guidance.help content lives under /guidance now. LayoutRenderTests pins both the retired href/text and the new one.