### PR TITLE
Make visual regression opt-in and remove stale test category traits

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -118,8 +118,10 @@ jobs:
       - name: Run E2E tests
         # Skip visual regression: baselines are captured against the local containerised
         # Linux-Chromium web. The deployed AKS review app serves a different surface
-        # (fonts, CSP, seed timing) so identical pixels are not expected. Visual
-        # regression stays a local concern, run via `make test-e2e`.
+        # (fonts, CSP, seed timing) so identical pixels are not expected. The checks are
+        # also gated off by default in code (CPD_E2E_VISUAL_REGRESSION); this filter is
+        # kept so the intent is visible in the pipeline rather than only at the call site.
+        # To run them deliberately: `make test-e2e-visual`.
         run: dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --configuration Release --no-build --filter "Category!=VisualRegression"
 
       # Surface the snapshot tree on failure so the "delete .png + push twice"

--- a/Makefile
+++ b/Makefile
@@ -222,18 +222,16 @@ scale-worker: get-cluster-credentials
 	kubectl -n ${NAMESPACE} scale deployment/${SERVICE_NAME}${DSUFFIX}-worker --replicas ${REPLICAS}
 
 .PHONY: test-e2e
-test-e2e: ## Run full E2E suite inside the Linux Playwright container; auto-bootstraps visual-regression baselines when the Snapshots dir is empty, then re-runs to verify stability
-	@SNAPSHOT_DIR=tests/DfE.CheckPerformanceData.E2ETests/Snapshots; \
-	if [ -z "$$(ls -A $$SNAPSHOT_DIR 2>/dev/null)" ]; then \
-		echo ">>> No visual-regression baselines found — running bootstrap pass to write PNGs..."; \
-		docker compose --profile e2e run --rm e2e-tests; \
-		echo ">>> Bootstrap complete. Re-running to verify baselines are stable..."; \
-	fi; \
+test-e2e: ## Run the E2E suite inside the Linux Playwright container (visual regression stays off)
 	docker compose --profile e2e run --rm e2e-tests
 
+.PHONY: test-e2e-visual
+test-e2e-visual: ## Run the E2E suite WITH visual regression, in the container the baselines were captured in
+	CPD_E2E_VISUAL_REGRESSION=1 docker compose --profile e2e run --rm e2e-tests
+
 .PHONY: test-e2e-fast
