### PR TITLE
Moved Seeding of countries out of dev seeding.

### DIFF
--- a/src/DfE.CheckPerformanceData.Persistence/Seeding/DevDataSeeder.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Seeding/DevDataSeeder.cs
@@ -9,8 +9,9 @@ public sealed class DevDataSeeder(IPortalDbContext dbContext)
 
     public async Task SeedAsync()
     {
-        await SeedCountries.ExecuteSeed(dbContext);
-
+        // Countries are seeded unconditionally on startup in every environment (see Program.cs),
+        // idempotently via SeedCountries.ExecuteSeed. They are not window-specific, so they are
+        // deliberately not part of the destructive dev/reset seed here.
         await SeedCheckingWindows.ExecuteSeed(dbContext, KeyStage4JuneCheckingWindowId, ClosedKeyStage4JuneCheckingWindowId);
 
         // Pupil data is no longer stored in the database — it is seeded into blob storage

--- a/src/DfE.CheckPerformanceData.Persistence/Seeding/SeedCountries.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Seeding/SeedCountries.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
 using DfE.CheckPerformanceData.Domain.Enums;
 using DfE.CheckPerformanceData.Persistence.Contexts;
 using DfE.CheckPerformanceData.Persistence.Entities;
@@ -8,6 +10,15 @@ namespace DfE.CheckPerformanceData.Persistence.Seeding;
 
 public static class SeedCountries
 {
+    // Settings-table marker holding a hash of the seed inputs from the last successful seed.
+    // Kept out of SettingDefinitions on purpose: it is an internal marker, not an editable
+    // setting, so it never appears in the admin settings editor.
+    private const string SeedHashSettingKey = "Countries:SeedHash";
+
+    // Bump when the parsing logic or Country shape changes in a way that should force a
+    // reseed even though the CSV bytes and hand-written entries are unchanged.
+    private const int SeedFormatVersion = 1;
+
     private static readonly (string Code, string Name, CountryKind Kind)[] HandWrittenEntries =
     [
         ("GB-ENG", "England", CountryKind.HomeNation),
@@ -19,12 +30,30 @@ public static class SeedCountries
         ("GG", "Guernsey", CountryKind.CrownDependency),
     ];
 
+    // Runs unconditionally on startup in every environment (see Program.cs). Idempotent and
+    // content-aware: it reseeds only when the table is empty or the seed inputs (embedded CSV
+    // bytes, hand-written entries, or SeedFormatVersion) have changed since the last seed,
+    // detected via a hash stored in the Settings table. An unchanged database is left alone,
+    // so repeated startups never duplicate rows; a changed CSV triggers a full replace.
     public static async Task ExecuteSeed(IPortalDbContext dbContext)
     {
+        var desiredHash = ComputeSeedHash();
+        var currentHash = await dbContext.Settings
+            .Where(s => s.Key == SeedHashSettingKey)
+            .Select(s => s.Value)
+            .FirstOrDefaultAsync();
+
+        // Up to date and populated — nothing to do. The AnyAsync guard reseeds even when the
+        // hash matches if the table has somehow been emptied (e.g. manual truncation).
+        if (currentHash == desiredHash && await dbContext.Countries.AnyAsync())
+            return;
+
+        // Content changed (or first run) — replace the dataset wholesale. ExecuteDeleteAsync
+        // runs immediately; if the subsequent insert fails, the marker is not updated, so the
+        // next startup re-detects the mismatch and reseeds (self-healing).
         await dbContext.Countries.ExecuteDeleteAsync();
 
         var countries = new List<Country>();
-
         countries.AddRange(ReadCsvEntries());
         countries.AddRange(HandWrittenEntries.Select(e => new Country
         {
@@ -36,18 +65,54 @@ public static class SeedCountries
         }));
 
         await dbContext.Countries.AddRangeAsync(countries);
+
+        var marker = await dbContext.Settings.FirstOrDefaultAsync(s => s.Key == SeedHashSettingKey);
+        if (marker is null)
+        {
+            marker = new Setting { Key = SeedHashSettingKey };
+            await dbContext.Settings.AddAsync(marker);
+        }
+        marker.Value = desiredHash;
+
         await dbContext.SaveChangesAsync();
     }
 
-    private static IEnumerable<Country> ReadCsvEntries()
+    // A stable fingerprint of everything that determines the seeded rows: a format version,
+    // the hand-written entries, and the raw CSV bytes. Any change flips the hash and triggers
+    // a reseed on next startup.
+    private static string ComputeSeedHash()
+    {
+        var prefix = new StringBuilder();
+        prefix.Append('v').Append(SeedFormatVersion).Append('\n');
+        foreach (var e in HandWrittenEntries)
+            prefix.Append(e.Code).Append('|').Append(e.Name).Append('|').Append((int)e.Kind).Append('\n');
+
+        var prefixBytes = Encoding.UTF8.GetBytes(prefix.ToString());
+        var csvBytes = ReadCsvBytes();
+
+        var combined = new byte[prefixBytes.Length + csvBytes.Length];
+        Buffer.BlockCopy(prefixBytes, 0, combined, 0, prefixBytes.Length);
+        Buffer.BlockCopy(csvBytes, 0, combined, prefixBytes.Length, csvBytes.Length);
+
+        return Convert.ToHexString(SHA256.HashData(combined));
+    }
+
+    private static byte[] ReadCsvBytes()
     {
         var assembly = Assembly.GetExecutingAssembly();
         var resourceName = assembly.GetManifestResourceNames()
             .Single(n => n.EndsWith("FCDO_Geographical_Names_Index.csv"));
 
         using var stream = assembly.GetManifestResourceStream(resourceName)!;
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+        return buffer.ToArray();
+    }
+
+    private static IEnumerable<Country> ReadCsvEntries()
+    {
         // File uses Latin-1 encoding (e.g. ü in "Türkiye")
-        using var reader = new StreamReader(stream, System.Text.Encoding.Latin1);
+        using var reader = new StreamReader(new MemoryStream(ReadCsvBytes()), Encoding.Latin1);
 
         reader.ReadLine(); // skip header
 

--- a/src/DfE.CheckPerformanceData.Web/Program.cs
+++ b/src/DfE.CheckPerformanceData.Web/Program.cs
@@ -9,6 +9,8 @@ using DfE.CheckPerformanceData.Web.Authentication;
 using DfE.CheckPerformanceData.Web.Diagnostics;
 using DfE.CheckPerformanceData.Web.Services;
 using DfE.CheckPerformanceData.Persistence;
+using DfE.CheckPerformanceData.Persistence.Contexts;
+using DfE.CheckPerformanceData.Persistence.Seeding;
 using DfE.CheckPerformanceData.Web.Extensions;
 using DfE.CheckPerformanceData.Application.RequestSubmission;
 using DfE.CheckPerformanceData.Application.FileStorage;
@@ -325,6 +327,12 @@ try
 
     using (var scope = app.Services.CreateScope())
     {
+        // Countries back the country autocomplete and must exist in every environment,
+        // including Production. Seeded idempotently and content-aware: a no-op when the table
+        // already matches the embedded seed data, a full reseed when the CSV/entries change.
+        // Safe to run unconditionally on every startup, unlike the dev-only data seeding below.
+        await SeedCountries.ExecuteSeed(scope.ServiceProvider.GetRequiredService<IPortalDbContext>());
+
         await scope.ServiceProvider.GetRequiredService<DefaultPageNodeSeeder>().SeedAsync();
         await scope.ServiceProvider
             .GetRequiredService<DfE.CheckPerformanceData.Application.Admin.DefaultAdminAccessSeeder>()


### PR DESCRIPTION
## Seed Countries in every environment, idempotently and content-aware

### Problem

The `Countries` table (backing the country autocomplete in change-request journeys) was only
seeded inside `DevDataSeeder.SeedAsync()`, which runs solely when `seedData` is true
(Development, or `SeedDevelopmentData=true`). As a result **countries were never seeded in
PROD**, breaking the country autocomplete there. The old `SeedCountries` was also destructive —
it did `ExecuteDeleteAsync()` + full re-insert on every run, regenerating all row `Id`s each time.

### Change

Country seeding now runs **unconditionally on every startup in every environment**, and is
**idempotent**:

- Moved the `SeedCountries.ExecuteSeed` call out of the dev-only seeder and into the
  unconditional post-migration startup block in `Program.cs`, alongside `DefaultPageNodeSeeder` /
  `DefaultAdminAccessSeeder`.
- Removed it from `DevDataSeeder.SeedAsync()` — countries aren't window-specific, so they don't
  belong in the destructive dev/reset seed. (The danger-zone "Reset seed data" flow no longer
  wipes/rebuilds countries, which is correct.)
- Made `SeedCountries` **content-aware**. Because the FCDO CSV is an embedded resource (no
  filesystem timestamp at runtime), it computes a SHA-256 hash of the seed inputs — CSV bytes +
  hand-written entries (home nations / Crown Dependencies) + a `SeedFormatVersion` constant — and
  stores it in the `Settings` table under `Countries:SeedHash`. On each startup:
  - **Hash matches and table populated** → no-op.
  - **Hash differs** (CSV edited, hand-written entries changed, or `SeedFormatVersion` bumped) →
    full replace, and the marker is updated.
  - **Table empty** (even if the hash matches) → reed table.

The marker is only written after a successful insernc`, so a
mid-seed failure leaves the marker stale and the next startup re-detects the mismatch and reseeds.

### How future data changes propagate

- Ship an updated CSV → the next deploy's startup detects the new hash and reseeds automatically
  in every environment.
- Change parsing logic / `Country` shape without touching the CSV → bump `SeedFormatVersion` to
  force the reseed.

### Notes / trade-offs

- A content change triggers a **wholesale delete + UIDs are
  regenerated. Nothing persists a country by `Id` (the autocomplete stores name/code), so this is
  safe today; if anything ever references a countrya reconciling
  upsert-by-`Code`.
- `Countries:SeedHash` is deliberately **not** adde it stays out of
  the admin settings editor.

### Testing

Verified locally against Postgres:

- **First run from an empty table** (simulating PROD): 0 → 202 countries, marker written, `GB`
  correctly excluded, 4 home nations present.
- **Second run**: no-op — count stayed 202 (no duplication), marker unchanged, and existing row
  `Id`s were preserved (confirming no delete/reinse