### PR TITLE
feat: add cross-field date validation to EAL details page AB#295246

### DIFF
--- a/src/DfE.CheckPerformanceData.Application/Journey/DateAnswer.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/DateAnswer.cs
@@ -20,4 +20,10 @@ public sealed class DateAnswer
     // date is not a complete, valid answer — so summary/confirmation rendering never throws.
     public string ToDisplayString() =>
         IsCompleteDate ? $"{Day} {new DateTime(Year, Month, Day):MMMM yyyy}" : string.Empty;
+
+    // Comparable form for date rules. Null rather than throwing for the incomplete and
+    // out-of-range cases IsCompleteDate already covers, so callers can treat "no usable date"
+    // and "no answer" identically.
+    public DateOnly? ToDateOnly() =>
+        IsCompleteDate ? new DateOnly(Year, Month, Day) : null;
 }

--- a/src/DfE.CheckPerformanceData.Application/Journey/DateRules/PageDateRules.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/DateRules/PageDateRules.cs
@@ -1,0 +1,167 @@
+using System.Globalization;
+
+namespace DfE.CheckPerformanceData.Application.Journey.DateRules;
+
+/// <summary>A cross-field date rule failure, anchored to the question that should be corrected.</summary>
+/// <param name="QuestionId">The raw question id from the flow config — this becomes the ModelState
+/// key, which is what <c>JourneyViewModelBuilder</c> looks the error up by.</param>
+public sealed record DateFieldViolation(string QuestionId, string Message);
+
+/// <summary>
+/// Cross-field date rules for the "Admitted from abroad with English not first language" page
+/// (AB#295246). The three dates must satisfy
+/// <c>arrivedInEngland &lt;= firstEnglishSchool &lt;= startedAtSchool</c>, none may be in the
+/// future, and the school start date may not predate the cohort.
+///
+/// These live in code rather than in the flow JSON on purpose. Flow configs are served from blob
+/// at runtime (see <see cref="QuestionFlowService"/>) and only reach blob via a seeding step gated
+/// on the environment, so a JSON-declared rule can be silently absent in a deployed environment
+/// whose blob still holds an older config — with nothing to indicate validation stopped happening.
+/// A rule compiled into the container cannot go missing. QuestionFlowValidatorAlignmentTests pins
+/// the ids below to the shipped config so the two cannot drift apart unnoticed.
+/// </summary>
+public static class PageDateRules
+{
+    public const string EalDetailsPageId = "english-not-first-language-details";
+
+    /// <summary>a. When did {pupilName} start at your school? (required)</summary>
+    public const string StartedAtSchool = "date-pupil-started";
+
+    /// <summary>b. When did {pupilName} first start at a school in England? (required)</summary>
+    public const string FirstEnglishSchool = "date-pupil-started-school-in-england";
+
+    /// <summary>c. When did {pupilName} arrive in England? (optional)</summary>
+    public const string ArrivedInEngland = "date-pupil-arrived-in-england";
+
+    // Scenario 001 (a < b)
+    private const string StartedBeforeFirstEnglishSchool =
+        "The date {pupilName} started at your school must be the same as or after {date} " +
+        "when they first started at a school in England";
+
+    private const string FirstEnglishSchoolAfterStarted =
+        "The date {pupilName} first started at a school in England must be the same as or before " +
+        "{date} when they started at your school";
+
+    // Scenario 002 (a < c)
+    private const string StartedBeforeArrival =
+        "The date {pupilName} started at your school must be the same as or after {date} " +
+        "when they arrived in England";
+
+    private const string ArrivedAfterStarted =
+        "The date {pupilName} arrived in England must be the same as or before {date} " +
+        "when they started at your school";
+
+    // Scenario 003 (b < c)
+    private const string FirstEnglishSchoolBeforeArrival =
+        "The date {pupilName} first started at a school in England must be the same as or after " +
+        "{date} when they arrived in England";
+
+    private const string ArrivedAfterFirstEnglishSchool =
+        "The date {pupilName} arrived in England must be the same as or before {date} " +
+        "when they first started at a school in England";
+
+    // Scenarios 004-006 (in the future)
+    private const string StartedInFuture =
+        "The date {pupilName} started at your school must be in the past";
+
+    private const string FirstEnglishSchoolInFuture =
+        "The date {pupilName} first started at a school in England must be in the past";
+
+    private const string ArrivedInFuture =
+        "The date {pupilName} arrived in England must be in the past";
+
+    // Scenario 007 (a predates the cohort)
+    private const string StartedBeforeCohort =
+        "The date {pupilName} started at your school cannot be more than 4 years ago " +
+        "when the cohort began";
+
+    /// <summary>
+    /// Earliest acceptable school admission date: 1 September of the school year four years back.
+    /// Mirrors the boundary the rules engine already applies to the same field —
+    /// <c>RulesEngineWorker/seed/rules.json</c> carries
+    /// <c>{ "field": "schoolAdmissionDate", "gte": "2022-09-01" }</c>, which is this expression
+    /// evaluated for a 2026 checking window. If the engine's boundary is ever re-cut, this must
+    /// move with it; PageDateRulesTests pins the 2026 case so the pair cannot drift silently.
+    /// </summary>
+    public static DateOnly CohortStart(DateOnly today) => new(today.Year - 4, 9, 1);
+
+    /// <summary>
+    /// Applies every scenario to the three dates and returns at most one message per field.
+    ///
+    /// A null date is one the user left blank, part-filled, or entered as a non-date; it is
+    /// excluded from every comparison it takes part in, because the per-question format rules
+    /// already own that failure and only the first error per question is ever rendered.
+    ///
+    /// Ordering matters. The "in the future" and "predates the cohort" checks run before the
+    /// three sequence checks: a date that is independently wrong makes any comparison against
+    /// it misleading, so it should be the message the user sees.
+    /// </summary>
+    public static IReadOnlyList<DateFieldViolation> Evaluate(
+        DateOnly? startedAtSchool,
+        DateOnly? firstEnglishSchool,
+        DateOnly? arrivedInEngland,
+        DateOnly today,
+        string pupilName)
+    {
+        var messages = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        void Flag(string questionId, string template, DateOnly? reference = null)
+        {
+            if (messages.ContainsKey(questionId)) return;
+            messages[questionId] = Format(template, pupilName, reference);
+        }
+
+        // Every comparison below relies on lifted nullable ordering: when either side is null the
+        // operator yields false, so a missing or unusable date silently drops out of the rule
+        // rather than needing a guard at each site.
+
+        // 004-006: no date may be in the future. Today itself is acceptable — the rule is
+        // "later than today", not "before today".
+        if (startedAtSchool > today) Flag(StartedAtSchool, StartedInFuture);
+        if (firstEnglishSchool > today) Flag(FirstEnglishSchool, FirstEnglishSchoolInFuture);
+        if (arrivedInEngland > today) Flag(ArrivedInEngland, ArrivedInFuture);
+
+        // 007: the school start date may not predate the cohort. Field a. only.
+        if (startedAtSchool < CohortStart(today)) Flag(StartedAtSchool, StartedBeforeCohort);
+
+        // 001-003: arrival <= first English school <= started at this school. Each failure is
+        // reported against both fields involved, phrased from that field's point of view.
+        if (startedAtSchool < firstEnglishSchool)
+        {
+            Flag(StartedAtSchool, StartedBeforeFirstEnglishSchool, firstEnglishSchool);
+            Flag(FirstEnglishSchool, FirstEnglishSchoolAfterStarted, startedAtSchool);
+        }
+
+        if (startedAtSchool < arrivedInEngland)
+        {
+            Flag(StartedAtSchool, StartedBeforeArrival, arrivedInEngland);
+            Flag(ArrivedInEngland, ArrivedAfterStarted, startedAtSchool);
+        }
+
+        if (firstEnglishSchool < arrivedInEngland)
+        {
+            Flag(FirstEnglishSchool, FirstEnglishSchoolBeforeArrival, arrivedInEngland);
+            Flag(ArrivedInEngland, ArrivedAfterFirstEnglishSchool, firstEnglishSchool);
+        }
+
+        // Returned in the order the questions appear on the page so the error summary reads
+        // top-to-bottom. (The summary is built from the page's question order regardless, but
+        // callers and tests get a stable order too.)
+        return OrderedIds
+            .Where(messages.ContainsKey)
+            .Select(id => new DateFieldViolation(id, messages[id]))
+            .ToList();
+    }
+
+    private static readonly string[] OrderedIds = [StartedAtSchool, FirstEnglishSchool, ArrivedInEngland];
+
+    // Dates are rendered "d MMMM yyyy" (e.g. "27 March 2026") to match how the same answers
+    // appear on the summary page. Invariant culture: the message must not change shape with the
+    // server's ambient culture.
+    private static string Format(string template, string pupilName, DateOnly? reference) =>
+        JourneyTemplate.Resolve(template, pupilName)
+            .Replace(
+                "{date}",
+                reference?.ToString("d MMMM yyyy", CultureInfo.InvariantCulture) ?? string.Empty,
+                StringComparison.Ordinal);
+}