-test-e2e-fast: ## Run E2E suite natively on host SDK, skipping visual regression (fast TDD inner loop)
-	dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --filter "Category!=VisualRegression" --configuration Release
+test-e2e-fast: ## Run E2E suite natively on host SDK (fast TDD inner loop)
+	dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --configuration Release
 
 .PHONY: dev-deps
 dev-deps: ## Start local dependency containers (Postgres + Azurite) for VS in-container debugging

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -26,6 +26,10 @@ services:
     working_dir: /work
     environment:
       - CPD_E2E_BASE_URL=${CPD_E2E_BASE_URL:-http://web:8080}
+      # Visual regression is off unless asked for — `make test-e2e-visual` sets this.
+      # The baselines were captured in this image, so this is the only place a
+      # comparison is meaningful.
+      - CPD_E2E_VISUAL_REGRESSION=${CPD_E2E_VISUAL_REGRESSION:-}
       - NUGET_PACKAGES=/root/.nuget/packages
       - DOTNET_NOLOGO=1
       - DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/docs/E2E-Playwright.md
+++ b/docs/E2E-Playwright.md
@@ -144,8 +144,8 @@ dotnet test tests/DfE.CheckPerformanceData.E2ETests/ `
 Useful filter variants:
 
 ```powershell
-# Single category
-dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --filter "Category=W2"
+# A single area, by namespace
+dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --filter "FullyQualifiedName~Admin"
 
 # Single test by name
 dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --filter "FullyQualifiedName~SoftDeleteWikiPageTests"
@@ -241,17 +241,16 @@ The suite drives the *deployed* app over HTTP — `docker compose up` brings up 
 
 The trade-off is speed: cold start (compose up + readiness probe + first Playwright launch) is ~30-40s. We accept that. Tight inner-loop runs use `make test-e2e-fast` natively on the host, skipping visual regression.
 
-## Test categories (`W0`-`W4`)
+## Test categories
 
-Every test is tagged with a `[Trait("Category", "W{N}")]`. The labels come from the original work-package breakdown but the practical use is `dotnet test --filter`:
+Tests are grouped by folder — `Wiki/`, `Web/`, `Admin/`, `Visual/` — and scoped
+with `--filter "FullyQualifiedName~..."`. Only two category traits remain, both
+for behaviour rather than grouping:
 
 | Trait | Scope |
 |-------|-------|
-| `W0` | Harness smoke (deployment ready, antiforgery scrape) |
-| `W1` | Read-path browse |
-| `W2` | Soft-delete, warning text, search sidebar |
-| `W4` | REST CRUD + visual regression |
-| `VisualRegression` | Cross-cutting trait on snapshot tests, Linux-only |
+| `VisualRegression` | Snapshot tests. Linux-only, and off unless `CPD_E2E_VISUAL_REGRESSION` is set. |
+| `Slow` | Tests that wait on real timeouts or polling. |
 
 `Category!=VisualRegression` is the most-used filter — it gives you the full functional sweep on any host without needing the Linux container for pixel-stable rendering.
 

--- a/docs/E2E-Playwright.md
+++ b/docs/E2E-Playwright.md
@@ -150,17 +150,17 @@ dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --filter "FullyQualifiedNam
 # Single test by name
 dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --filter "FullyQualifiedName~SoftDeleteWikiPageTests"
 
-# Including visual regression (only meaningful on Linux or via make test-e2e)
-dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --configuration Release
+# Including visual regression — only meaningful inside the pinned container
+CPD_E2E_VISUAL_REGRESSION=1 dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --configuration Release
 ```
 
-To run the full visual regression sweep from PowerShell — same as `make test-e2e`:
+To run the full visual regression sweep from PowerShell — same as `make test-e2e-visual`:
 
 ```powershell
-docker compose --profile e2e run --rm e2e-tests
+$env:CPD_E2E_VISUAL_REGRESSION=1; docker compose --profile e2e run --rm e2e-tests
 ```
 
-That builds the runner image (first time only), brings up dependencies, executes the full suite *including* visual regression (using the container's own baselines, regenerated on first run), and tears down.
+That builds the runner image (first time only), brings up dependencies, executes the full suite *including* visual regression against the committed baselines, and tears down. Without the variable the same command runs the functional suite and skips the comparisons.
 
 If you alternated between native and container runs and hit `NETSDK1047 'project.assets.json' doesn't have a target for 'net10.0/win-x64'`:
 
@@ -217,7 +217,7 @@ VS speaks `.slnx` natively in 17.12+ (LTSC) / 2026.
 | You want to… | Use |
 |--------------|-----|
 | Tight inner loop, functional tests only | PowerShell or VS/VSC Test Explorer with `Category!=VisualRegression` |
-| Validate visual regression before push / PR | `make test-e2e` (or `docker compose --profile e2e run --rm e2e-tests` from PowerShell) |
+| Validate visual regression before push / PR | `make test-e2e-visual` (or `CPD_E2E_VISUAL_REGRESSION=1 docker compose --profile e2e run --rm e2e-tests`) |
 | Step through a single failing test in a debugger | VS Code or VS, "Debug Test" |
 | Reproduce a CI failure exactly | `make test-e2e` — same image, same Linux-Chromium; rebuild the baseline inside the container before comparing |
 

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminAuthTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminAuthTests.cs
@@ -5,7 +5,6 @@ using DfE.CheckPerformanceData.E2ETests.Helpers;
 namespace DfE.CheckPerformanceData.E2ETests.Admin;
 
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class AdminAuthTests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminDashboardTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminDashboardTests.cs
@@ -12,7 +12,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Admin;
 // users must be able to stop it). The button is hidden until the script schedules a
 // reload, then clicking it cancels the reload and announces via the role=status region.
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class AdminDashboardTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
     public override BrowserNewContextOptions ContextOptions() =>

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminLandingGroupedTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminLandingGroupedTests.cs
@@ -13,7 +13,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Admin;
 // 182); disabled rail row tabindex absent). The UI-SPEC is the source of truth
 // for those three values.
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class AdminLandingGroupedTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
     public override BrowserNewContextOptions ContextOptions() =>

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminRulesAuthTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminRulesAuthTests.cs
@@ -5,7 +5,6 @@ using DfE.CheckPerformanceData.E2ETests.Helpers;
 namespace DfE.CheckPerformanceData.E2ETests.Admin;
 
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class AdminRulesAuthTests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminRulesEditAsyncTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminRulesEditAsyncTests.cs
@@ -10,7 +10,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Admin;
 // the transient "Saved" toast while staying on the edit page. Linux-only [SkippableFact],
 // matching the repo's Playwright-interaction convention (see AdminLandingGroupedTests).
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class AdminRulesEditAsyncTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
     private const string EditUrl = "/admin/rules/outcomes/Inclusion/branches/INC-REJ/edit";

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminRulesEditTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminRulesEditTests.cs
@@ -5,7 +5,6 @@ using DfE.CheckPerformanceData.E2ETests.Helpers;
 namespace DfE.CheckPerformanceData.E2ETests.Admin;
 
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class AdminRulesEditTests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminRulesM4Tests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminRulesM4Tests.cs
@@ -5,7 +5,6 @@ using DfE.CheckPerformanceData.E2ETests.Helpers;
 namespace DfE.CheckPerformanceData.E2ETests.Admin;
 
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class AdminRulesM4Tests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminSettingsTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/AdminSettingsTests.cs
@@ -5,7 +5,6 @@ using DfE.CheckPerformanceData.E2ETests.Helpers;
 namespace DfE.CheckPerformanceData.E2ETests.Admin;
 
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class AdminSettingsTests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/ContentStagingTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/ContentStagingTests.cs
@@ -8,7 +8,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Admin;
 // fixture impersonates for the whole collection. HTTP-level checks keep these robust against
 // CMS content state (the export endpoint works even on an empty environment).
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class ContentStagingTests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/MessagesGroupAndDetailTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/MessagesGroupAndDetailTests.cs
@@ -17,7 +17,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Admin;
 // tests/DfE.CheckPerformanceData.E2ETests/Snapshots/search-ux/. Linux-only for browser
 // install parity; visual assertions on other OSes drift on font metrics.
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class MessagesGroupAndDetailTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
     public override BrowserNewContextOptions ContextOptions() =>

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/ObservabilityBoardTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/ObservabilityBoardTests.cs
@@ -10,7 +10,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Admin;
 // stage + recent transitions) so the information is available without motion. The export CTA and
 // the board/export scripts are wired into the page. All assertions are DOM-level, not pixel.
 [Collection("E2E")]
-[Trait("Category", "W0")]
 public sealed class ObservabilityBoardTests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;
@@ -121,7 +120,6 @@ public sealed class ObservabilityBoardTests(PlaywrightFixture fixture)
 // the rendered skeleton, the recent-transitions live region is present and animated tokens are
 // keyboard-focusable. Assertions are DOM/JS-level, not pixel.
 [Collection("E2E")]
-[Trait("Category", "W0")]
 public sealed class ObservabilityBoardBrowserTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
     [Fact]

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/QueueAdminTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/QueueAdminTests.cs
@@ -5,7 +5,6 @@ using DfE.CheckPerformanceData.E2ETests.Helpers;
 namespace DfE.CheckPerformanceData.E2ETests.Admin;
 
 [Collection("E2E")]
-[Trait("Category", "W0")]
 public sealed class QueueAdminTests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/SearchAnalyticsDashboardTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/SearchAnalyticsDashboardTests.cs
@@ -17,7 +17,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Admin;
 // eyeball them before merging. Linux-only for browser install parity; visual assertions
 // on other OSes drift on font metrics.
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class SearchAnalyticsDashboardTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
     public override BrowserNewContextOptions ContextOptions() =>

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/ShareLinkTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/ShareLinkTests.cs
@@ -10,7 +10,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Admin;
 // invalid token returns 404 — never a redirect into the DfE OIDC challenge. The admin generates
 // tokens from the role-gated /admin/share surface. All assertions are DOM-level.
 [Collection("E2E")]
-[Trait("Category", "W0")]
 public sealed class ShareLinkTests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/TestDataAdminTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/TestDataAdminTests.cs
@@ -21,7 +21,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Admin;
 // Snapshots/search-ux/seed-admin/ (or seed-progress/ / danger-zone/ depending on the
 // captured surface — see SaveScreenshotAsync below for the routing).
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class TestDataAdminTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
     public override BrowserNewContextOptions ContextOptions() =>

--- a/tests/DfE.CheckPerformanceData.E2ETests/ContentPages/ResultsWidgetE2ETests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/ContentPages/ResultsWidgetE2ETests.cs
@@ -13,7 +13,6 @@ namespace DfE.CheckPerformanceData.E2ETests.ContentPages;
 //   SiteSearchMergedPagedTests (service math)
 //   WidgetEditorContractTests (editor form fields)
 [Collection("E2E")]
-[Trait("Category", "W1")]
 public sealed class ResultsWidgetE2ETests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
     // Term with enough real-content hits to guarantee multi-page pagination at the

--- a/tests/DfE.CheckPerformanceData.E2ETests/CrossBrowserSmokeTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/CrossBrowserSmokeTests.cs
@@ -20,7 +20,6 @@ using Microsoft.Playwright;
 namespace DfE.CheckPerformanceData.E2ETests;
 
 [Collection("E2E")]
-[Trait("Category", "W0")]
 public sealed class CrossBrowserSmokeTests
 {
     private readonly PlaywrightFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/HarnessSmokeTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/HarnessSmokeTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Playwright.Xunit;
 namespace DfE.CheckPerformanceData.E2ETests;
 
 [Collection("E2E")]
-[Trait("Category", "W0")]
 public sealed class HarnessSmokeTests(PlaywrightFixture fixture) : PageTest
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Pages/RequestSubmissionPage.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Pages/RequestSubmissionPage.cs
@@ -7,7 +7,6 @@ using xRetry;
 namespace DfE.CheckPerformanceData.E2ETests.Pages;
 
 [Collection("E2E")]
-[Trait("Category", "W0")]
 public sealed class RequestSubmissionPage(PlaywrightFixture fixture) : PageTest
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/README.md
+++ b/tests/DfE.CheckPerformanceData.E2ETests/README.md
@@ -8,10 +8,11 @@ There are two ways to run the suite, depending on what you need:
 
 | Flow | Command | What it runs | When to pick |
 |------|---------|--------------|--------------|
-| Container (canonical) | `make test-e2e` | Full suite incl. visual regression, inside the Linux Playwright container against the canonical Linux-Chromium baseline | Before commit/push, when touching anything that affects rendered output, before opening a PR |
-| Host (fast) | `make test-e2e-fast` | E2E suite natively on the host SDK with `--filter Category!=VisualRegression`; visual regression skipped | TDD inner loop on functional tests; quick smoke after a non-visual code change |
+| Container (canonical) | `make test-e2e` | Full functional suite inside the Linux Playwright container. Visual regression stays off. | Before commit/push, before opening a PR |
+| Host (fast) | `make test-e2e-fast` | Same suite natively on the host SDK | TDD inner loop; quick smoke after a code change |
+| Container + visual | `make test-e2e-visual` | Adds the visual-regression comparisons, in the container the baselines were captured in | Only when deliberately checking or refreshing snapshots |
 
-Both targets `cd` into the repo from the repo root and assume Docker (for `make test-e2e`) or the .NET 10 host SDK (for `make test-e2e-fast`) is installed. `make help` from the repo root lists every target the Makefile exposes.
+These targets `cd` into the repo from the repo root and assume Docker (for `make test-e2e`) or the .NET 10 host SDK (for `make test-e2e-fast`) is installed. `make help` from the repo root lists every target the Makefile exposes.
 
 First run of `make test-e2e` is slow — it pulls the ~1.5GB Playwright image, builds the thin .NET 10 overlay (per `tests/DfE.CheckPerformanceData.E2ETests/Dockerfile`), and warms the named NuGet cache volume. Allow ~3-5 minutes. Subsequent runs reuse both the image layer cache and the NuGet volume → seconds-to-test-output.
 
@@ -96,13 +97,24 @@ Watch mode — re-runs the matched tests whenever a source file under the test p
 dotnet watch test --project tests/DfE.CheckPerformanceData.E2ETests/ -- --filter "FullyQualifiedName~WarningTextRenderTests"
 ```
 
-The `--` separator passes everything after it through to `dotnet test` rather than `dotnet watch`. Pair with a non-VR filter — VR tests skip cleanly on Windows/macOS but the skip still spins up the runner, which slows the watch loop unnecessarily. Watch mode assumes the compose stack (`docker compose --profile e2e up -d web db azurite`) is already up; if it isn't, the fixture's readiness probe will fail every iteration.
+The `--` separator passes everything after it through to `dotnet test` rather than `dotnet watch`. Visual regression is already off by default, so no extra filter is needed. Watch mode assumes the compose stack (`docker compose --profile e2e up -d web db azurite`) is already up; if it isn't, the fixture's readiness probe will fail every iteration.
 
 ## Visual regression
 
 Visual regression tests live under `Visual/` and capture full-page Chromium screenshots which are pixel-diffed against committed `.png` artefacts under `Snapshots/linux-chromium/`. The diff helper is `IPage.MatchSnapshotAsync(name, maxDiffPixelRatio: 0.005)` in `Helpers/PageSnapshotExtensions.cs` — it uses `SixLabors.ImageSharp` for the per-pixel comparison with a small per-channel tolerance so anti-aliasing jitter does not cause false positives below the 0.5% diff threshold.
 
-Snapshots are **Linux-only**. Each test calls `Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux), ...)` so on Windows/macOS the tests skip cleanly. Linux-Chromium and Windows-Chromium produce different rendered pixels — never commit a snapshot generated locally on Windows or macOS. The CI Linux runner is the canonical source.
+The comparisons are **off by default everywhere**. Each test calls
+`Skip.IfNot(VisualRegressionSwitch.Enabled, ...)`, so they run only when
+`CPD_E2E_VISUAL_REGRESSION` is set to `1` — which `make test-e2e-visual` does. A
+bare `dotnet test` on the project skips them, which no category filter would have
+achieved.
+
+They are also **Linux-only**: a second `Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux), ...)`
+keeps them off Windows and macOS. Rendered pixels differ between platforms and
+between container and host, so a comparison run anywhere but the pinned Playwright
+container reports differences that say nothing about the code — and rewrites the
+committed baselines as a side effect. Never commit a snapshot generated outside
+that container.
 
 ### Update workflow
 
@@ -114,7 +126,7 @@ To intentionally regenerate a snapshot:
    rm tests/DfE.CheckPerformanceData.E2ETests/Snapshots/linux-chromium/{name}.png
    ```
 3. Choose either path:
