### PR TITLE
feat: add-back removal reasons for KS4 June (PBIs 292525/292926/292927)

### DIFF
--- a/src/DfE.CheckPerformanceData.Application/DependencyManager.cs
+++ b/src/DfE.CheckPerformanceData.Application/DependencyManager.cs
@@ -44,6 +44,8 @@ public static class DependencyManager
         services.AddScoped<ICountryService, CountryService>();
         services.AddScoped<IOptionVisibilityService, OptionVisibilityService>();
         services.AddScoped<IJourneyCondition, SchoolIsIndependentCondition>();
+        services.AddScoped<IJourneyCondition, PupilIsAddBackCondition>();
+        services.AddScoped<IJourneyCondition, PupilIsNotAddBackCondition>();
         services.AddScoped<IFormatValidator, DfeNumberFormatValidator>();
         services.AddScoped<IAmendmentRequestsService, AmendmentRequestsService>();
         services.AddScoped<IBulkSubmissionService, BulkSubmissionService>();

--- a/src/DfE.CheckPerformanceData.Application/Journey/Conditions/PupilIsAddBackCondition.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/Conditions/PupilIsAddBackCondition.cs
@@ -1,0 +1,17 @@
+using DfE.CheckPerformanceData.Application.RulesEngine;
+
+namespace DfE.CheckPerformanceData.Application.Journey.Conditions;
+
+/// <summary>
+/// Shows options gated on the picked pupil having been "added back" into the
+/// school's results by DfE (Pupil Inclusion Status Flag 403 — the same code the
+/// rules engine uses via <see cref="AnswerFieldMap.AddBackPincl"/>). No pupil
+/// picked, or Pincl unsupplied (0), counts as not add-back.
+/// </summary>
+public sealed class PupilIsAddBackCondition : IJourneyCondition
+{
+    public string Name => "PupilIsAddBack";
+
+    public bool Evaluate(JourneyConditionContext ctx) =>
+        ctx.Journey.SelectedPupil?.Pincl == AnswerFieldMap.AddBackPincl;
+}

--- a/src/DfE.CheckPerformanceData.Application/Journey/Conditions/PupilIsNotAddBackCondition.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/Conditions/PupilIsNotAddBackCondition.cs
@@ -1,0 +1,17 @@
+using DfE.CheckPerformanceData.Application.RulesEngine;
+
+namespace DfE.CheckPerformanceData.Application.Journey.Conditions;
+
+/// <summary>
+/// The complement of <see cref="PupilIsAddBackCondition"/>: hides the standard
+/// removal reasons from add-back (Pincl 403) pupils per PBI 292525. Defaults to
+/// true when no pupil is picked or Pincl is unsupplied, so the standard reason
+/// list is the fail-safe view.
+/// </summary>
+public sealed class PupilIsNotAddBackCondition : IJourneyCondition
+{
+    public string Name => "PupilIsNotAddBack";
+
+    public bool Evaluate(JourneyConditionContext ctx) =>
+        ctx.Journey.SelectedPupil?.Pincl != AnswerFieldMap.AddBackPincl;
+}

--- a/src/DfE.CheckPerformanceData.Application/Journey/IOptionVisibilityService.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/IOptionVisibilityService.cs
@@ -8,9 +8,9 @@ public interface IOptionVisibilityService
     /// VisibleWhen are always shown; a VisibleWhen naming an unregistered
     /// condition is hidden (fail closed). Never mutates the question.
     /// <para>
-    /// This is a render-only filter: the controller does not reject posted radio values
-    /// that belong to hidden options. Submissions are reviewed by Zendesk staff, which
-    /// serves as the downstream enforcement point.
+    /// Rendering and POST validation both consume this filter: the controller
+    /// rejects posted radio values that are not in the visible set, so hidden
+    /// options cannot be selected by hand-crafting a request.
     /// </para>
     /// </summary>
     IReadOnlyList<QuestionOption> GetVisibleOptions(Question question, JourneyConditionContext ctx);

