### PR TITLE
Persist the seed rate before the job reports completion - AB#293118

### DIFF
--- a/src/DfE.CheckPerformanceData.Web/Controllers/TestDataController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/TestDataController.cs
@@ -495,12 +495,16 @@ public sealed class TestDataController : Controller
             }
             else
             {
-                _jobStore.MarkCompleted(jobId, auditId);
-
                 // Adaptive EMA of the per-event seconds rate. Only fires on non-cancelled
                 // non-failed completions — a cancelled or failed run doesn't reflect true
                 // throughput. Isolated in its own try/catch so a settings-store hiccup
-                // never derails the job state transition above.
+                // never derails the job state transition below.
+                //
+                // This runs BEFORE MarkCompleted so that "job reports terminal" implies
+                // "the new rate is already readable". With the order reversed, anything
+                // that polls for the terminal state and then reads the rate — the seed
+                // page itself, and the test covering this — could observe the old value,
+                // because the save had not landed yet.
                 try
                 {
                     var settings = scope.ServiceProvider.GetService<ISettingService>();
@@ -523,6 +527,8 @@ public sealed class TestDataController : Controller
                     // Non-fatal. The next seed will just start from the previous stored
                     // value and re-attempt the blend.
                 }
+
+                _jobStore.MarkCompleted(jobId, auditId);
             }
         }
         catch


### PR DESCRIPTION
The adaptive per-event rate was blended and saved AFTER the job store transitioned to Completed, so "job reports terminal" did not imply "the new rate is readable". Anything that polls for the terminal state and then reads the rate could observe the previous value — the seed page does exactly that, and so does the test covering it, which is why it failed on a loaded CI runner while passing locally.

Move the blend above MarkCompleted. It keeps its own try/catch, so a settings-store hiccup still cannot derail the state transition; it just now happens first.

Reproduced by injecting a delay ahead of the save: with the old ordering the covering test fails, with the new ordering the same delay passes.

[AB#293118](https://dfe-gov-uk.visualstudio.com/b947688b-53a4-4c90-9c43-5a5db31e313d/_workitems/edit/293118)