-   - **Local container path (preferred when Docker is available):** `make test-e2e` (first run writes the new `.png` and fails the test with "did not exist — written, run again to verify"). Inspect the generated PNG, then `make test-e2e` again to confirm the comparison now passes. Commit the regenerated PNG.
+   - **Local container path (preferred when Docker is available):** `make test-e2e-visual` (first run writes the new `.png` and fails the test with "did not exist — written, run again to verify"). Inspect the generated PNG, then `make test-e2e-visual` again to confirm the comparison now passes. Commit the regenerated PNG.
    - **CI path (fallback for devs without Docker):** Push to a branch labelled `deploy` so the CI `e2e:` job runs on Linux. The first CI run writes the new `.png` and fails. Download the `e2e-snapshots` artefact from that run; the regenerated PNG is under `linux-chromium/{name}.png`. Commit it back. Push again — second CI run passes; PR diff surfaces the regenerated PNG for review.
 
 No env var, no `--update-snapshots` flag plumbing — delete the file and run twice.
@@ -283,7 +295,7 @@ When you stop writing test scaffolding and need to seed a real wiki page or cont
   dotnet test tests/DfE.CheckPerformanceData.E2ETests/ --filter "Category!=VisualRegression" -c Release --no-build --nologo
 
   ### 5. E2E WITH visual regression (~10-15min) — Linux-Chromium container, the canonical baseline