--- a/src/DfE.CheckPerformanceData.Application/Journey/OptionVisibilityService.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/OptionVisibilityService.cs
@@ -13,10 +13,12 @@ public sealed class OptionVisibilityService(IEnumerable<IJourneyCondition> condi
 
     private bool IsVisible(QuestionOption option, JourneyConditionContext ctx)
     {
-        if (string.IsNullOrEmpty(option.VisibleWhen))
+        if (option.VisibleWhen is not { Count: > 0 } names)
             return true;
 
-        var condition = conditions.FirstOrDefault(c => c.Name == option.VisibleWhen);
-        return condition is not null && condition.Evaluate(ctx);
+        // Every named condition must be registered and evaluate true (AND);
+        // an unregistered name hides the option (fail closed).
+        return names.All(name =>
+            conditions.FirstOrDefault(c => c.Name == name) is { } condition && condition.Evaluate(ctx));
     }
 }

--- a/src/DfE.CheckPerformanceData.Application/Journey/QuestionOption.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/QuestionOption.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace DfE.CheckPerformanceData.Application.Journey;
 
 public sealed class QuestionOption
@@ -6,5 +8,12 @@ public sealed class QuestionOption
     public required string Label { get; init; }
     public string? SubLabel { get; init; }
     public string? NextPageId { get; init; }
-    public string? VisibleWhen { get; init; }
+
+    /// <summary>
+    /// Names of the <see cref="IJourneyCondition"/>s that must ALL evaluate true
+    /// for this option to be shown/selectable. JSON accepts a bare string (legacy
+    /// single-condition form) or an array; see <see cref="VisibleWhenJsonConverter"/>.
+    /// </summary>
+    [JsonConverter(typeof(VisibleWhenJsonConverter))]
+    public IReadOnlyList<string>? VisibleWhen { get; init; }
 }

--- a/src/DfE.CheckPerformanceData.Application/Journey/VisibleWhenJsonConverter.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/VisibleWhenJsonConverter.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DfE.CheckPerformanceData.Application.Journey;
+
+/// <summary>
+/// Reads <c>visibleWhen</c> as either a bare condition name (the original
+/// single-condition contract, still present in deployed blobs) or an array of
+/// names. Always writes the array form.
+/// </summary>
+public sealed class VisibleWhenJsonConverter : JsonConverter<IReadOnlyList<string>>
+{
+    public override IReadOnlyList<string>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+            return [reader.GetString()!];
+
+        return JsonSerializer.Deserialize<List<string>>(ref reader, options);
+    }
+
+    public override void Write(Utf8JsonWriter writer, IReadOnlyList<string> value, JsonSerializerOptions options)
+        => JsonSerializer.Serialize(writer, (IEnumerable<string>)value, options);
+}

--- a/src/DfE.CheckPerformanceData.Application/RulesEngine/AnswerFieldMap.cs
+++ b/src/DfE.CheckPerformanceData.Application/RulesEngine/AnswerFieldMap.cs
@@ -139,9 +139,9 @@ public static class AnswerFieldMap
     /// the flow configs to this map in CI. Lookup is case-insensitive and tolerant of
     /// trailing/leading whitespace.
     ///
-    /// Outcomes with no journey flow yet (<c>CompletedKs4Elsewhere</c>,
-    /// <c>AssessmentsDeferred</c>, <c>PupilAddedAfterSummerTerm</c>,
-    /// <c>PupilNotOnJuneList</c>, <c>NotAtEndOf16To18Study</c>, <c>Other</c>) have no
+    /// Outcomes with no journey flow yet (<c>AssessmentsDeferred</c>,
+    /// <c>PupilAddedAfterSummerTerm</c>, <c>PupilNotOnJuneList</c>,
+    /// <c>NotAtEndOf16To18Study</c>) have no
     /// entry here; add one when the KS2/Post16 flows are authored
     /// (see <c>SeedRulesValidationTests.PendingJourneyOutcomeKeys</c>).
     /// </summary>
@@ -166,6 +166,11 @@ public static class AnswerFieldMap
             ["Remove - social-care-involvement"]       = "SocialCareInvolvement",
             ["Remove - life-limiting-illness"]         = "TerminalCriticalIllness",
             ["Remove - year-group-change"]             = "YearGroupChange",