--- a/src/DfE.CheckPerformanceData.Application/Journey/IJourneyValidationService.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/IJourneyValidationService.cs
@@ -1,3 +1,4 @@
+using DfE.CheckPerformanceData.Application.Journey.DateRules;
 using DfE.CheckPerformanceData.Domain.Enums;
 
 namespace DfE.CheckPerformanceData.Application.Journey;
@@ -7,6 +8,14 @@ public interface IJourneyValidationService
     int MaxEvidencePages { get; }
     bool IsAnswered(Question question, QuestionAnswer? answer);
     RequireAtLeastOneResult? ValidateRequireAtLeastOne(JourneyPage page, IReadOnlyDictionary<string, QuestionAnswer> answers, string pupilName);
+
+    /// <summary>
+    /// Cross-field date rules for the page, if it has any. Returns at most one message per
+    /// question. Empty for every page without rules, which is all of them bar the EAL details
+    /// page today.
+    /// </summary>
+    IReadOnlyList<DateFieldViolation> ValidatePageDates(JourneyPage page, IReadOnlyDictionary<string, QuestionAnswer> answers, string pupilName);
+
     string? ValidateAnswer(Question question, QuestionAnswer answer, string resolvedTitle, string? resolvedValidationFailure = null);
     string? ValidateFileUpload(string fileName, int newPageCount, IReadOnlyList<FileAnswer> existingFiles);
     string GenerateReference(CheckingWindowType? windowType);

--- a/src/DfE.CheckPerformanceData.Application/Journey/JourneyValidationService.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/JourneyValidationService.cs
@@ -1,3 +1,4 @@
+using DfE.CheckPerformanceData.Application.Journey.DateRules;
 using DfE.CheckPerformanceData.Application.Journey.Validators;
 using DfE.CheckPerformanceData.Domain.Enums;
 