-  make test-e2e
+  make test-e2e-visual
   #### Or, equivalently, without make:
   docker compose --profile e2e run --rm e2e-tests
 
@@ -296,7 +308,7 @@ When you stop writing test scaffolding and need to seed a real wiki page or cont
   dotnet test src/DfE.CheckPerformanceData.slnx -c Release --nologo
 
   The one-shot dotnet command works but the VR tests inside it use the host's Chromium pixels, not the canonical Linux container — so the diff   
-  thresholds are tuned wrong and you'll get false positives on Windows/macOS. Use make test-e2e for the real VR run.
+  thresholds are tuned wrong and you'll get false positives on Windows/macOS. Use make test-e2e-visual for the real VR run.
 
   ## Useful filters when narrowing in
 
@@ -329,6 +341,6 @@ When you stop writing test scaffolding and need to seed a real wiki page or cont
   1. dotnet build src/DfE.CheckPerformanceData.slnx -c Release --nologo — fast smoke for compile errors
   2. dotnet test src/DfE.CheckPerformanceData.slnx --filter "FullyQualifiedName!~E2ETests" -c Release --no-build --nologo — unit + integration in
   one shot
-  3. make test-e2e — full E2E + VR in the canonical container
+  3. make test-e2e-visual — full E2E + VR in the canonical container
 
   That's the pattern I'd run automatically given more autonomy on this repo. The first two together are ~90 seconds; the third is the long pole.