+
+            // Add-back-exclusive reasons (PBIs 292926/292927) — both outcomes are
+            // seeded with a single Scrutiny otherwise-rule ("always sent for scrutiny").
+            ["Remove - completed-ks4-elsewhere"]       = "CompletedKs4Elsewhere",
+            ["Remove - other"]                         = "Other",
         };
 
     /// <summary>

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyConditionContextFactory.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyConditionContextFactory.cs
@@ -1,0 +1,22 @@
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.Journey;
+
+namespace DfE.CheckPerformanceData.Web.Controllers.Journey;
+
+// Single place that assembles the context journey conditions inspect, shared by
+// the GET-side option filtering (view model builder) and the POST-side
+// selection gate (controller) so both always evaluate the same facts.
+internal static class JourneyConditionContextFactory
+{
+    public static JourneyConditionContext Create(RequestState journey, ICurrentUserService currentUser) => new()
+    {
+        Journey = journey,
+        User = new JourneyUserContext
+        {
+            OrganisationUrn = currentUser.OrganisationUrn,
+            OrganisationId = currentUser.OrganisationId,
+            OrganisationName = currentUser.OrganisationName,
+            OrganisationTypeId = currentUser.OrganisationTypeId
+        }
+    };
+}

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyController.cs
@@ -21,7 +21,8 @@ public sealed class JourneyController(
     ICheckYourPupilDataService pupilDataService,
     IJourneyViewModelBuilder viewModelBuilder,
     IAnalyticsService analytics,
-    ICurrentUserService currentUserService) : Controller
+    ICurrentUserService currentUserService,
+    IOptionVisibilityService optionVisibilityService) : Controller
 {
     internal static string FieldName(string questionId) => $"q_{questionId.Replace("-", "_")}";
 
@@ -242,6 +243,7 @@ public sealed class JourneyController(
         var newAnswers = new Dictionary<string, QuestionAnswer>();
         var pupilName = JourneyViewModelBuilder.GetPupilName(journey);
         var isValid = true;
+        var conditionContext = JourneyConditionContextFactory.Create(journey, currentUserService);
 
         // Commit a file the user selected in Browse but didn't click "Upload file" for — clicking
         // Continue with a file staged should attach it rather than report "upload a file".
@@ -275,10 +277,26 @@ public sealed class JourneyController(
             else
             {
                 var answer = ReadFormAnswer(question);
-                // visibleWhen is a render-only gate: radio values are not validated against
-                // the visible-options set here. A user who hand-crafts a hidden option value
-                // will be routed into that branch and their request will reach Zendesk staff,
-                // who review all submissions before acting on them.
+
+                // visibleWhen gates selection as well as rendering: a posted radio value
+                // that is not among this user's visible options (hidden by a condition,
+                // or not a defined option at all) is rejected with the question's own
+                // validation message, exactly as if nothing was selected. This backs the
+                // add-back policy restriction (PBI 292525) server-side.
+                if (question.Type == QuestionType.Radio && question.Options is { Count: > 0 }
+                    && journeyService.IsAnswered(question, answer)
+                    && optionVisibilityService.GetVisibleOptions(question, conditionContext)
+                        .All(o => o.Value != answer.TextValue))
+                {
+                    var hiddenFailure = question.ValidationFailure is not null
+                        ? JourneyTemplate.Resolve(question.ValidationFailure, pupilName)
+                        : "Select an option";
+                    ModelState.AddModelError(question.Id, hiddenFailure);
+                    isValid = false;
+                    newAnswers[question.Id] = answer;
+                    continue;
+                }
+
                 // Required answers are validated unconditionally; optional answers are
                 // still format-checked (char limit, real date) when they have been filled in.
                 if (!question.Optional || journeyService.IsAnswered(question, answer))

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyViewModelBuilder.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyViewModelBuilder.cs
@@ -190,17 +190,8 @@ public sealed class JourneyViewModelBuilder(
         };
     }
 
-    private JourneyConditionContext BuildConditionContext(RequestState journey) => new()
-    {
-        Journey = journey,
-        User = new JourneyUserContext
-        {
-            OrganisationUrn = currentUserService.OrganisationUrn,
-            OrganisationId = currentUserService.OrganisationId,
-            OrganisationName = currentUserService.OrganisationName,
-            OrganisationTypeId = currentUserService.OrganisationTypeId
-        }
-    };
+    private JourneyConditionContext BuildConditionContext(RequestState journey) =>
+        JourneyConditionContextFactory.Create(journey, currentUserService);
 
     internal static string GetPupilName(RequestState journey) =>
         journey.SelectedPupil is { } p ? $"{p.Firstname} {p.Surname}".Trim() : string.Empty;

--- a/src/DfE.CheckPerformanceData.Web/Data/QuestionFlows/Remove_KS4June.json
+++ b/src/DfE.CheckPerformanceData.Web/Data/QuestionFlows/Remove_KS4June.json
@@ -26,7 +26,8 @@
             {
               "value": "permanent-exclusion",
               "label": "Admitted following permanent exclusion (not registered independent schools)",
-              "nextPageId": "permanent-exclusion"
+              "nextPageId": "permanent-exclusion",
+              "visibleWhen": "PupilIsNotAddBack"
             },
             {
               "value": "english-not-first-language",
@@ -34,9 +35,16 @@
               "nextPageId": "english-not-first-language"
             },
             {
+              "value": "completed-ks4-elsewhere",
+              "label": "Completed KS4 studies this academic year in year 11 at another school or college",
+              "nextPageId": "completed-ks4-elsewhere",
+              "visibleWhen": "PupilIsAddBack"
+            },
+            {
               "value": "child-missing-education",
               "label": "Child missing education",
-              "nextPageId": "child-missing-education"
+              "nextPageId": "child-missing-education",
+              "visibleWhen": "PupilIsNotAddBack"
             },
             {
               "value": "pupil-died",
@@ -46,23 +54,26 @@
             {
               "value": "dual-registered-moved",
               "label": "Dual registered or moved school",
-              "nextPageId": "dual-registered-moved"
+              "nextPageId": "dual-registered-moved",
+              "visibleWhen": "PupilIsNotAddBack"
             },
             {
               "value": "elective-home-education",
               "label": "Elective home education",
-              "nextPageId": "elective-home-education"
+              "nextPageId": "elective-home-education",
+              "visibleWhen": "PupilIsNotAddBack"
             },
             {
               "value": "not-on-roll",
               "label": "Not on roll",
               "nextPageId": "not-on-roll",
-              "visibleWhen": "SchoolIsIndependent"
+              "visibleWhen": ["SchoolIsIndependent", "PupilIsNotAddBack"]
             },
             {
               "value": "permanently-excluded",
               "label": "Permanently excluded from current school",
-              "nextPageId": "permanently-excluded"
+              "nextPageId": "permanently-excluded",
+              "visibleWhen": "PupilIsNotAddBack"
             },
             {
               "value": "permanently-left-england",
@@ -72,17 +83,26 @@
             {
               "value": "social-care-involvement",
               "label": "Social care involvement - including police or prison",
-              "nextPageId": "social-care"
+              "nextPageId": "social-care",
+              "visibleWhen": "PupilIsNotAddBack"
             },
             {
               "value": "life-limiting-illness",
               "label": "Life-limiting or critical illness",
-              "nextPageId": "life-limiting-illness"
+              "nextPageId": "life-limiting-illness",
+              "visibleWhen": "PupilIsNotAddBack"
             },
             {
               "value": "year-group-change",
               "label": "Year group change",
-              "nextPageId": "year-group-change-higher-lower"
+              "nextPageId": "year-group-change-higher-lower",
+              "visibleWhen": "PupilIsNotAddBack"
+            },
+            {
+              "value": "other",
+              "label": "Other",
+              "nextPageId": "evidence",
+              "visibleWhen": "PupilIsAddBack"
             }
           ]
         }
@@ -191,6 +211,24 @@
           "hint" : "For example, 123/4567 or 1234567",
           "validator": "DfeNumber",
           "validationFailure": "Enter the DfE number of the school {pupilName}'s exam results should be transferred to",
+          "questionHelpTitle" : "How can I find a DfE number?",
+          "questionHelpText" : "<p>To find the DfE number, search the school or college name on <a href=\"https://get-information-schools.service.gov.uk/\" target=\"_blank\">Get Information About Schools (opens in new window)</a></p>"
+        }
+      ]
+    },
+    {
+      "id": "completed-ks4-elsewhere",
+      "pageTitle": "School or college DfE number",
+      "nextPageId": "evidence",
+      "questions": [
+        {
+          "id": "completed-ks4-elsewhere-dfe-number",
+          "type": "FreeText",
+          "title": "What is the DfE number of the school or college where {pupilName} completed KS4?",
+          "summaryTitle": "School or college DfE number",
+          "hint" : "For example, 123/4567 or 1234567",
+          "validator": "DfeNumber",
+          "validationFailure": "Enter the DfE number of the school or college where {pupilName} completed KS4",
           "questionHelpTitle" : "How can I find a DfE number?",
           "questionHelpText" : "<p>To find the DfE number, search the school or college name on <a href=\"https://get-information-schools.service.gov.uk/\" target=\"_blank\">Get Information About Schools (opens in new window)</a></p>"
         }

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/_Radio.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/_Radio.cshtml
@@ -24,7 +24,7 @@
             </p>
         }
         <div class="govuk-radios">
-            @* visibleWhen is a render-only gate: options are filtered here but the server does not reject posted values for hidden options. *@
+            @* Options are filtered by visibleWhen; the server also rejects posted values for hidden options. *@
             @foreach (var option in Model.VisibleOptions)
             {
                 var optionId = $"{Model.FieldName}-{option.Value}";

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerTests.cs
@@ -95,7 +95,8 @@ public class JourneyControllerTests
             _flowService, _journeyService, _optionVisibilityService, _currentUserService);
 
         _sut = new JourneyController(_flowService, _journeyService, _fileStorageService,
-            _requestService, _pupilDataService, viewModelBuilder, _analytics, _currentUserService)
+            _requestService, _pupilDataService, viewModelBuilder, _analytics, _currentUserService,
+            _optionVisibilityService)
         {
             ControllerContext = new ControllerContext { HttpContext = _httpContext },
             TempData = new TempDataDictionary(_httpContext, Substitute.For<ITempDataProvider>())
@@ -513,6 +514,50 @@ public class JourneyControllerTests
                     ? "year-group-change-higher-lower"
                     : "pupil-died";
             });