@@ -6,10 +7,19 @@ namespace DfE.CheckPerformanceData.Application.Journey;
 // Pass maxEvidencePages > 0 to the DI registration to re-enable the page-count limit.
 public sealed class JourneyValidationService(
     IEnumerable<IFormatValidator>? formatValidators = null,
-    int maxEvidencePages = 0) : IJourneyValidationService
+    int maxEvidencePages = 0,
+    TimeProvider? timeProvider = null) : IJourneyValidationService
 {
     private readonly IReadOnlyList<IFormatValidator> _formatValidators =
         formatValidators?.ToList() ?? [];
+
+    private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+
+    // Date rules compare against the UK calendar date, not UTC: between midnight and 1am BST the
+    // two disagree, and "today" to a school means today in England. Duplicated from
+    // Web/Extensions/LondonTime.cs because Application cannot reference Web; that file documents
+    // why the IANA id resolves on both the Linux deploy target and Windows.
+    private static readonly TimeZoneInfo UkZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/London");
 
     public int MaxEvidencePages => maxEvidencePages;
 
@@ -38,6 +48,26 @@ public sealed class JourneyValidationService(
 
         return new RequireAtLeastOneResult("You must answer at least one of these questions", fieldErrors);
     }
+
+    public IReadOnlyList<DateFieldViolation> ValidatePageDates(
+        JourneyPage page, IReadOnlyDictionary<string, QuestionAnswer> answers, string pupilName)
+    {
+        if (!string.Equals(page.Id, PageDateRules.EalDetailsPageId, StringComparison.Ordinal))
+            return [];
+
+        DateOnly? Answered(string questionId) =>
+            answers.TryGetValue(questionId, out var answer) ? answer.DateValue?.ToDateOnly() : null;
+
+        return PageDateRules.Evaluate(
+            Answered(PageDateRules.StartedAtSchool),
+            Answered(PageDateRules.FirstEnglishSchool),
+            Answered(PageDateRules.ArrivedInEngland),
+            UkToday(),
+            pupilName);
+    }
+
+    private DateOnly UkToday() => DateOnly.FromDateTime(
+        TimeZoneInfo.ConvertTimeFromUtc(_timeProvider.GetUtcNow().UtcDateTime, UkZone));
 
     public string? ValidateAnswer(Question question, QuestionAnswer answer, string resolvedTitle, string? resolvedValidationFailure = null)
     {

--- a/src/DfE.CheckPerformanceData.Web/Analytics/ValidationErrorCoding.cs
+++ b/src/DfE.CheckPerformanceData.Web/Analytics/ValidationErrorCoding.cs
@@ -15,6 +15,10 @@ public static class ValidationErrorCoding
     public const string FileRequired = "file_required";
     public const string Conflict = "conflict";
 
+    /// <summary>A date that is well-formed but inconsistent with another date on the same page,
+    /// or with today — distinct from <c>bad_date</c>, which means unparseable.</summary>
+    public const string DateInconsistent = "date_inconsistent";
+
     /// <summary>Code for a question that failed validation. An unanswered required
     /// question is <c>required</c>; an answered-but-invalid one is classified by type.</summary>
     public static string ForQuestion(Question question, bool isAnswered)

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyController.cs
@@ -318,6 +318,20 @@ public sealed class JourneyController(
             }
         }
 
+        // Cross-field date rules (AB#295246). Runs after the loop because it needs every answer
+        // on the page, and skips any question that already failed its own format check — the
+        // view model renders only the first error per question, so adding a second here would
+        // replace "must be a real date" with a comparison against a date the user never entered.
+        var dateRuleQuestionIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var violation in journeyService.ValidatePageDates(page, newAnswers, pupilName))
+        {
+            if (ModelState.TryGetValue(violation.QuestionId, out var existing) && existing.Errors.Count > 0)
+                continue;
+            ModelState.AddModelError(violation.QuestionId, violation.Message);
+            dateRuleQuestionIds.Add(violation.QuestionId);
+            isValid = false;
+        }
+
         // Page-level "at least one answered" rule (e.g. EvidenceUpload pages).
         var atLeastOne = journeyService.ValidateRequireAtLeastOne(page, newAnswers, pupilName);
         if (atLeastOne is not null)
@@ -334,6 +348,9 @@ public sealed class JourneyController(
             {
                 if (!ModelState.TryGetValue(q.Id, out var entry) || entry.Errors.Count == 0) continue;
                 if (q.Type == QuestionType.FileUpload) { codes.Add(ValidationErrorCoding.FileRequired); continue; }
+                // A cross-field failure is a well-formed date in the wrong place, not a malformed
+                // one — coding it as bad_date would hide the distinction the rule exists to make.
+                if (dateRuleQuestionIds.Contains(q.Id)) { codes.Add(ValidationErrorCoding.DateInconsistent); continue; }
                 newAnswers.TryGetValue(q.Id, out var ans);
                 var answered = ans is not null && journeyService.IsAnswered(q, ans);
                 codes.Add(ValidationErrorCoding.ForQuestion(q, answered));

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/DateAnswerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/DateAnswerTests.cs
@@ -27,6 +27,26 @@ public class DateAnswerTests
         Assert.Equal(string.Empty, date.ToDisplayString());
     }
 
+    [Fact]
+    public void ToDateOnly_ValidDate_ReturnsTheDate()
+    {
+        var date = new DateAnswer { Day = 12, Month = 3, Year = 2025 };
+
+        Assert.Equal(new DateOnly(2025, 3, 12), date.ToDateOnly());
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0)]      // blank optional date
+    [InlineData(12, 0, 2025)]  // part-filled
+    [InlineData(31, 2, 2025)]  // impossible calendar date
+    [InlineData(15, 6, 26)]    // two-digit year
+    public void ToDateOnly_IncompleteOrInvalidDate_ReturnsNull(int day, int month, int year)
+    {
+        var date = new DateAnswer { Day = day, Month = month, Year = year };
+
+        Assert.Null(date.ToDateOnly());
+    }
+
     [Theory]
     [InlineData(12, 3, 2025, true)]
     [InlineData(29, 2, 2024, true)]   // leap day

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerTests.cs
@@ -5,6 +5,7 @@ using DfE.CheckPerformanceData.Application.CheckYourPupilData;
 using DfE.CheckPerformanceData.Application.CurrentUser;
 using DfE.CheckPerformanceData.Application.FileStorage;
 using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.Journey.DateRules;
 using DfE.CheckPerformanceData.Application.LandingPage;
 using DfE.CheckPerformanceData.Application.RequestSubmission;
 using DfE.CheckPerformanceData.Domain.Enums;
@@ -644,6 +645,108 @@ public class JourneyControllerTests
                 e.ErrorCodes.Contains("required") && e.WhatToChange == "Remove" && e.FromSummary == false),
             Arg.Any<CancellationToken>());
     }