--- a/tests/DfE.CheckPerformanceData.E2ETests/README.md
+++ b/tests/DfE.CheckPerformanceData.E2ETests/README.md
@@ -57,11 +57,12 @@ The thrown `XunitException` message ends with the absolute path to the `Snapshot
 
 | Trait | Filter | Use |
 |-------|--------|-----|
-| `W0` | `--filter "Category=W0"` | Harness smoke. |
-| `W1` | `--filter "Category=W1"` | Read-path browse. |
-| `W2` | `--filter "Category=W2"` | Soft-delete + warning-text + search sidebar. |
-| `W4` | `--filter "Category=W4"` | REST CRUD + visual regression. |
-| `VisualRegression` | `--filter "Category=VisualRegression"` | Snapshot-diff tests only — Linux-only, skipped on Windows/macOS. |
+| `VisualRegression` | `--filter "Category=VisualRegression"` | Snapshot-diff tests only — Linux-only, and off unless `CPD_E2E_VISUAL_REGRESSION` is set. |
+| `Slow` | `--filter "Category!=Slow"` | Tests that wait on real timeouts or polling; exclude them for a quicker sweep. |
+
+Tests are otherwise grouped by folder rather than by trait — `Wiki/`, `Web/`,
+`Admin/`, `Visual/` — so scope a run with `--filter "FullyQualifiedName~Admin"`
+rather than reaching for a category.
 
 Quick functional sweep (excludes visual regression):
 
@@ -174,7 +175,7 @@ tests/DfE.CheckPerformanceData.E2ETests/
 
 1. Pick the appropriate folder (`Wiki/` for browser-driven wiki tests, `Web/` for HTTP and chrome/layout browser tests, `Visual/` for snapshots).
 2. Inherit `PageTest` for browser tests; omit inheritance for HTTP-only tests.
-3. Add `[Collection("E2E")]` and `[Trait("Category", "W{N}")]`.
+3. Add `[Collection("E2E")]`. Only add a `[Trait("Category", ...)]` if the test needs one of the traits in the table above.
 4. If the test creates wiki pages or content blocks, implement `IAsyncLifetime` with cleanup in `DisposeAsync`.
 5. Use the `e2e-{Guid:N}-` prefix on every slug/key.
 6. Use `_fixture.SeedClient` + `SeedHelpers.*` for HTTP seeding.
@@ -192,7 +193,6 @@ using Microsoft.Playwright.Xunit;
 namespace DfE.CheckPerformanceData.E2ETests.Web;
 
 [Collection("E2E")]
-[Trait("Category", "W1")]
 public sealed class CookieBannerTests(PlaywrightFixture fixture) : PageTest
 {
     private readonly PlaywrightFixture _fixture = fixture;
@@ -252,7 +252,6 @@ What each line is doing — read alongside the seven-step checklist above:
 | Pattern | Why |
 |---|---|
 | `: PageTest` + primary-ctor `(PlaywrightFixture fixture)` | `PageTest` (from `Microsoft.Playwright.Xunit`) gives you `Page` and `Expect(...)` for free. The fixture comes from the collection (one Postgres + one running Web container shared by every test in `[Collection("E2E")]`). |
-| `[Trait("Category", "W1")]` | Categorises the test for the filter table in this README. `W1` = read-path browse. Pick the trait that matches what your test exercises so it runs (or skips) cleanly with the existing Make targets. |
 | `await Page.Context.ClearCookiesAsync()` *before* `GotoAsync` | The collection-shared `Page` carries cookies from earlier tests. Anonymous-state tests must clear first or risk a false-pass because a previous test left the consent cookie behind. |
 | `Page.Locator("[data-module=...]")` scoping + `banner.Locator("[data-accept-cookies]")` | Scope a parent locator once, then resolve child locators from it. Lazier than `Page.Locator(...)` everywhere, and reads as "click the accept button *inside this banner*", which mirrors the page structure. |
 | `Expect(...).ToBeVisibleAsync()` / `ToBeHiddenAsync()` | Both auto-wait up to 5s. `ToBeHiddenAsync()` is satisfied by the `hidden` HTML attribute, `display: none`, or `visibility: hidden` — so the banner's Razor `hidden` attribute counts as hidden without extra CSS assertions. |

--- a/tests/DfE.CheckPerformanceData.E2ETests/Visual/AdminLandingVisualTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Visual/AdminLandingVisualTests.cs
@@ -6,7 +6,6 @@ using Microsoft.Playwright;
 namespace DfE.CheckPerformanceData.E2ETests.Visual;
 
 [Collection("E2E")]
-[Trait("Category", "W4")]
 [Trait("Category", "VisualRegression")]
 public sealed class AdminLandingVisualTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {

--- a/tests/DfE.CheckPerformanceData.E2ETests/Visual/AdminLandingVisualTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Visual/AdminLandingVisualTests.cs
@@ -18,6 +18,8 @@ public sealed class AdminLandingVisualTests(PlaywrightFixture fixture) : Seeding
     [SkippableFact]
     public async Task AdminLandingPage_MatchesSnapshot()
     {
+        Skip.IfNot(VisualRegressionSwitch.Enabled, VisualRegressionSwitch.SkipReason);
+
         Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
             "Visual regression Linux-only");
 

--- a/tests/DfE.CheckPerformanceData.E2ETests/Visual/ObservabilityVisualTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Visual/ObservabilityVisualTests.cs
@@ -11,7 +11,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Visual;
 // snapshot is stable across runs. StabiliseAsync additionally strips animation/transition before
 // the capture.
 [Collection("E2E")]
-[Trait("Category", "W4")]
 [Trait("Category", "VisualRegression")]
 public sealed class ObservabilityVisualTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {

--- a/tests/DfE.CheckPerformanceData.E2ETests/Visual/ObservabilityVisualTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Visual/ObservabilityVisualTests.cs
@@ -25,6 +25,8 @@ public sealed class ObservabilityVisualTests(PlaywrightFixture fixture) : Seedin
     [SkippableFact]
     public async Task DashboardPage_MatchesSnapshot()
     {
+        Skip.IfNot(VisualRegressionSwitch.Enabled, VisualRegressionSwitch.SkipReason);
+
         Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
             "Visual regression Linux-only");
 

--- a/tests/DfE.CheckPerformanceData.E2ETests/Visual/VisualRegressionSwitch.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Visual/VisualRegressionSwitch.cs
@@ -1,0 +1,35 @@
+namespace DfE.CheckPerformanceData.E2ETests.Visual;
+
+/// <summary>
+/// Opt-in switch for the visual-regression comparisons. Off unless explicitly asked for.
+/// </summary>
+/// <remarks>
+/// A screenshot comparison is only meaningful against baselines captured in the pinned
+/// Playwright container. Run from anywhere else — a developer machine, a dev container —
+/// and the images differ on font rasterisation and DPI alone, so the run reports failures
+/// that say nothing about the code and, worse, rewrites the committed baseline PNGs on
+/// disk as a side effect. A later container run then compares against those corrupted
+/// baselines, and the damage is invisible until someone reads the diff.
+///
+/// Nothing depends on these checks: the deploy workflow already excludes them by category,
+/// so they have only ever run when invoked by hand. Gating them behind an environment
+/// variable makes "off" the behaviour everywhere — including a bare
+/// <c>dotnet test</c> on the project, which no category filter covers — while keeping the
+/// tests and their baselines in place for whoever wants to run them deliberately.
+/// </remarks>
+internal static class VisualRegressionSwitch
+{
+    internal const string EnvironmentVariable = "CPD_E2E_VISUAL_REGRESSION";
+
+    internal const string SkipReason =
+        "Visual regression is off by default. Set " + EnvironmentVariable +
+        "=1 and run inside the Playwright container to compare against the committed baselines.";
+
+    /// <summary>
+    /// True only when the switch is set to <c>1</c> or <c>true</c>. Any other value — including
+    /// unset, empty, or an accidental <c>0</c> — leaves the comparisons off.
+    /// </summary>
+    internal static bool Enabled =>
+        Environment.GetEnvironmentVariable(EnvironmentVariable)
+            ?.Trim() is "1" or "true" or "TRUE" or "True";
+}

--- a/tests/DfE.CheckPerformanceData.E2ETests/Web/BackToTopTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Web/BackToTopTests.cs
@@ -24,7 +24,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Web;
 // of layout check (long body, Wiki.cshtml render path). The behaviour is layout-
 // agnostic though — every Content/Wiki page picks the same partial + CSS up.
 [Collection("E2E")]
-[Trait("Category", "W1")]
 public sealed class BackToTopTests(PlaywrightFixture fixture) : PageTest
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Web/ContactUsTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Web/ContactUsTests.cs
@@ -6,7 +6,6 @@ using Microsoft.Playwright.Xunit;
 namespace DfE.CheckPerformanceData.E2ETests.Web;
 
 [Collection("E2E")]
-[Trait("Category", "W0")]
 public sealed class ContactUsTests(PlaywrightFixture fixture) : PageTest
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Web/ContentBlockCrudTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Web/ContentBlockCrudTests.cs
@@ -5,7 +5,6 @@ using DfE.CheckPerformanceData.E2ETests.Helpers;
 namespace DfE.CheckPerformanceData.E2ETests.Web;
 
 [Collection("E2E")]
-[Trait("Category", "W4")]
 public sealed class ContentBlockCrudTests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Web/NotFoundTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Web/NotFoundTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Playwright.Xunit;
 namespace DfE.CheckPerformanceData.E2ETests.Web;
 
 [Collection("E2E")]
-[Trait("Category", "W1")]
 public sealed class NotFoundTests(PlaywrightFixture fixture) : PageTest
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Web/SignInNavTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Web/SignInNavTests.cs
@@ -16,7 +16,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Web;
 // actually delete the cookie, the claims transformer doesn't apply the editor
 // role, or the server-side rendering misreads the cookie value.
 [Collection("E2E")]
-[Trait("Category", "W0")]
 public sealed class SignInNavTests(PlaywrightFixture fixture) : PageTest
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Wiki/ContentBlockRenderTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Wiki/ContentBlockRenderTests.cs
@@ -5,7 +5,6 @@ using Microsoft.Playwright;
 namespace DfE.CheckPerformanceData.E2ETests.Wiki;
 
 [Collection("E2E")]
-[Trait("Category", "W1")]
 public sealed class ContentBlockRenderTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
     // Content-block leak accepted: no DELETE route on ContentBlockController. UUID-prefixed

--- a/tests/DfE.CheckPerformanceData.E2ETests/Wiki/GovUkAssetsTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Wiki/GovUkAssetsTests.cs
@@ -7,7 +7,6 @@ using xRetry;
 namespace DfE.CheckPerformanceData.E2ETests.Wiki;
 
 [Collection("E2E")]
-[Trait("Category", "W1")]
 public sealed class GovUkAssetsTests(PlaywrightFixture fixture) : PageTest
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Wiki/HealthcheckTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Wiki/HealthcheckTests.cs
@@ -4,7 +4,6 @@ using DfE.CheckPerformanceData.E2ETests.Fixtures;
 namespace DfE.CheckPerformanceData.E2ETests.Wiki;
 
 [Collection("E2E")]
-[Trait("Category", "W1")]
 public sealed class HealthcheckTests(PlaywrightFixture fixture)
 {
     private readonly PlaywrightFixture _fixture = fixture;

--- a/tests/DfE.CheckPerformanceData.E2ETests/Wiki/SearchPaginationTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Wiki/SearchPaginationTests.cs
@@ -15,7 +15,6 @@ namespace DfE.CheckPerformanceData.E2ETests.Wiki;
 // <div class="cypmd-search-results">. A descendant selector — ".cypmd-search-results
 // li h3 a" — matches both without needing an intermediate ul.govuk-list step.
 [Collection("E2E")]
-[Trait("Category", "W1")]
 public sealed class SearchPaginationTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
     // Track seeded pages for teardown so a failing test doesn't leave orphans that

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/AddSearchAnalyticsMigrationTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/AddSearchAnalyticsMigrationTests.cs
@@ -10,7 +10,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 // two tables can be decoupled). The rescope invariant is that no PII columns exist on
 // search_events — a sink DB leak reveals nothing that ties a row to a person.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class AddSearchAnalyticsMigrationTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SampleSearchDataSeederHitPoolTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SampleSearchDataSeederHitPoolTests.cs
@@ -19,7 +19,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 //   * Null dependencies (backward-compat): seeder still runs and emits results, using the
 //     internal sentinel fallback.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SampleSearchDataSeederHitPoolTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsAuthTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsAuthTests.cs
@@ -31,7 +31,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 // pre-compiled Razor views are not discoverable from the IntegrationTests TestServer without a
 // full layout dependency graph, so admin-pass-through does not run through this HostBuilder.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SearchAnalyticsAuthTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsChartTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsChartTests.cs
@@ -27,7 +27,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 // less bucket by hour; anything wider buckets by day. Every bucket bound + generate_series
 // step is server-computed and parameterised — the read path has no injection surface.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SearchAnalyticsChartTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsControllerTests.cs
@@ -20,7 +20,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 // against a seeded corpus — by calling the Index action directly against a real IPortalDbContext
 // so the query service exercises the same SQL production runs.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SearchAnalyticsControllerTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsDrillInTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsDrillInTests.cs
@@ -29,7 +29,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 // Npgsql — the read path has no injection surface even though the paging inputs (page, pageSize)
 // arrive from the query string.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SearchAnalyticsDrillInTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsInsightCardsTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsInsightCardsTests.cs
@@ -13,7 +13,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 //   - Zero-result → next-action outcome funnel (refined / feedback / silent)
 //   - Week-over-week prior-window summary (drives anomaly chips)
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SearchAnalyticsInsightCardsTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsNewDrillInActionsTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsNewDrillInActionsTests.cs
@@ -18,7 +18,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 // testcontainer so route model binding, defensive clamps, and empty-state renders exercise
 // the same code path the browser hits.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SearchAnalyticsNewDrillInActionsTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsQueryServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsQueryServiceTests.cs
@@ -14,7 +14,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 // pre-fill helper). Every window bound is a server-owned DateTime and every SQL parameter
 // binds via Npgsql so the read path has no injection surface.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SearchAnalyticsQueryServiceTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsRecoveryAndJourneyTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsRecoveryAndJourneyTests.cs
@@ -12,7 +12,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 // the shared Postgres testcontainer so the SQL text — window predicates, CTEs, ordering,
 // server-side clamps — is contract-tested end-to-end rather than mocked out.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SearchAnalyticsRecoveryAndJourneyTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsTopBlocksTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsTopBlocksTests.cs
@@ -13,7 +13,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 // semantically different — a page is a URL, a block is a snippet — and mixing them on one
 // card produces a "Top pages" list with non-navigable entries mid-list.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SearchAnalyticsTopBlocksTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SessionCookieLifetimeTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SessionCookieLifetimeTests.cs
@@ -16,7 +16,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Analytics;
 //   - IdleTimeout honours the SearchAnalytics:SessionIdleMinutes override
 //   - Cookie.MaxAge is deliberately NOT set — that's a browser hint only; the server-
 //     side absolute-lifetime cap lives in SessionAbsoluteLifetimeMiddleware (test 3b)
-[Trait("Category", "W0")]
 public sealed class SessionCookieLifetimeTests
 {
     [Fact]

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Health/WorkerHealthTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Health/WorkerHealthTests.cs
@@ -22,7 +22,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Health;
 /// database reachability so a crash-looping or DB-isolated worker is detectable.
 /// </summary>
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W3")]
 public sealed class WorkerHealthTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/BoardReplayTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/BoardReplayTests.cs
@@ -12,7 +12,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Observability;
 // actually happened. Real Postgres so the ordering and window bounds are exercised against
 // the real engine.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class BoardReplayTests
 {
     private const string RulesEngineQueue = "rules-engine";

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/HealthStripRenderTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/HealthStripRenderTests.cs
@@ -21,7 +21,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Observability;
 // naming each signal that crossed a threshold and the actual-vs-limit figures, while a flowing
 // light surfaces none. The Explain logic itself is unit-tested; this proves the model the
 // controller assembles renders into the markup a stakeholder actually sees.
-[Trait("Category", "W0")]
 public sealed class HealthStripRenderTests
 {
     private static HealthState NeedsAttention =>

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/MetricsEventEndToEndTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/MetricsEventEndToEndTests.cs
@@ -15,7 +15,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Observability;
 /// every field round-trips.
 /// </summary>
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class MetricsEventEndToEndTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/MetricsQueryTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/MetricsQueryTests.cs
@@ -12,7 +12,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Observability;
 // per-stage dwell, decision-mix, per-message journey, and deploy markers. Real Postgres so
 // the date_trunc + generate_series SQL is exercised against the actual engine.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class MetricsQueryTests
 {
     private const string RulesEngineQueue = "rules-engine";

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/MetricsRetentionTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/MetricsRetentionTests.cs
@@ -18,7 +18,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Observability;
 /// two-overload RunOnceAsync that the test drives directly with collaborators.
 /// </summary>
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class MetricsRetentionTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/ObservabilityStreamTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/ObservabilityStreamTests.cs
@@ -29,7 +29,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Observability;
 // pushing a snapshot on every tick. The heartbeat is driven shorter here so the test span
 // crosses several ticks quickly.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class ObservabilityStreamTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/ShareTokenTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/ShareTokenTests.cs
@@ -10,7 +10,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Observability;
 // can never reveal a live token. Validation hashes the incoming token and compares the hash to a
 // non-revoked row with a constant-time compare; revocation makes the same token validate false.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class ShareTokenTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/SubmittedStageTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Observability/SubmittedStageTests.cs
@@ -17,7 +17,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Observability;
 // enqueue time — not at the first consumer ack. Real Postgres: the submission flow enqueues a
 // queue row AND writes a Submitted metric row, and the journey query returns it first.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class SubmittedStageTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Queue/DlqRetentionTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Queue/DlqRetentionTests.cs
@@ -12,7 +12,6 @@ using DfE.CheckPerformanceData.Application.Notify;
 namespace DfE.CheckPerformanceData.IntegrationTests.Queue;
 
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class DlqRetentionTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Queue/QueueServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Queue/QueueServiceTests.cs
@@ -5,7 +5,6 @@ using DfE.CheckPerformanceData.Infrastructure.Queue;
 namespace DfE.CheckPerformanceData.IntegrationTests.Queue;
 
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class QueueServiceTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Queue/ZendeskConsumerIdempotencyTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Queue/ZendeskConsumerIdempotencyTests.cs
@@ -14,7 +14,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.Queue;
 // as happens after a restart or a redrive) must still create no second ticket — the guarantee
 // rests on the database, not on in-memory state.
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class ZendeskConsumerIdempotencyTests
 {
     private const string Reference = "REF-IDEM-001";

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/RequestSubmission/DuplicateRequestValidationIntegrationTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/RequestSubmission/DuplicateRequestValidationIntegrationTests.cs
@@ -18,7 +18,6 @@ using NSubstitute;
 namespace DfE.CheckPerformanceData.IntegrationTests.RequestSubmission;
 
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class DuplicateRequestValidationIntegrationTests
 {
     private readonly PostgresFixture _fixture;

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/DevPipelinePresetRoutingTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/DevPipelinePresetRoutingTests.cs
@@ -24,7 +24,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.RulesEngine;
 /// or Pincl regresses, the matching decision no longer lands and this fails.
 /// </summary>
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class DevPipelinePresetRoutingTests
 {
     private static readonly RulesSnapshot Snapshot = LoadSeedSnapshot();

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/RulesEngineEndToEndTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/RulesEngine/RulesEngineEndToEndTests.cs
@@ -27,7 +27,6 @@ namespace DfE.CheckPerformanceData.IntegrationTests.RulesEngine;
 /// proves the consumer writes back both the decision status and the outcome key.
 /// </summary>
 [Collection(nameof(PostgresCollection))]
-[Trait("Category", "W0")]
 public sealed class RulesEngineEndToEndTests
 {
     private static readonly RulesSnapshot Snapshot = LoadSeedSnapshot();


### PR DESCRIPTION
Two related pieces of test-suite housekeeping.

  ## Visual regression is now opt-in

  It was already filtered out of the deploy pipeline, so it only ran when invoked by
  hand — and outside the pinned Playwright container it fails on font rasterisation
  and DPI differences alone while rewriting the committed baseline PNGs as a side
  effect, silently corrupting them for the next container run.
  
  Gated behind CPD_E2E_VISUAL_REGRESSION, defaulting off. A category filter alone is
  not sufficient: a bare `dotnet test` on the E2E project applies no filter, which is
  exactly how baselines get overwritten by accident.

  - Add Visual/VisualRegressionSwitch.cs and guard both comparison tests with it,
    using the SkippableFact mechanism already present in those files
  - `make test-e2e` no longer runs the comparisons or the baseline bootstrap;
    `make test-e2e-visual` runs them deliberately, in the container the baselines
    were captured in
  - Pass the variable through docker-compose.e2e.yml
  - Keep the pipeline's existing category filter so the intent stays visible there
  
  Both tests and all baseline images are retained.
  
  ## Stale category traits removed

  The single-letter category labels on the test classes no longer described anything
  about the tests: nothing in CI, the Makefile, compose or any script filtered on
  them, the two documentation tables listing them had drifted out of step with actual
  usage in both directions, and one file still carried an unsubstituted placeholder.

  Removed, along with the tables describing them. Tests are grouped by folder and
  scoped with `--filter "FullyQualifiedName~..."`. The traits that describe behaviour
  rather than grouping are kept: VisualRegression, Slow and ConfirmModal.
  
  ## Documentation
  
  Both E2E documents are brought in line with the above. The snapshot regeneration
  workflow previously pointed at a target that will now skip the comparisons, so
  following it would have left the PNG untouched and looking correct.
  
  ## Verification
  
  - Full Release solution build: clean
  - Unit: 3394 passed, 0 failed
  - Integration: 605 passed, 0 failed
  - E2E with no filter: 122 passed, 0 failed, 4 skipped — both comparison tests
    skipped as intended
  
  [AB#296274](https://dfe-gov-uk.visualstudio.com/b947688b-53a4-4c90-9c43-5a5db31e313d/_workitems/edit/296274)