+    }
+
+    // ── PagePost — hidden-option server-side gate ────────────────────────────
+
+    [Fact]
+    public async Task PagePost_RadioValueForHiddenOption_IsRejectedWithTheQuestionsValidationMessage()
+    {
+        SetupReasonBranchPage();
+        // Simulate the option being filtered out for this user/pupil: the
+        // visibility service returns every option EXCEPT year-group-change.
+        _optionVisibilityService.GetVisibleOptions(Arg.Any<Question>(), Arg.Any<JourneyConditionContext>())
+            .Returns(ci => (IReadOnlyList<QuestionOption>)(ci.Arg<Question>().Options?
+                .Where(o => o.Value != "year-group-change").ToList() ?? []));
+        _journeyService.IsAnswered(Arg.Any<Question>(), Arg.Any<QuestionAnswer>()).Returns(true);
+        SetupSession(ValidSession(history: ["select-pupil", "reason"]));
+        _httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+        {
+            ["q_reason"] = "year-group-change"
+        });
+
+        var result = await _sut.PagePost(WindowId, "reason", fromSummary: false);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Equal("Page", view.ViewName);
+        Assert.False(_sut.ModelState.IsValid);
+        // The saved journey must not advance into the hidden branch.
+        Assert.DoesNotContain("year-group-change",
+            _session.GetRequestState(WindowId).QuestionHistory);
+    }
+
+    [Fact]
+    public async Task PagePost_RadioValueForVisibleOption_StillProceeds()
+    {
+        SetupReasonBranchPage();
+        SetupSession(ValidSession(history: ["select-pupil", "reason"]));
+        _httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+        {
+            ["q_reason"] = "pupil-died"
+        });
+
+        var result = await _sut.PagePost(WindowId, "reason", fromSummary: false);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Page", redirect.ActionName);
     }
 
     [Fact]

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/OptionVisibilityServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/OptionVisibilityServiceTests.cs
@@ -36,7 +36,7 @@ public class OptionVisibilityServiceTests
     public void OptionWithConditionTrue_IsShown()
     {
         var sut = new OptionVisibilityService([new FakeCondition("Flag", true)]);
-        var question = RadioWith(new QuestionOption { Value = "a", Label = "A", VisibleWhen = "Flag" });
+        var question = RadioWith(new QuestionOption { Value = "a", Label = "A", VisibleWhen = ["Flag"] });
 
         var result = sut.GetVisibleOptions(question, Ctx);
 
@@ -48,7 +48,7 @@ public class OptionVisibilityServiceTests
     public void OptionWithConditionFalse_IsHidden()
     {
         var sut = new OptionVisibilityService([new FakeCondition("Flag", false)]);
-        var question = RadioWith(new QuestionOption { Value = "a", Label = "A", VisibleWhen = "Flag" });
+        var question = RadioWith(new QuestionOption { Value = "a", Label = "A", VisibleWhen = ["Flag"] });
 
         var result = sut.GetVisibleOptions(question, Ctx);
 
@@ -59,7 +59,7 @@ public class OptionVisibilityServiceTests
     public void OptionWithUnknownCondition_IsHidden()
     {
         var sut = new OptionVisibilityService([new FakeCondition("Other", true)]);
-        var question = RadioWith(new QuestionOption { Value = "a", Label = "A", VisibleWhen = "Missing" });
+        var question = RadioWith(new QuestionOption { Value = "a", Label = "A", VisibleWhen = ["Missing"] });
 
         var result = sut.GetVisibleOptions(question, Ctx);
 
@@ -72,7 +72,7 @@ public class OptionVisibilityServiceTests
         var sut = new OptionVisibilityService([new FakeCondition("Flag", false)]);
         var question = RadioWith(
             new QuestionOption { Value = "first", Label = "First" },
-            new QuestionOption { Value = "hidden", Label = "Hidden", VisibleWhen = "Flag" },
+            new QuestionOption { Value = "hidden", Label = "Hidden", VisibleWhen = ["Flag"] },
             new QuestionOption { Value = "last", Label = "Last" });
 
         var result = sut.GetVisibleOptions(question, Ctx);
@@ -86,7 +86,7 @@ public class OptionVisibilityServiceTests
         var sut = new OptionVisibilityService([new FakeCondition("Flag", false)]);
         var question = RadioWith(
             new QuestionOption { Value = "a", Label = "A" },
-            new QuestionOption { Value = "b", Label = "B", VisibleWhen = "Flag" });
+            new QuestionOption { Value = "b", Label = "B", VisibleWhen = ["Flag"] });
 
         sut.GetVisibleOptions(question, Ctx);
 
@@ -98,6 +98,39 @@ public class OptionVisibilityServiceTests
     {
         var sut = new OptionVisibilityService([]);
         var question = new Question { Id = "q", Type = QuestionType.FreeText, Title = "Q" };
+
+        var result = sut.GetVisibleOptions(question, Ctx);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void MultipleConditions_AllTrue_IsShown()
+    {
+        var sut = new OptionVisibilityService([new FakeCondition("A", true), new FakeCondition("B", true)]);
+        var question = RadioWith(new QuestionOption { Value = "a", Label = "A", VisibleWhen = ["A", "B"] });
+
+        var result = sut.GetVisibleOptions(question, Ctx);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void MultipleConditions_OneFalse_IsHidden()
+    {
+        var sut = new OptionVisibilityService([new FakeCondition("A", true), new FakeCondition("B", false)]);
+        var question = RadioWith(new QuestionOption { Value = "a", Label = "A", VisibleWhen = ["A", "B"] });
+
+        var result = sut.GetVisibleOptions(question, Ctx);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void MultipleConditions_OneUnregistered_IsHidden()
+    {
+        var sut = new OptionVisibilityService([new FakeCondition("A", true)]);
+        var question = RadioWith(new QuestionOption { Value = "a", Label = "A", VisibleWhen = ["A", "Missing"] });
 
         var result = sut.GetVisibleOptions(question, Ctx);
 

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/PupilAddBackConditionTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/PupilAddBackConditionTests.cs
@@ -1,0 +1,51 @@
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.Journey.Conditions;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+public class PupilAddBackConditionTests
+{
+    private static JourneyConditionContext ContextWithPincl(int? pincl) => new()
+    {
+        Journey = new RequestState
+        {
+            SelectedPupil = pincl is { } code
+                ? new PupilDto
+                {
+                    Id = Guid.NewGuid(), Firstname = "Test", Surname = "Pupil",
+                    Sex = "F", DateOfBirth = "01/09/2010", Age = 15,
+                    Cypmd_Id = "C1", Upn = "U1", Pincl = code
+                }
+                : null
+        },
+        User = new JourneyUserContext()
+    };
+
+    [Fact]
+    public void Names_MatchTheJsonContract()
+    {
+        Assert.Equal("PupilIsAddBack", new PupilIsAddBackCondition().Name);
+        Assert.Equal("PupilIsNotAddBack", new PupilIsNotAddBackCondition().Name);
+    }
+
+    [Fact]
+    public void AddBack_TrueOnlyFor403()
+    {
+        var sut = new PupilIsAddBackCondition();
+        Assert.True(sut.Evaluate(ContextWithPincl(403)));
+        Assert.False(sut.Evaluate(ContextWithPincl(401)));
+        Assert.False(sut.Evaluate(ContextWithPincl(0)));
+        Assert.False(sut.Evaluate(ContextWithPincl(null))); // no pupil picked
+    }
+
+    [Fact]
+    public void NotAddBack_IsTheExactComplement()
+    {
+        var sut = new PupilIsNotAddBackCondition();
+        Assert.False(sut.Evaluate(ContextWithPincl(403)));
+        Assert.True(sut.Evaluate(ContextWithPincl(401)));
+        Assert.True(sut.Evaluate(ContextWithPincl(0)));
+        Assert.True(sut.Evaluate(ContextWithPincl(null)));
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/PupilSearchJourneyTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/PupilSearchJourneyTests.cs
@@ -117,7 +117,8 @@ public class PupilSearchJourneyTests
             _flowService, _journeyService, _optionVisibilityService, _currentUserService);
 
         _sut = new JourneyController(_flowService, _journeyService, _fileStorageService,
-            _requestService, _pupilDataService, viewModelBuilder, _analytics, _currentUserService)
+            _requestService, _pupilDataService, viewModelBuilder, _analytics, _currentUserService,
+            _optionVisibilityService)
         {
             ControllerContext = new ControllerContext { HttpContext = _httpContext },
             TempData = new TempDataDictionary(_httpContext, Substitute.For<ITempDataProvider>())

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/VisibleWhenJsonConverterTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/VisibleWhenJsonConverterTests.cs
@@ -1,0 +1,55 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DfE.CheckPerformanceData.Application.Journey;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+public class VisibleWhenJsonConverterTests
+{
+    // Mirrors QuestionFlowBlobClient's deserialization options.
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    [Fact]
+    public void BareString_DeserializesToSingleElementList()
+    {
+        var json = """{ "value": "a", "label": "A", "visibleWhen": "SchoolIsIndependent" }""";
+
+        var option = JsonSerializer.Deserialize<QuestionOption>(json, Options)!;
+
+        Assert.Equal(["SchoolIsIndependent"], option.VisibleWhen);
+    }
+
+    [Fact]
+    public void Array_DeserializesToList()
+    {
+        var json = """{ "value": "a", "label": "A", "visibleWhen": ["SchoolIsIndependent", "PupilIsNotAddBack"] }""";
+
+        var option = JsonSerializer.Deserialize<QuestionOption>(json, Options)!;
+
+        Assert.Equal(["SchoolIsIndependent", "PupilIsNotAddBack"], option.VisibleWhen);
+    }
+
+    [Fact]
+    public void Absent_DeserializesToNull()
+    {
+        var json = """{ "value": "a", "label": "A" }""";
+
+        var option = JsonSerializer.Deserialize<QuestionOption>(json, Options)!;
+
+        Assert.Null(option.VisibleWhen);
+    }
+
+    [Fact]
+    public void Serializes_AsArray()
+    {
+        var option = new QuestionOption { Value = "a", Label = "A", VisibleWhen = ["Flag"] };
+
+        var json = JsonSerializer.Serialize(option, Options);
+
+        Assert.Contains("[\"Flag\"]", json);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/SeedRulesValidationTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/SeedRulesValidationTests.cs
@@ -77,12 +77,10 @@ public sealed class SeedRulesValidationTests
     /// </summary>
     private static readonly string[] PendingJourneyOutcomeKeys =
     [
-        "CompletedKs4Elsewhere",
         "AssessmentsDeferred",
         "PupilAddedAfterSummerTerm",
         "PupilNotOnJuneList",
         "NotAtEndOf16To18Study",
-        "Other",
     ];
 
     [Fact]


### PR DESCRIPTION
## What & why
Pupils DfE has "added back" into results (Pupil Inclusion Status Flag `403`) must
see only the policy-allowed removal reasons on the **KS4 June** journey, and
everyone else must not see the two new add-back-only reasons.

- **292525** — 403 pupil sees exactly: EAL → *Completed KS4 studies… at another
  school or college* → Pupil has died → Permanently left England → *Other*.
- **292927** — new *Completed KS4 studies…* reason → DfE-number page
  (FreeText + `DfeNumber` validator + GIAS help) → evidence → summary.
- **292926** — new *Other* reason → straight to evidence.

## How
- **visibleWhen string → array (AND):** `VisibleWhenJsonConverter` reads legacy
  bare strings *and* arrays, always writes arrays (deployed blobs keep parsing);
  `OptionVisibilityService` ANDs all named conditions, unregistered = hidden.
- **New conditions:** `PupilIsAddBack` / `PupilIsNotAddBack` on
  `SelectedPupil.Pincl == AnswerFieldMap.AddBackPincl` (403).
- **Server-side enforcement:** posted radio values not in the visible set are now
  rejected (backs the "viewing **or selecting**" wording) — supersedes the former
  render-only gate. Shared `JourneyConditionContextFactory` keeps GET/POST in sync.
- **Routing:** `Remove - completed-ks4-elsewhere` → `CompletedKs4Elsewhere`,
  `Remove - other` → `Other` (both outcomes already seeded, Scrutiny-only).

## ⚠️ Behaviour change
A hand-crafted POST of a hidden reason value is now **rejected** where it was
previously accepted. Deliberate, per the tickets.

## Rollout
- **Deploy code before/with the new-format blob.** Old code binds `visibleWhen`
  as a string only — an array value fails deserialization and breaks the flow.
- Flows are cached `NeverRemove`; restart web pods after a manual blob upload in
  non-seeding environments.
- No database, `rules.json`, or Terraform changes.

## Testing
- Full unit suite green (**2886** tests) incl. converter, AND-semantics,
  condition, and POST-gate tests.
- Manual E2E in docker: 401 pupil sees original reasons only; 403 pupil sees the
  5 spec reasons in order; DfE-number validation (empty/invalid/valid); both new
  journeys submit and the rules engine returns **Scrutiny** (`CompletedKs4Elsewhere`
  / `Other`, `WorkerStatus=RulesProcessed`); server-side gate rejects an injected
  hidden value.

## Follow-ups (non-blocking)
- Content editors may want to author guidance blocks for
  `…-remove-completed-ks4-elsewhere` and `…-remove-other` (pages render fine without).
