### PR TITLE
2855 - Updates variables in review-app-reconcile

### DIFF
--- a/.github/workflows/review-app-reconcile.yml
+++ b/.github/workflows/review-app-reconcile.yml
@@ -20,7 +20,6 @@ env:
   GLOBAL_CONFIG_PATH: global_config
   TF_VARS_PATH: terraform/application/config
   TERRAFORM_BASE: terraform/application
-  TF_FILE: terraform.tf
   SERVICE_NAME: check-performance-data
   RESOURCE_GROUP_NAME: s189t01-cypd-rv-rg
   STORAGE_ACCOUNT_NAME: s189t01cypdrvtfsa
@@ -52,7 +51,6 @@ jobs:
           resource-group-name: ${{ env.RESOURCE_GROUP_NAME }}
           storage-account-name: ${{ env.STORAGE_ACCOUNT_NAME }}
           terraform-base: ${{ env.TERRAFORM_BASE }}
-          tf-file: ${{ env.TF_FILE }}
           service-name: ${{ env.SERVICE_NAME }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           github-repo: ${{ github.repository }}
@@ -90,7 +88,7 @@ jobs:
         shell: bash
         run: |
           echo "PR_NUMBER=${{ matrix.pr_number }}" >> $GITHUB_ENV
-          echo "ENVIRONMENT=pr-${{ matrix.pr_number }}" >> $GITHUB_ENV
+          echo "ENVIRONMENT=pr-${PR_NUMBER}" >> $GITHUB_ENV
           source global_config/review.sh
           echo "AZURE_RESOURCE_PREFIX=${AZURE_RESOURCE_PREFIX}" >> $GITHUB_ENV
           echo "CONFIG_SHORT=${CONFIG_SHORT}" >> $GITHUB_ENV
@@ -104,10 +102,10 @@ jobs:
           azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          terraform-base: ${{ env.TERRAFORM_BASE }}
-          tf-file: ${{ env.TF_FILE }}
+          gcp-wip: ${{ vars.GCP_WIP }}
+          gcp-project-id: ${{ vars.GCP_PROJECT_ID }}
           pr-number: ${{ matrix.pr_number }}
           resource-group-name: ${{ env.RESOURCE_GROUP_NAME }}
           storage-account-name: ${{ env.STORAGE_ACCOUNT_NAME }}
           container-name: ${{ env.CONTAINER_NAME }}
-          tf-state-file: review-${{ matrix.pr_number }}_kubernetes.tfstate
+          tf-state-file: "${{ env.ENVIRONMENT }}_kubernetes.tfstate"


### PR DESCRIPTION
## Context

We get quite a few rogue review apps - i.e., the PR has been merged or closed, but the review app wasn’t deleted.

A new workflow was added to remedy the situation in this service, but it generated an error regarding a variable that was defined unnecessarily.

## Changes proposed in this pull request

This updated workflow reorganises the variable structure to resolve the above issue.

The code can be found here: [Review app reconcile](https://github.com/DFE-Digital/check-performance-data/blob/2855-updates-review-app-reconcile/.github/workflows/review-app-reconcile.yml)

## Guidance to review

Branch off of my feature branch and add the following code to the **review-app-reconcile.yml** file of your new branch:

```
schedule:
    - cron: "0 08 * * 0"
push:
    branches:
        - <your-branch-name>
```

Once this is pushed up to remote, the workflow will automatically process a dry run, which should complete successfully. My dry run is here for this service: [Dry run](https://github.com/DFE-Digital/check-performance-data/actions/runs/30540380278)

Aside from waiting until it fails on Sunday, we can test the deletion of review apps by running the workflow manually and removing the dry run flag. I did not do this as it is during the day and the review apps may still be needed.

There will be no issue if it fails to delete the review apps on Sunday because it should just list any existing review apps, as it would in a manually launched dry run. This will just need revisiting if the automated deletion process should fail for any reason.

## Link to Trello card

[Trello card](https://trello.com/c/ZWznDc8Y/2855-add-review-app-cleanup-workflow)

## Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Applied DevOps label
- [x] Tested by running locally