+
+    // ── PagePost — cross-field date rules (AB#295246) ────────────────────────
+
+    [Fact]
+    public async Task PagePost_DateRuleViolation_AddsTheErrorUnderTheQuestionId()
+    {
+        // The ModelState key has to be the raw question id: JourneyViewModelBuilder looks the
+        // error up by it, and anything else means the message renders nowhere at all.
+        SetupDatePage();
+        _journeyService.ValidatePageDates(Arg.Any<JourneyPage>(),
+                Arg.Any<IReadOnlyDictionary<string, QuestionAnswer>>(), Arg.Any<string>())
+            .Returns([new DateFieldViolation("date-a", "Dates are the wrong way round")]);
+        SetupSession(ValidSession(history: ["date-page"]));
+        PostDates(aYear: "2023", bYear: "2024");
+
+        var result = await _sut.PagePost(WindowId, "date-page", fromSummary: false);
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Equal("Page", view.ViewName);
+        Assert.False(_sut.ModelState.IsValid);
+        Assert.Equal("Dates are the wrong way round",
+            _sut.ModelState["date-a"]!.Errors.Single().ErrorMessage);
+    }
+
+    [Fact]
+    public async Task PagePost_DateRuleViolation_DoesNotDisplaceAFormatError()
+    {
+        // Only the first error per question is rendered. A comparison against a date the user
+        // never successfully entered must not replace "must be a real date".
+        SetupDatePage();
+        _journeyService.ValidateAnswer(Arg.Any<Question>(), Arg.Any<QuestionAnswer>(), Arg.Any<string>(), Arg.Any<string?>())
+            .Returns("Enter a real date");
+        _journeyService.ValidatePageDates(Arg.Any<JourneyPage>(),
+                Arg.Any<IReadOnlyDictionary<string, QuestionAnswer>>(), Arg.Any<string>())
+            .Returns([new DateFieldViolation("date-a", "Dates are the wrong way round")]);
+        SetupSession(ValidSession(history: ["date-page"]));
+        PostDates(aYear: "2023", bYear: "2024");
+
+        var result = await _sut.PagePost(WindowId, "date-page", fromSummary: false);
+
+        Assert.IsType<ViewResult>(result);
+        Assert.Equal("Enter a real date", _sut.ModelState["date-a"]!.Errors.Single().ErrorMessage);
+    }
+
+    [Fact]
+    public async Task PagePost_DateRuleViolation_IsCodedAsInconsistentNotBadDate()
+    {
+        // A well-formed date in the wrong place is a different failure from an unparseable one,
+        // and the analytics taxonomy has to keep them apart.
+        SetupDatePage();
+        _journeyService.IsAnswered(Arg.Any<Question>(), Arg.Any<QuestionAnswer>()).Returns(true);
+        _journeyService.ValidatePageDates(Arg.Any<JourneyPage>(),
+                Arg.Any<IReadOnlyDictionary<string, QuestionAnswer>>(), Arg.Any<string>())
+            .Returns([new DateFieldViolation("date-a", "Dates are the wrong way round")]);
+        SetupSession(ValidSession(history: ["date-page"]));
+        PostDates(aYear: "2023", bYear: "2024");
+
+        await _sut.PagePost(WindowId, "date-page", fromSummary: false);
+
+        await _analytics.Received(1).TrackAsync(
+            Arg.Is<ValidationErrorEvent>(e =>
+                e.ErrorCodes.Contains("date_inconsistent") && !e.ErrorCodes.Contains("bad_date")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PagePost_NoDateRuleViolations_StillAdvances()
+    {
+        SetupDatePage();
+        SetupSession(ValidSession(history: ["date-page"]));
+        PostDates(aYear: "2024", bYear: "2023");
+
+        var result = await _sut.PagePost(WindowId, "date-page", fromSummary: false);
+
+        Assert.IsType<RedirectToActionResult>(result);
+    }
+
+    private void SetupDatePage()
+    {
+        var datePage = new JourneyPage
+        {
+            Id = "date-page",
+            Questions =
+            [
+                new Question { Id = "date-a", Type = QuestionType.Date, Title = "Date A" },
+                new Question { Id = "date-b", Type = QuestionType.Date, Title = "Date B" }
+            ],
+            NextPageId = "page-2"
+        };
+        _flowService.GetPage(Config, "date-page").Returns(datePage);
+        _journeyService.ValidateAnswer(Arg.Any<Question>(), Arg.Any<QuestionAnswer>(), Arg.Any<string>(), Arg.Any<string?>())
+            .Returns((string?)null);
+        _flowService.GetNextPageId(Config, "date-page", Arg.Any<Dictionary<string, QuestionAnswer>>())
+            .Returns("page-2");
+    }
+
+    private void PostDates(string aYear, string bYear) =>
+        _httpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>
+        {
+            ["q_date_a_day"] = "4", ["q_date_a_month"] = "9", ["q_date_a_year"] = aYear,
+            ["q_date_b_day"] = "8", ["q_date_b_month"] = "1", ["q_date_b_year"] = bYear
+        });
 
     // ── SaveDraft ────────────────────────────────────────────────────────────
 

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyValidationServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyValidationServiceTests.cs
@@ -1,6 +1,8 @@
 using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.Journey.DateRules;
 using DfE.CheckPerformanceData.Application.Journey.Validators;
 using DfE.CheckPerformanceData.Domain.Enums;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
 
@@ -523,7 +525,167 @@ public class JourneyValidationServiceTests
         Assert.Contains("You must answer at least one of these questions", result!.Messages);
     }
 
+    // ── ValidatePageDates ───────────────────────────────────────────────────
+    //
+    // The rules themselves are covered by PageDateRulesTests. These cover the wiring: which
+    // pages the rules apply to, how answers are turned into comparable dates, and which
+    // calendar "today" comes from.
+
+    [Fact]
+    public void ValidatePageDates_PageWithoutDateRules_ReturnsEmpty()
+    {
+        var page = MakeEvidencePage(requireAtLeastOne: false);
+
+        Assert.Empty(_sut.ValidatePageDates(page, new Dictionary<string, QuestionAnswer>(), "Jane Smith"));
+    }
+
+    [Fact]
+    public void ValidatePageDates_EalDetailsPage_AppliesTheRules()
+    {
+        var sut = DateRuleSut("2026-06-15T12:00:00Z");
+        var answers = EalAnswers(
+            started: new DateAnswer { Day = 4, Month = 9, Year = 2023 },
+            firstEnglishSchool: new DateAnswer { Day = 8, Month = 1, Year = 2024 });
+
+        var violations = sut.ValidatePageDates(MakeEalDetailsPage(), answers, "Jane Smith");
+
+        Assert.Equal(2, violations.Count);
+        Assert.Contains(violations, v => v.QuestionId == PageDateRules.StartedAtSchool);
+        Assert.Contains(violations, v => v.QuestionId == PageDateRules.FirstEnglishSchool);
+    }
+
+    [Fact]
+    public void ValidatePageDates_ConsistentAnswers_ReturnsEmpty()
+    {
+        var sut = DateRuleSut("2026-06-15T12:00:00Z");
+        var answers = EalAnswers(
+            started: new DateAnswer { Day = 2, Month = 9, Year = 2024 },
+            firstEnglishSchool: new DateAnswer { Day = 4, Month = 9, Year = 2023 },
+            arrived: new DateAnswer { Day = 20, Month = 8, Year = 2023 });
+
+        Assert.Empty(sut.ValidatePageDates(MakeEalDetailsPage(), answers, "Jane Smith"));
+    }
+
+    [Fact]
+    public void ValidatePageDates_IncompleteDate_IsExcludedFromComparisons()
+    {
+        // A part-filled optional date is stored with the missing part as 0. It is not a date the
+        // user can be told to reconcile with anything, so no rule involving it may fire.
+        var sut = DateRuleSut("2026-06-15T12:00:00Z");
+        var answers = EalAnswers(
+            started: new DateAnswer { Day = 2, Month = 9, Year = 2024 },
+            firstEnglishSchool: new DateAnswer { Day = 4, Month = 9, Year = 2023 },
+            arrived: new DateAnswer { Day = 20, Month = 0, Year = 2025 });
+
+        Assert.Empty(sut.ValidatePageDates(MakeEalDetailsPage(), answers, "Jane Smith"));
+    }
+
+    [Fact]
+    public void ValidatePageDates_UnansweredQuestion_IsExcludedFromComparisons()
+    {
+        var sut = DateRuleSut("2026-06-15T12:00:00Z");
+        var answers = EalAnswers(started: new DateAnswer { Day = 2, Month = 9, Year = 2024 });
+
+        Assert.Empty(sut.ValidatePageDates(MakeEalDetailsPage(), answers, "Jane Smith"));
+    }
+
+    [Fact]
+    public void ValidatePageDates_UsesTheUkCalendarDate_NotUtc()
+    {
+        // 23:30 UTC on 15 June is 00:30 BST on the 16th. A school completing the form just after
+        // midnight must be able to enter today's UK date without it being called a future date.
+        var sut = DateRuleSut("2026-06-15T23:30:00Z");
+        var answers = EalAnswers(
+            started: new DateAnswer { Day = 16, Month = 6, Year = 2026 },
+            firstEnglishSchool: new DateAnswer { Day = 16, Month = 6, Year = 2026 });
+
+        Assert.Empty(sut.ValidatePageDates(MakeEalDetailsPage(), answers, "Jane Smith"));
+    }
+
+    [Fact]
+    public void ValidatePageDates_ResolvesThePupilNameInMessages()
+    {
+        var sut = DateRuleSut("2026-06-15T12:00:00Z");
+        var answers = EalAnswers(
+            started: new DateAnswer { Day = 16, Month = 6, Year = 2027 },
+            firstEnglishSchool: new DateAnswer { Day = 4, Month = 9, Year = 2023 });
+
+        var violation = Assert.Single(sut.ValidatePageDates(MakeEalDetailsPage(), answers, "Jane Smith"));
+
+        Assert.Equal("The date Jane Smith started at your school must be in the past", violation.Message);
+        Assert.DoesNotContain("{pupilName}", violation.Message, StringComparison.Ordinal);
+    }
+
+    // ── DI activation ───────────────────────────────────────────────────────
+    //
+    // Every constructor parameter is optional and one of them (maxEvidencePages) can never be
+    // resolved from the container, so the service is only constructible because the DI
+    // container falls back to declared defaults. Adding a parameter is therefore riskier than
+    // it looks, and nothing else covers it: no integration test boots the journey graph.
+
+    [Fact]
+    public void IsResolvable_FromTheContainer_AsRegistered()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(TimeProvider.System);
+        services.AddScoped<IJourneyValidationService, JourneyValidationService>();
+
+        using var provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+        using var scope = provider.CreateScope();
+
+        Assert.NotNull(scope.ServiceProvider.GetRequiredService<IJourneyValidationService>());
+    }
+
+    [Fact]
+    public void IsResolvable_WhenNoTimeProviderIsRegistered()
+    {
+        // The worker composes a narrower service graph than the web host. Falling back to the
+        // system clock keeps the date rules working rather than failing activation.
+        var services = new ServiceCollection();
+        services.AddScoped<IJourneyValidationService, JourneyValidationService>();
+
+        using var provider = services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
+        using var scope = provider.CreateScope();
+
+        Assert.NotNull(scope.ServiceProvider.GetRequiredService<IJourneyValidationService>());
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static JourneyValidationService DateRuleSut(string utcNow) =>
+        new(timeProvider: new FakeTimeProvider(DateTimeOffset.Parse(utcNow)));
+
+    private static Dictionary<string, QuestionAnswer> EalAnswers(
+        DateAnswer? started = null, DateAnswer? firstEnglishSchool = null, DateAnswer? arrived = null)
+    {
+        var answers = new Dictionary<string, QuestionAnswer>();
+        if (started is not null)
+            answers[PageDateRules.StartedAtSchool] = new QuestionAnswer { DateValue = started };
+        if (firstEnglishSchool is not null)
+            answers[PageDateRules.FirstEnglishSchool] = new QuestionAnswer { DateValue = firstEnglishSchool };
+        if (arrived is not null)
+            answers[PageDateRules.ArrivedInEngland] = new QuestionAnswer { DateValue = arrived };
+        return answers;
+    }
+
+    private static JourneyPage MakeEalDetailsPage() =>
+        new()
+        {
+            Id = PageDateRules.EalDetailsPageId,
+            Questions =
+            [
+                new Question { Id = PageDateRules.StartedAtSchool, Type = QuestionType.Date, Title = "Started" },
+                new Question { Id = PageDateRules.FirstEnglishSchool, Type = QuestionType.Date, Title = "First English school" },
+                new Question { Id = PageDateRules.ArrivedInEngland, Type = QuestionType.Date, Title = "Arrived", Optional = true }
+            ]
+        };
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
 
     private static Question MakeQuestion(QuestionType type, string id = "q1", int? characterLimit = null,
         string? validator = null, bool optional = false) =>

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/PageDateRulesTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/PageDateRulesTests.cs
@@ -1,0 +1,248 @@
+using DfE.CheckPerformanceData.Application.Journey.DateRules;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+/// <summary>
+/// The seven scenarios from AB#295246, against the invariant
+/// <c>arrivedInEngland &lt;= firstEnglishSchool &lt;= startedAtSchool</c>, none in the future,
+/// and the school start date on or after the cohort start.
+/// </summary>
+public sealed class PageDateRulesTests
+{
+    // A date inside a KS4 June checking window, so CohortStart is 1 September 2022 — the same
+    // boundary the rules engine seeds for schoolAdmissionDate.
+    private static readonly DateOnly Today = new(2026, 6, 15);
+
+    private const string Pupil = "Alice Smith";
+
+    // ── 001: started at this school before starting any English school ──────
+
+    [Fact]
+    public void Scenario001_StartedBeforeFirstEnglishSchool_FlagsBothFields()
+    {
+        var violations = Evaluate(a: new DateOnly(2023, 9, 4), b: new DateOnly(2024, 1, 8));
+
+        Assert.Equal(2, violations.Count);
+        Assert.Equal(
+            "The date Alice Smith started at your school must be the same as or after " +
+            "8 January 2024 when they first started at a school in England",
+            MessageFor(violations, PageDateRules.StartedAtSchool));
+        Assert.Equal(
+            "The date Alice Smith first started at a school in England must be the same as or " +
+            "before 4 September 2023 when they started at your school",
+            MessageFor(violations, PageDateRules.FirstEnglishSchool));
+    }
+
+    // ── 002: started at this school before arriving in England ──────────────
+
+    [Fact]
+    public void Scenario002_StartedBeforeArrival_FlagsBothFields()
+    {
+        var violations = Evaluate(
+            a: new DateOnly(2023, 9, 4), b: new DateOnly(2023, 9, 4), c: new DateOnly(2024, 1, 8));
+
+        Assert.Equal(
+            "The date Alice Smith started at your school must be the same as or after " +
+            "8 January 2024 when they arrived in England",
+            MessageFor(violations, PageDateRules.StartedAtSchool));
+        Assert.Equal(
+            "The date Alice Smith arrived in England must be the same as or before " +
+            "4 September 2023 when they started at your school",
+            MessageFor(violations, PageDateRules.ArrivedInEngland));
+    }
+
+    // ── 003: started at an English school before arriving in England ────────
+
+    [Fact]
+    public void Scenario003_FirstEnglishSchoolBeforeArrival_FlagsBothFields()
+    {
+        var violations = Evaluate(
+            a: new DateOnly(2025, 1, 1), b: new DateOnly(2023, 9, 4), c: new DateOnly(2024, 1, 8));
+
+        Assert.Equal(
+            "The date Alice Smith first started at a school in England must be the same as or " +
+            "after 8 January 2024 when they arrived in England",
+            MessageFor(violations, PageDateRules.FirstEnglishSchool));
+        Assert.Equal(
+            "The date Alice Smith arrived in England must be the same as or before " +
+            "4 September 2023 when they first started at a school in England",
+            MessageFor(violations, PageDateRules.ArrivedInEngland));
+    }
+
+    // ── 004-006: no date may be in the future ───────────────────────────────
+
+    [Fact]
+    public void Scenario004_StartedInFuture_FlagsStartedAtSchool()
+    {
+        var violations = Evaluate(a: Today.AddDays(1), b: new DateOnly(2023, 9, 4));
+
+        Assert.Equal(
+            "The date Alice Smith started at your school must be in the past",
+            MessageFor(violations, PageDateRules.StartedAtSchool));
+    }
+
+    [Fact]
+    public void Scenario005_FirstEnglishSchoolInFuture_FlagsFirstEnglishSchool()
+    {
+        var violations = Evaluate(a: Today.AddDays(2), b: Today.AddDays(1));
+
+        Assert.Equal(
+            "The date Alice Smith first started at a school in England must be in the past",
+            MessageFor(violations, PageDateRules.FirstEnglishSchool));
+    }
+
+    [Fact]
+    public void Scenario006_ArrivalInFuture_FlagsArrivedInEngland()
+    {
+        var violations = Evaluate(a: Today, b: Today, c: Today.AddDays(1));
+
+        Assert.Equal(
+            "The date Alice Smith arrived in England must be in the past",
+            MessageFor(violations, PageDateRules.ArrivedInEngland));
+    }
+
+    [Fact]
+    public void Today_IsAcceptable_ForEveryField()
+    {
+        // The rule is "later than today", not "before today" — a pupil admitted this morning
+        // is a legitimate answer.
+        Assert.Empty(Evaluate(a: Today, b: Today, c: Today));
+    }
+
+    // ── 007: the school start date may not predate the cohort ───────────────
+
+    [Fact]
+    public void Scenario007_StartedBeforeCohort_FlagsStartedAtSchool()
+    {
+        var violations = Evaluate(a: new DateOnly(2022, 8, 31), b: new DateOnly(2022, 8, 31));
+
+        Assert.Equal(
+            "The date Alice Smith started at your school cannot be more than 4 years ago " +
+            "when the cohort began",
+            MessageFor(violations, PageDateRules.StartedAtSchool));
+    }
+
+    [Fact]
+    public void Scenario007_StartedOnCohortStart_IsAcceptable()
+    {
+        Assert.Empty(Evaluate(a: new DateOnly(2022, 9, 1), b: new DateOnly(2022, 9, 1)));
+    }
+
+    [Fact]
+    public void Scenario007_AppliesToStartedAtSchoolOnly()
+    {
+        // b. and c. may legitimately predate the cohort — this pupil was in England, at school,
+        // before the cohort began; only the date they joined *this* school is bounded.
+        Assert.Empty(Evaluate(
+            a: new DateOnly(2023, 1, 9), b: new DateOnly(2019, 4, 1), c: new DateOnly(2018, 7, 20)));
+    }
+
+    /// <summary>
+    /// Pins <see cref="PageDateRules.CohortStart"/> to the boundary the rules engine already
+    /// seeds for the same field (<c>schoolAdmissionDate gte 2022-09-01</c>). If the engine's
+    /// boundary moves and this does not, journey validation and auto-triage disagree: a request
+    /// the form accepted would be auto-rejected downstream.
+    /// </summary>
+    [Theory]
+    [InlineData(2026, 6, 15, 2022)]
+    [InlineData(2026, 1, 5, 2022)]
+    [InlineData(2027, 6, 15, 2023)]
+    public void CohortStart_IsFirstOfSeptemberFourYearsBack(int year, int month, int day, int expectedYear)
+    {
+        Assert.Equal(new DateOnly(expectedYear, 9, 1), PageDateRules.CohortStart(new DateOnly(year, month, day)));
+    }
+
+    // ── Valid combinations ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ConsistentDates_ProduceNoViolations()
+    {
+        Assert.Empty(Evaluate(
+            a: new DateOnly(2024, 9, 2), b: new DateOnly(2023, 9, 4), c: new DateOnly(2023, 8, 20)));
+    }
+
+    [Fact]
+    public void EqualDates_ProduceNoViolations()
+    {
+        // Arriving, starting school and joining this school on the same day is unusual but valid;
+        // every message says "the same as or".
+        var sameDay = new DateOnly(2023, 9, 4);
+
+        Assert.Empty(Evaluate(a: sameDay, b: sameDay, c: sameDay));
+    }
+
+    // ── Missing and unusable dates ──────────────────────────────────────────
+
+    [Fact]
+    public void ArrivalOmitted_SkipsTheRulesThatNeedIt()
+    {
+        // c. is optional. 002, 003 and 006 cannot be evaluated without it; 001 still can.
+        var violations = Evaluate(a: new DateOnly(2023, 9, 4), b: new DateOnly(2024, 1, 8), c: null);
+
+        Assert.Equal(2, violations.Count);
+        Assert.DoesNotContain(violations, v => v.QuestionId == PageDateRules.ArrivedInEngland);
+    }
+
+    [Fact]
+    public void StartedAtSchoolOmitted_SkipsEveryComparisonInvolvingIt()
+    {
+        // a. failed its own format check, so it is unusable here. 003 does not involve it and
+        // must still fire.
+        var violations = Evaluate(a: null, b: new DateOnly(2023, 9, 4), c: new DateOnly(2024, 1, 8));
+
+        Assert.Equal(2, violations.Count);
+        Assert.DoesNotContain(violations, v => v.QuestionId == PageDateRules.StartedAtSchool);
+    }
+
+    [Fact]
+    public void AllDatesOmitted_ProducesNoViolations()
+    {
+        Assert.Empty(Evaluate(a: null, b: null, c: null));
+    }
+
+    // ── Precedence ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FutureDate_TakesPrecedenceOverSequenceRule()
+    {
+        // a. is both in the future and before b. Reporting "must be the same as or after
+        // {b}" would send the user to fix the ordering when the real problem is the year.
+        var violations = Evaluate(a: Today.AddYears(1), b: Today.AddYears(2));
+
+        Assert.Equal(
+            "The date Alice Smith started at your school must be in the past",
+            MessageFor(violations, PageDateRules.StartedAtSchool));
+    }
+
+    [Fact]
+    public void EachFieldGetsAtMostOneMessage()
+    {
+        // a. violates 001 and 002; b. violates 001 and 003; c. violates 002 and 003. Only the
+        // first error per question is ever rendered, so only one may be returned.
+        var violations = Evaluate(
+            a: new DateOnly(2023, 1, 1), b: new DateOnly(2023, 6, 1), c: new DateOnly(2024, 1, 1));
+
+        Assert.Equal(3, violations.Count);
+        Assert.Equal(violations.Select(v => v.QuestionId).Distinct().Count(), violations.Count);
+    }
+
+    [Fact]
+    public void Violations_AreOrderedAsTheQuestionsAppearOnThePage()
+    {
+        var violations = Evaluate(
+            a: new DateOnly(2023, 1, 1), b: new DateOnly(2023, 6, 1), c: new DateOnly(2024, 1, 1));
+
+        Assert.Equal(
+            [PageDateRules.StartedAtSchool, PageDateRules.FirstEnglishSchool, PageDateRules.ArrivedInEngland],
+            violations.Select(v => v.QuestionId));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private static IReadOnlyList<DateFieldViolation> Evaluate(
+        DateOnly? a = null, DateOnly? b = null, DateOnly? c = null) =>
+        PageDateRules.Evaluate(a, b, c, Today, Pupil);
+
+    private static string? MessageFor(IReadOnlyList<DateFieldViolation> violations, string questionId) =>
+        violations.SingleOrDefault(v => v.QuestionId == questionId)?.Message;
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/QuestionFlowValidatorAlignmentTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/QuestionFlowValidatorAlignmentTests.cs
@@ -1,7 +1,9 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.Journey.DateRules;
 using DfE.CheckPerformanceData.Application.Journey.Validators;
+using DfE.CheckPerformanceData.Domain.Enums;
 
 namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
 
@@ -64,6 +66,49 @@ public sealed class QuestionFlowValidatorAlignmentTests
         }
     }
 
+    /// <summary>
+    /// The same guard for the one rule that runs from code rather than config: the cross-field
+    /// date rules in <see cref="PageDateRules"/> address questions by id, and nothing at runtime
+    /// notices if the page or a question id is renamed in the flow JSON — the rules would simply
+    /// stop matching and the validation would silently stop happening.
+    /// </summary>
+    [Fact]
+    public void PageDateRules_QuestionIds_MatchTheShippedFlowConfig()
+    {
+        var page = AllFlowPages()
+            .SingleOrDefault(p => p.Page.Id == PageDateRules.EalDetailsPageId);
+
+        Assert.True(page.Page is not null,
+            $"No flow config contains a page '{PageDateRules.EalDetailsPageId}', which " +
+            $"PageDateRules addresses by id — its date rules would never run.");
+
+        string[] ruleIds =
+        [
+            PageDateRules.StartedAtSchool,
+            PageDateRules.FirstEnglishSchool,
+            PageDateRules.ArrivedInEngland
+        ];
+
+        foreach (var id in ruleIds)
+        {
+            var question = page.Page!.Questions.SingleOrDefault(q => q.Id == id);
+            Assert.True(question is not null,
+                $"{page.File}: page '{page.Page.Id}' has no question '{id}', which PageDateRules " +
+                $"compares — that rule would silently never fire.");
+            Assert.True(question!.Type == QuestionType.Date,
+                $"{page.File}: question '{id}' is {question.Type}, not Date — PageDateRules reads " +
+                $"it as a date answer and would always see it as unanswered.");
+        }
+
+        // The optionality of the arrival date is load-bearing: three of the seven rules are only
+        // evaluated when it has been filled in.
+        Assert.True(
+            page.Page!.Questions.Single(q => q.Id == PageDateRules.ArrivedInEngland).Optional,
+            $"{page.File}: '{PageDateRules.ArrivedInEngland}' is no longer optional. PageDateRules " +
+            $"treats a blank answer as 'rule not applicable' rather than an error — if the question " +
+            $"is now mandatory, confirm that is still the intended behaviour.");
+    }
+
     private static IEnumerable<string> ReferencedConditionNames(Question question)
     {
         foreach (var name in question.OptionalWhen ?? [])
@@ -96,14 +141,16 @@ public sealed class QuestionFlowValidatorAlignmentTests
             .ToHashSet(StringComparer.Ordinal);
     }
 
-    private static IEnumerable<(string File, Question Question)> AllFlowQuestions()
+    private static IEnumerable<(string File, Question Question)> AllFlowQuestions() =>
+        AllFlowPages().SelectMany(p => p.Page.Questions.Select(q => (p.File, q)));
+
+    private static IEnumerable<(string File, JourneyPage Page)> AllFlowPages()
     {
         foreach (var file in Directory.GetFiles(LocateFlowsDirectory(), "*.json").Order())
         {
             var config = JsonSerializer.Deserialize<QuestionFlowConfig>(File.ReadAllText(file), JsonOptions)!;
             foreach (var page in config.Pages)
-            foreach (var question in page.Questions)
-                yield return (Path.GetFileName(file), question);
+                yield return (Path.GetFileName(file), page);
         }
     }
 


### PR DESCRIPTION
  Schools could enter logically impossible date combinations on
  english-not-first-language-details — starting at a school before arriving
  in England, or before starting any English school — which then had to be
  reviewed and rejected by hand. Enforce the ordering server-side instead.

  The three dates must satisfy
  arrivedInEngland <= firstEnglishSchool <= startedAtSchool, none may be in
  the future, and the school admission date may not predate the cohort.
  Covers all seven scenarios from the ticket.

  - Application/Journey/DateRules/PageDateRules.cs: rule evaluation and message templates
  - DateAnswer.ToDateOnly(): comparable form, null for anything IsCompleteDate rejects
  - IJourneyValidationService.ValidatePageDates(): mirrors the shape of the existing ValidateRequireAtLeastOne page-level rule
  - JourneyController.PagePost: runs after the per-question loop, where every answer on the page is available
  - ValidationErrorCoding.DateInconsistent: a well-formed date in the wrong place is a different failure from an unparseable one

  Three decisions worth flagging:

  Rules live in code, not flow JSON. Flow configs are served from blob at
  runtime and only reach blob via an environment-gated seeding step, so a
  JSON-declared rule can be silently absent in a deployed environment whose
  blob holds an older config — with nothing to indicate validation stopped
  happening. QuestionFlowValidatorAlignmentTests pins the question ids to
  the shipped config so the two cannot drift apart unnoticed.

  The cohort boundary is 1 September of (year - 4), which is the same
  boundary the rules engine already seeds for schoolAdmissionDate
  (rules.json: gte 2022-09-01 for a 2026 window). Pinned by test: if the
  engine's boundary moves and this does not, the form would accept requests
  that are auto-rejected downstream.

  Temporal checks run before ordering checks. Only the first error per
  question is rendered, so a date that is both in the future and out of
  sequence reports "must be in the past" rather than a comparison against a
  date the user has to fix anyway.

  No view, config or schema changes. Unit 3436 passed (was 3396),
  integration 618 passed, build 0 errors.

  The source spec contradicts itself in three places — inverted comparators
  on scenarios 002/003, two copy-paste errors in the message table, and an
  ambiguous 4-year boundary. The readings taken are recorded as D1-D8 in
  the plan and still need BA sign-off.