### PR TITLE
 29528 followup - Show-in-menu / Appear-in-search checkbox render fix

### DIFF
--- a/src/DfE.CheckPerformanceData.Web/Views/ContentBlock/Index.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/ContentBlock/Index.cshtml
@@ -126,14 +126,18 @@ else
                                 <div class="govuk-form-group">
                                     <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
                                         <div class="govuk-checkboxes__item">
-                                            @* Checkbox first, hidden false second — same pattern as the page editor,
-                                               so an unticked box posts a single "false" and the model binder is not
-                                               tempted to leave the flag at its previous value. *@
+                                            @* Hidden AFTER the label, not between. GDS's :checked+label:after
+                                               and :focus+label:before selectors need the label adjacent to the
+                                               checkbox — a hidden input between them breaks tick and focus-ring
+                                               rendering (state still toggles, users just can't see it). Same
+                                               reason as ContentPage/Edit.cshtml. First-value-wins model binding
+                                               still resolves true when checked because the checkbox is emitted
+                                               first in DOM order. *@
                                             <input class="govuk-checkboxes__input" id="cb-appearinsearch-@b.Key" type="checkbox"
                                                    name="AppearInSearch" value="true" aria-describedby="cb-appearinsearch-@b.Key-hint"
                                                    @(b.AppearInSearch ? "checked" : null) />
-                                            <input type="hidden" name="AppearInSearch" value="false" />
                                             <label class="govuk-label govuk-checkboxes__label" for="cb-appearinsearch-@b.Key">Appear in search</label>
+                                            <input type="hidden" name="AppearInSearch" value="false" />
                                             <div id="cb-appearinsearch-@b.Key-hint" class="govuk-hint govuk-checkboxes__hint">
                                                 Uncheck to hide this block from help-search results. The block still
                                                 renders on every page that uses it.

--- a/src/DfE.CheckPerformanceData.Web/Views/ContentPage/Edit.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/ContentPage/Edit.cshtml
@@ -209,17 +209,21 @@
                         <div class="govuk-form-group">
                             <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
                                 <div class="govuk-checkboxes__item">
-                                    @* Checkbox first, hidden second — same pattern ASP.NET Core's
-                                       asp-for tag helper uses for booleans. When ticked, the form
-                                       posts showInMenu=true&showInMenu=false and the model binder
-                                       takes the first parseable value (true). When unticked, only
-                                       the hidden false is posted. Reversing this order silently
-                                       clobbers the flag to false every time you save. *@
+                                    @* Order matters twice over. (1) Model binding: checkbox emits
+                                       first so the browser posts showInMenu=true&showInMenu=false
+                                       when ticked; first-value-wins gives true. Only false is
+                                       posted when unticked. (2) GDS CSS: the tick mark and focus
+                                       ring are drawn by :checked+label:after / :focus+label:before,
+                                       which need the label to be the *adjacent* sibling of the
+                                       checkbox. Any element between them (including a hidden input)
+                                       kills the visual feedback — the state toggles but nothing
+                                       renders, so users think the box is broken. Put the hidden
+                                       AFTER the label to keep both invariants. *@
                                     <input class="govuk-checkboxes__input" id="cpb-showinmenu" type="checkbox"
                                            name="showInMenu" value="true" aria-describedby="cpb-showinmenu-hint"
                                            @(Model.ShowInMenu ? "checked" : null) />
-                                    <input type="hidden" name="showInMenu" value="false" />
                                     <label class="govuk-label govuk-checkboxes__label" for="cpb-showinmenu">Show in menu</label>
+                                    <input type="hidden" name="showInMenu" value="false" />
                                     <div id="cpb-showinmenu-hint" class="govuk-hint govuk-checkboxes__hint">
                                         Uncheck to hide this page from the public side navigation.
                                         Unpublished pages are always hidden from menus.
@@ -229,8 +233,8 @@
                                     <input class="govuk-checkboxes__input" id="cpb-appearinsearch" type="checkbox"
                                            name="appearInSearch" value="true" aria-describedby="cpb-appearinsearch-hint"
                                            @(Model.AppearInSearch ? "checked" : null) />
-                                    <input type="hidden" name="appearInSearch" value="false" />
                                     <label class="govuk-label govuk-checkboxes__label" for="cpb-appearinsearch">Appear in search</label>
+                                    <input type="hidden" name="appearInSearch" value="false" />
                                     <div id="cpb-appearinsearch-hint" class="govuk-hint govuk-checkboxes__hint">
                                         Uncheck to hide this page from help-search results. The page URL
                                         still works and direct links / nav still find it.


### PR DESCRIPTION
Follow-up to #203. The Show-in-menu and Appear-in-search checkboxes on the page editor (and Appear-in-search on the content-block editor) toggled state correctly on click and spacebar, but the tick mark and focus ring never rendered — so the boxes looked completely inert.
  

  ## Cause

  The GDS checkbox visuals are drawn by adjacent-sibling CSS selectors on `govuk-frontend`:

  ```css
  .govuk-checkboxes__input:checked + .govuk-checkboxes__label:after { opacity: 1; }
  .govuk-checkboxes__input:focus   + .govuk-checkboxes__label:before { box-shadow: 0 0 0 3px #fd0; }
  ```
  
  Our markup put the paired `<input type="hidden" value="false">` **between** the checkbox and the label, which breaks the `+` selector. The underlying state was correctly toggling on every interaction; only the visual feedback was missing.

  ## Fix
  
  Moved the hidden input to sit **after** the label. DOM order is now `[checkbox] → [label] → [hidden] → [hint]`, so:

  - GDS `+` selectors match again → tick + focus ring render correctly.
  - First-value-wins model binding still resolves `true` when checked, because the checkbox is still emitted before the hidden input in DOM order (browsers submit form fields in DOM order).
  
  ## Files

  - `Views/ContentPage/Edit.cshtml` — Show in menu + Appear in search
  - `Views/ContentBlock/Index.cshtml` — Appear in search (block)
  
  Updated the inline comments in both to explain the ordering constraint so this doesn't get accidentally undone.

  ## Test plan
  
  - [ ] Hard-refresh the page editor Properties tab. Clicking each checkbox toggles the visible tick.
  - [ ] Tabbing to each checkbox shows the yellow focus ring.
  - [ ] Untick Show-in-menu → save → page disappears from public nav.
  - [ ] Untick Appear-in-search → save → page disappears from `/search`.
  - [ ] Same drill on `/admin/content-blocks/edit/{key}` Appear-in-search.
  - [ ] Existing test suites still green (no controller or model changes).