### PR TITLE
Fix checking window times (293705) and guidance card focus state (292995)

### DIFF
--- a/src/DfE.CheckPerformanceData.Application/WindowManagement/WindowService.cs
+++ b/src/DfE.CheckPerformanceData.Application/WindowManagement/WindowService.cs
@@ -2,6 +2,8 @@ namespace DfE.CheckPerformanceData.Application.WindowManagement;
 
 public class WindowService(IWindowRepository windowRepository, TimeProvider timeProvider): IWindowService
 {
+    private const int WindowClosingHour = 17;
+
     public async Task<PageResult?> GetAllDataAsync(CancellationToken cancellationToken)
     {
         DateTimeOffset now = timeProvider.GetLocalNow();
@@ -16,10 +18,25 @@ public class WindowService(IWindowRepository windowRepository, TimeProvider time
     public async Task<CheckingWindowDto> GetByIdAsync(Guid id, CancellationToken cancellationToken) =>
         await windowRepository.GetByIdAsync(id, cancellationToken);
 
-    public async Task UpdateAsync(CheckingWindowDto window, CancellationToken cancellationToken) =>
+    public async Task UpdateAsync(CheckingWindowDto window, CancellationToken cancellationToken)
+    {
+        ApplyWindowOpeningHours(window);
         await windowRepository.UpdateAsync(window, cancellationToken);
-    
-    public async Task<CheckingWindowDto> CreateAsync(CheckingWindowDto window, CancellationToken cancellationToken) =>
-        await windowRepository.CreateAsync(window, cancellationToken);
+    }
 
+    public async Task<CheckingWindowDto> CreateAsync(CheckingWindowDto window, CancellationToken cancellationToken)
+    {
+        ApplyWindowOpeningHours(window);
+        return await windowRepository.CreateAsync(window, cancellationToken);
+    }
+
+    /// <summary>
+    /// A checking window always opens at midnight on its start date and closes at 17:00 on its end
+    /// date. Admins choose dates only, so any time component carried on the supplied dates is replaced.
+    /// </summary>
+    private static void ApplyWindowOpeningHours(CheckingWindowDto window)
+    {
+        window.StartDate = window.StartDate.Date;
+        window.EndDate = window.EndDate.Date.AddHours(WindowClosingHour);
+    }
 }

--- a/src/DfE.CheckPerformanceData.Web/wwwroot/css/site.css
+++ b/src/DfE.CheckPerformanceData.Web/wwwroot/css/site.css
@@ -1588,7 +1588,58 @@ body.js-enabled .rules-condition__apply {
 }
 
 /* Guidance cards use the canonical dfe-card component (whole-card link, hover/focus
-   states) from dfefrontend — no bespoke card CSS here. */
+   states) from dfefrontend 2.0.0. The rules below correct that component's focus state;
+   everything else about the card is the vendor's. Both defects are the vendor's own and
+   are worth raising upstream at DFE-Digital/dfe-frontend so this block can be deleted. */
+
+/* dfefrontend turns the whole card navy on :focus-within, while a separate vendor rule
+   (.dfe-card-container .dfe-card-link--header:focus) wins on specificity and forces the
+   title black. Black on #003a69 is about 1.6:1 and fails WCAG 2.2 AA. That rule hard-codes
+   the text half of GOV.UK's focus pair without the yellow background half, which only works
+   if the link also carries .govuk-link; the cards authored in the CMS use
+   .dfe-card-link--header on its own, so the black lands straight on the navy.
+   Keep the title white, as it already is on hover (11.6:1). */
+.dfe-card:focus-within .dfe-card-link--header:focus {
+  color: #ffffff;
+}
+
+/* The same blanket white-text rule hits the other card variant the opposite way: a card link
+   that also carries .govuk-link gets GOV.UK's yellow focus highlight, and white on #fd0 is
+   1.35:1. The yellow highlight is designed to pair with black text — restore that (14.6:1). */
+.dfe-card:focus-within .govuk-link:focus {
+  color: #0b0c0c;
+}
+
+/* The navy fill and yellow outline are driven by :focus-within, so a mouse click leaves the
+   card stuck in its focused appearance — and it comes back on browser Back, when focus is
+   restored to the link. Confine that appearance to keyboard focus so pointer users only ever
+   see hover; :not(:hover) keeps the hover state intact while the pointer is still on the card.
+   Browsers without :has() drop this whole block and keep the vendor behaviour. */
+.dfe-card:focus-within:not(:hover):not(:has(:focus-visible)) {
+  background-color: #ffffff;
+  outline: 0;
+}
+/* Dropping the card outline would otherwise leave the focused link with no indicator at all —
+   it has no underline or outline of its own — so anyone whose focus lands here without
+   :focus-visible matching (returning via Alt+Left, programmatic focus, some switch access)
+   would lose track of where they are. Underline it instead: quiet enough not to read as a
+   stuck highlight, but still a cue. */
+.dfe-card:focus-within:not(:hover):not(:has(:focus-visible)) .dfe-card-link--header:focus {
+  text-decoration: underline;
+}
+.dfe-card:focus-within:not(:hover):not(:has(:focus-visible)) .govuk-heading-m,
+.dfe-card:focus-within:not(:hover):not(:has(:focus-visible)) .dfe-card-link--header:focus {
+  color: #347ca9;
+}
+/* The vendor's blanket .dfe-card:focus-within a{color:#fff} still applies to any OTHER link in
+   the card — a body link a CMS author added — which would be white on the white card we just
+   restored. :not(:focus) leaves the focused link to the rules above. */
+.dfe-card:focus-within:not(:hover):not(:has(:focus-visible)) a:not(:focus) {
+  color: #347ca9;
+}
+.dfe-card:focus-within:not(:hover):not(:has(:focus-visible)) p {
+  color: #0b0c0c;
+}
 
 /* GDS "Dos and don'ts": colour-coded top rule + tick/cross icon, no background fill.
    Colour is never the only signal — the "Do"/"Do not" heading text and the icon carry

--- a/tests/DfE.CheckPerformanceData.UnitTests/Admin/WindowAdmin/WindowServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Admin/WindowAdmin/WindowServiceTests.cs
@@ -1,0 +1,128 @@
+using DfE.CheckPerformanceData.Application.WindowManagement;
+using DfE.CheckPerformanceData.Domain.Enums;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Admin.WindowAdmin;
+
+public class WindowServiceTests
+{
+    [Fact]
+    public async Task CreateAsync_forces_start_to_midnight_and_end_to_five_pm()
+    {
+        IWindowRepository repository = Substitute.For<IWindowRepository>();
+        repository.CreateAsync(Arg.Any<CheckingWindowDto>(), Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<CheckingWindowDto>());
+
+        WindowService service = new(repository, TimeProvider.System);
+
+        CheckingWindowDto window = Window(
+            startDate: new DateTime(2027, 1, 1, 9, 30, 15),
+            endDate: new DateTime(2027, 2, 1, 9, 30, 15));
+
+        await service.CreateAsync(window, CancellationToken.None);
+
+        await repository.Received(1).CreateAsync(
+            Arg.Is<CheckingWindowDto>(w =>
+                w.StartDate == new DateTime(2027, 1, 1, 0, 0, 0) &&
+                w.EndDate == new DateTime(2027, 2, 1, 17, 0, 0)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_forces_start_to_midnight_and_end_to_five_pm()
+    {
+        IWindowRepository repository = Substitute.For<IWindowRepository>();
+
+        WindowService service = new(repository, TimeProvider.System);
+
+        CheckingWindowDto window = Window(
+            startDate: new DateTime(2027, 1, 1, 23, 59, 59),
+            endDate: new DateTime(2027, 2, 1, 3, 15, 0));
+
+        await service.UpdateAsync(window, CancellationToken.None);
+
+        await repository.Received(1).UpdateAsync(
+            Arg.Is<CheckingWindowDto>(w =>
+                w.StartDate == new DateTime(2027, 1, 1, 0, 0, 0) &&
+                w.EndDate == new DateTime(2027, 2, 1, 17, 0, 0)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateAsync_brings_a_late_end_time_back_to_five_pm()
+    {
+        IWindowRepository repository = Substitute.For<IWindowRepository>();
+        repository.CreateAsync(Arg.Any<CheckingWindowDto>(), Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<CheckingWindowDto>());
+
+        WindowService service = new(repository, TimeProvider.System);
+
+        CheckingWindowDto window = Window(
+            startDate: new DateTime(2027, 1, 1, 0, 0, 0),
+            endDate: new DateTime(2027, 2, 1, 22, 0, 0));
+
+        await service.CreateAsync(window, CancellationToken.None);
+
+        await repository.Received(1).CreateAsync(
+            Arg.Is<CheckingWindowDto>(w => w.EndDate == new DateTime(2027, 2, 1, 17, 0, 0)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateAsync_keeps_dates_unspecified_for_the_timestamp_without_time_zone_column()
+    {
+        IWindowRepository repository = Substitute.For<IWindowRepository>();
+        CheckingWindowDto? persisted = null;
+        repository.CreateAsync(Arg.Any<CheckingWindowDto>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                persisted = call.Arg<CheckingWindowDto>();
+                return persisted;
+            });
+
+        WindowService service = new(repository, TimeProvider.System);
+
+        CheckingWindowDto window = Window(
+            startDate: new DateTime(2027, 1, 1, 9, 30, 15, DateTimeKind.Unspecified),
+            endDate: new DateTime(2027, 2, 1, 9, 30, 15, DateTimeKind.Unspecified));
+
+        await service.CreateAsync(window, CancellationToken.None);
+
+        Assert.NotNull(persisted);
+        Assert.Equal(DateTimeKind.Unspecified, persisted!.StartDate.Kind);
+        Assert.Equal(DateTimeKind.Unspecified, persisted.EndDate.Kind);
+    }
+
+    [Fact]
+    public async Task CreateAsync_leaves_already_normalised_dates_unchanged()
+    {
+        IWindowRepository repository = Substitute.For<IWindowRepository>();
+        repository.CreateAsync(Arg.Any<CheckingWindowDto>(), Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<CheckingWindowDto>());
+
+        WindowService service = new(repository, TimeProvider.System);
+
+        CheckingWindowDto window = Window(
+            startDate: new DateTime(2027, 1, 1, 0, 0, 0),
+            endDate: new DateTime(2027, 2, 1, 17, 0, 0));
+
+        await service.CreateAsync(window, CancellationToken.None);
+
+        await repository.Received(1).CreateAsync(
+            Arg.Is<CheckingWindowDto>(w =>
+                w.StartDate == new DateTime(2027, 1, 1, 0, 0, 0) &&
+                w.EndDate == new DateTime(2027, 2, 1, 17, 0, 0)),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static CheckingWindowDto Window(DateTime startDate, DateTime endDate) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Title = "Existing window",
+            StartDate = startDate,
+            EndDate = endDate,
+            KeyStage = KeyStages.KS2,
+            CheckingWindowType = CheckingWindowType.KS2
+        };
+}


### PR DESCRIPTION
Two unrelated bug fixes, one per commit, so they can be reviewed or reverted independently.

## 293705 — Checking window start/end times (`8a75fc89`)

Admins choose dates only; there is no time field anywhere in the window admin UI. But the end date was persisted at midnight, so windows displayed "12am" and the `EndDate >= now` filters closed them at the *start* of their stated final day rather than the end of it. Start and end are now always saved as `00:00:00` and `17:00:00`.

Normalised in `WindowService` rather than in the controllers: it is the single choke point that both the create flow and the per-field edit flow pass through, and no other production code writes window dates. The dev seed data already used `.Date.AddHours(17)`, and the user-facing copy has always said the window closes at 5pm, so this brings the admin path in line with what the rest of the service already assumed.

Five new unit tests cover upward adjustment, downward clamping, idempotence on already-correct values, and `DateTimeKind` staying `Unspecified` for the `timestamp without time zone` column.

**Two things reviewers should weigh in on, deliberately not in this PR:**

1. **No data migration.** Windows already in the database keep `EndDate` at 00:00. They then get silently shifted to 17:00 the first time an admin edits an unrelated field, because `TitleController`, `SchemaController`, `IngressFileController`, `WindowTypeController` and `ValidateWindowController` all round-trip the DTO through `UpdateAsync`. A typo fix on a live window's closing day would quietly reopen it for 17 hours. A one-line `date_trunc` migration would settle it, but it moves real deadlines on live windows.
2. **The 17:00 is server-local, not London.** Containers run UTC, so during BST the window actually closes at 18:00 UK time while the page and confirmation email both say 5pm. This pre-dates the change; it was just invisible while the time was 00:00.

## 292995 — Guidance card hover/click focus state (`f4e57cab`)

Clicking a guidance card turned the title black on the navy card, and the highlight stayed put after navigating back until the user clicked elsewhere.

Two `dfefrontend` 2.0.0 rules collide. One paints the whole card navy with a yellow outline on `:focus-within`. The other, `.dfe-card-container .dfe-card-link--header:focus`, is more specific than the card's own white-text rule and forces the title black — about 1.6:1 against the navy, failing WCAG 2.2 AA. That black-text rule only works when the link also carries `.govuk-link`, but the guidance cards are CMS-authored HTML using `.dfe-card-link--header` on its own, so the black lands straight on the navy. Because the trigger is `:focus-within`, a mouse click leaves it applied and the browser restores it on Back.

The fix keeps the title white on focus and confines the navy/outline appearance to keyboard focus, so pointer users only ever see hover. Dropping the card outline would leave the link with no focus indicator at all, so it is underlined instead for anyone whose focus lands there without `:focus-visible` matching. It also restores GDS black-on-yellow for the `.govuk-link` card variant, which had white on yellow at 1.35:1.

### How it was verified

Reproduced in a browser harness loading the real stylesheets in the real order, then computed styles measured in Chrome across every state:

| State | Result |
|---|---|
| Resting | White card, blue link |
| Hover | Navy card, white title |
| Click, pointer away | Back to resting, link underlined |
| Hover while focused | Navy card, white title (hover preserved) |
| Keyboard Tab | Navy card, white title, 3px yellow outline |
| Browser Back | Not highlighted |

Browsers without `:has()` drop the un-stick block and keep the vendor behaviour; the contrast fix still applies. `site.css` already depends on `:has()` elsewhere, so this adds no new baseline.

### Worth knowing

Both defects belong to the vendored component rather than to this service, so they are worth raising at `DFE-Digital/dfe-frontend` — that would let this override block be deleted rather than carried forward. There is also no automated coverage of these focus states, and the fix is pinned to dfefrontend 2.0.0's palette and selector shapes, so a vendor upgrade could invalidate it silently.
