### PR TITLE
Back to top reveal threshold - Fix when the back-to-top link appears

### DIFF
--- a/src/DfE.CheckPerformanceData.Application/PageTree/SamplePageNodeSeeder.cs
+++ b/src/DfE.CheckPerformanceData.Application/PageTree/SamplePageNodeSeeder.cs
@@ -178,7 +178,14 @@ public sealed class SamplePageNodeSeeder(IPageNodeService pageNodes)
                 "<p>The main KS4 checking exercise covers secondary school results. A separate re-checking window opens in June for results affected by appeals and re-marks.</p>"),
             new("post-16",          "Post-16 performance data",
                 "Post-16 performance data",
-                "<p>Performance results for sixth-form colleges, FE colleges and school sixth forms. Data is provisional until the checking window closes.</p>")
+                "<p>Performance results for sixth-form colleges, FE colleges and school sixth forms. Data is provisional until the checking window closes.</p>"),
+            // Deliberately one short paragraph. GDS guidance says not to use the
+            // back-to-top link on pages that fit the viewport, so the suppression
+            // needs a page with no meaningful scroll depth to prove itself against.
+            // Keep this body short — lengthening it silently weakens that check.
+            new("short-page",       "Short page",
+                "Short page",
+                "<p>A deliberately short page. There is not enough content here to scroll, so no back-to-top link should appear.</p>")
         ])
     ];
 }

--- a/src/DfE.CheckPerformanceData.Web/Views/Shared/ContentPages/_BackToTop.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Shared/ContentPages/_BackToTop.cshtml
@@ -1,7 +1,8 @@
 @* Back-to-top link for wiki/content pages. Sticky positioning keeps it 50px above the
    viewport bottom and releases at the natural end of the content flow so it doesn't
    overlap the footer. A tiny JS module (back-to-top.js) hides the link until the reader
-   has scrolled past the initial fold — matching the GDS design-guidance behaviour:
+   has scrolled nearly a whole viewport, and keeps it hidden entirely on pages short
+   enough to fit the viewport — matching the GDS design-guidance behaviour:
    https://design-system.service.gov.uk/community/resources-and-tools/
    The module only toggles a class; it never rewrites the DOM. Without JS the link stays
    visible as a graceful fallback (users can still reach it by scrolling normally).

--- a/src/DfE.CheckPerformanceData.Web/wwwroot/css/site.css
+++ b/src/DfE.CheckPerformanceData.Web/wwwroot/css/site.css
@@ -1830,8 +1830,9 @@ main.govuk-main-wrapper:has(.cpb-breadcrumbs) { padding-top: 0 !important; }
 
    Reveal-on-scroll is done by a tiny JS enhancement (back-to-top.js): once the module
    has run, it flips data-back-to-top-init on <html>, which activates the hidden-by-
-   default state below. Until the reader scrolls past ~100 px, the link is opacity: 0 +
-   visibility: hidden. Past that threshold the module adds .is-visible on the container
+   default state below. Until the reader has scrolled nearly a full viewport the link is
+   opacity: 0 + visibility: hidden, and on a page short enough to fit the viewport it
+   never reveals at all. Past the threshold the module adds .is-visible on the container
    and CSS transitions it in. Without JS neither the marker nor the .is-visible class
    is ever set, so the link stays visible as a graceful accessibility fallback. */
 .app-back-to-top {

--- a/src/DfE.CheckPerformanceData.Web/wwwroot/js/back-to-top.js
+++ b/src/DfE.CheckPerformanceData.Web/wwwroot/js/back-to-top.js
@@ -6,8 +6,9 @@
 //      link. Without JS this marker is never set and the link stays visible at the
 //      end of the content flow (accessibility fallback: users can still reach it by
 //      scrolling normally).
-//   2. Adds .is-visible when scrollY passes the threshold; removes it when the user
-//      scrolls back to the top.
+//   2. Adds .is-visible once the reader has travelled far enough to want it, and only
+//      on pages long enough to warrant the component at all; removes it when the user
+//      scrolls back up.
 //   3. Uses requestAnimationFrame to coalesce scroll events so we don't do the class
 //      flip on every single scroll notification (~60 Hz cap).
 //   4. Idempotent: if the script is loaded more than once (bfcache, hot-reload, a
@@ -25,9 +26,21 @@
     var containers = document.querySelectorAll('.app-back-to-top');
     if (containers.length === 0) return;
 
-    // Any scroll at all reveals the link. GDS uses a slightly larger threshold to
-    // avoid revealing on incidental micro-scrolls, so match that here.
-    var revealThreshold = 100;
+    // Both thresholds are measured in viewports rather than pixels, because "how far
+    // has the reader travelled" and "is this page long enough to need the component"
+    // are questions about screenfuls, not about absolute pixel counts — a threshold
+    // that behaves on a laptop is meaningless on a phone or a tall external monitor.
+    //
+    // REVEAL_AFTER_VIEWPORTS: the reader must have put very nearly a whole screenful
+    // behind them before the link appears. The top of the document is still one
+    // flick of the wheel away until then, so offering a shortcut to it is noise.
+    //
+    // MIN_SCROLLABLE_VIEWPORTS: the page must offer at least a full screenful of
+    // scrolling beyond the fold before the link is eligible at all. This is the GDS
+    // guidance — "avoid using this component on short pages or on pages designed to
+    // fit the entire viewport" — expressed as a measurement the browser can make.
+    var REVEAL_AFTER_VIEWPORTS = 0.9;
+    var MIN_SCROLLABLE_VIEWPORTS = 1;
 
     // Flip the initialisation marker on the document root so the corresponding CSS
     // block (which hides the link) takes effect. Non-JS environments never see this
@@ -38,7 +51,19 @@
     var wasVisible = null;
     function apply() {
         ticking = false;
-        var visible = window.scrollY > revealThreshold;
+
+        // Layout reads first, DOM writes after, so the frame costs one style recalc
+        // rather than one per container. scrollHeight is re-read every time instead of
+        // being cached at start-up: content that grows or shrinks after load (lazy
+        // images settling, a <details> being opened, a filter collapsing a list) changes
+        // whether the page qualifies, and neither of those fires resize.
+        var viewport = window.innerHeight;
+        var scrollable = document.documentElement.scrollHeight - viewport;
+
+        var longEnough = scrollable >= viewport * MIN_SCROLLABLE_VIEWPORTS;
+        var scrolledFarEnough = window.scrollY > viewport * REVEAL_AFTER_VIEWPORTS;
+        var visible = longEnough && scrolledFarEnough;
+
         // Skip the DOM write when the visibility state didn't change since the last frame.
         // classList.toggle('is-visible', visible) is not free on low-power devices — every
         // call triggers a style invalidation even when the class is already at the desired

--- a/src/DfE.CheckPerformanceData.Web/wwwroot/js/back-to-top.js
+++ b/src/DfE.CheckPerformanceData.Web/wwwroot/js/back-to-top.js
@@ -26,19 +26,40 @@
     var containers = document.querySelectorAll('.app-back-to-top');
     if (containers.length === 0) return;
 
-    // One rule, measured in viewports rather than pixels: the reader must have put very
-    // nearly a whole screenful behind them before the link appears. Until then the top of
-    // the document is still one flick of the wheel away, so offering a shortcut is noise.
-    //
-    // Screenfuls rather than pixels because "how far has the reader travelled" is a
-    // question about screens — a pixel threshold tuned on a laptop means something quite
-    // different on a phone or a tall external monitor.
-    //
-    // This also delivers the GDS guidance to "avoid using this component on short pages or
-    // on pages designed to fit the entire viewport" without a second rule: a page that fits
-    // the viewport has nothing to scroll, and a page with only a third of a screen of
-    // scroll can never reach the threshold, so neither ever reveals the link.
+    // The reader must have put nearly a whole screenful behind them before the link
+    // appears — until then the top of the document is one flick of the wheel away, so a
+    // shortcut to it is noise. Measured in screenfuls rather than pixels because "how far
+    // has the reader travelled" is a question about screens: a pixel threshold tuned on a
+    // laptop means something quite different on a phone or a tall external monitor.
     var REVEAL_AFTER_VIEWPORTS = 0.9;
+
+    // ...but a screenful alone is not enough, because a tall window is penalised twice: the
+    // threshold goes up while the same document's scrollable distance goes down. A page of
+    // ~2000px is 1.3 screens of scrolling on a 900px window and only 0.6 of one at 1300px,
+    // so a fixed fraction of the viewport silently stops being reachable on big monitors —
+    // the component disappears from most of the site for anyone with a large screen.
+    //
+    // So cap the threshold at a fraction of what the page actually offers. Long articles
+    // still reveal after a screenful (the cap is far away); pages that only just outrun the
+    // window reveal halfway down instead of never.
+    var REVEAL_AFTER_PAGE_FRACTION = 0.5;
+
+    // Below this there is not enough page to be worth a shortcut — the GDS guidance to
+    // "avoid using this component on short pages or on pages designed to fit the entire
+    // viewport". Two floors, and the page has to clear both:
+    //
+    //   * half a screen, so the judgement scales with the reader's window;
+    //   * an absolute distance, because "is scrolling back to the top a chore?" is a
+    //     question about travel, not about screens. Without it, a page that fits a desktop
+    //     window comfortably becomes 1.8 screens on a small laptop and starts showing a
+    //     link it has no business showing — the very complaint this component was reported
+    //     for. 600px is about two-thirds of a laptop screen.
+    //
+    // These are the only pixel-denominated numbers here, and deliberately so: the reveal
+    // threshold answers "how far has the reader come" (screens), this answers "is there
+    // enough page to bother" (distance).
+    var MIN_SCROLLABLE_VIEWPORTS = 0.5;
+    var MIN_SCROLLABLE_PIXELS = 600;
 
     // Flip the initialisation marker on the document root so the corresponding CSS
     // block (which hides the link) takes effect. Non-JS environments never see this
@@ -50,7 +71,19 @@
     function apply() {
         ticking = false;
 
-        var visible = window.scrollY > window.innerHeight * REVEAL_AFTER_VIEWPORTS;
+        // Layout reads first, DOM writes after, so the frame costs one style recalc rather
+        // than one per container. scrollHeight is re-read every time rather than cached at
+        // start-up: content that grows or shrinks after load (lazy images settling, a
+        // <details> being opened, a filter collapsing a list) moves the threshold, and
+        // neither of those fires a resize event.
+        var viewport = window.innerHeight;
+        var scrollable = document.documentElement.scrollHeight - viewport;
+
+        var worthShowing = scrollable > Math.max(viewport * MIN_SCROLLABLE_VIEWPORTS,
+                                                MIN_SCROLLABLE_PIXELS);
+        var threshold = Math.min(viewport * REVEAL_AFTER_VIEWPORTS,
+                                 scrollable * REVEAL_AFTER_PAGE_FRACTION);
+        var visible = worthShowing && window.scrollY > threshold;
 
         // Skip the DOM write when the visibility state didn't change since the last frame.
         // classList.toggle('is-visible', visible) is not free on low-power devices — every

--- a/src/DfE.CheckPerformanceData.Web/wwwroot/js/back-to-top.js
+++ b/src/DfE.CheckPerformanceData.Web/wwwroot/js/back-to-top.js
@@ -6,9 +6,9 @@
 //      link. Without JS this marker is never set and the link stays visible at the
 //      end of the content flow (accessibility fallback: users can still reach it by
 //      scrolling normally).
-//   2. Adds .is-visible once the reader has travelled far enough to want it, and only
-//      on pages long enough to warrant the component at all; removes it when the user
-//      scrolls back up.
+//   2. Adds .is-visible once the reader has scrolled nearly a whole viewport; removes it
+//      when the user scrolls back up. Pages too short to reach that never show the link,
+//      which is the GDS "not on short pages" guidance falling out of the same rule.
 //   3. Uses requestAnimationFrame to coalesce scroll events so we don't do the class
 //      flip on every single scroll notification (~60 Hz cap).
 //   4. Idempotent: if the script is loaded more than once (bfcache, hot-reload, a
@@ -26,21 +26,19 @@
     var containers = document.querySelectorAll('.app-back-to-top');
     if (containers.length === 0) return;
 
-    // Both thresholds are measured in viewports rather than pixels, because "how far
-    // has the reader travelled" and "is this page long enough to need the component"
-    // are questions about screenfuls, not about absolute pixel counts — a threshold
-    // that behaves on a laptop is meaningless on a phone or a tall external monitor.
+    // One rule, measured in viewports rather than pixels: the reader must have put very
+    // nearly a whole screenful behind them before the link appears. Until then the top of
+    // the document is still one flick of the wheel away, so offering a shortcut is noise.
     //
-    // REVEAL_AFTER_VIEWPORTS: the reader must have put very nearly a whole screenful
-    // behind them before the link appears. The top of the document is still one
-    // flick of the wheel away until then, so offering a shortcut to it is noise.
+    // Screenfuls rather than pixels because "how far has the reader travelled" is a
+    // question about screens — a pixel threshold tuned on a laptop means something quite
+    // different on a phone or a tall external monitor.
     //
-    // MIN_SCROLLABLE_VIEWPORTS: the page must offer at least a full screenful of
-    // scrolling beyond the fold before the link is eligible at all. This is the GDS
-    // guidance — "avoid using this component on short pages or on pages designed to
-    // fit the entire viewport" — expressed as a measurement the browser can make.
+    // This also delivers the GDS guidance to "avoid using this component on short pages or
+    // on pages designed to fit the entire viewport" without a second rule: a page that fits
+    // the viewport has nothing to scroll, and a page with only a third of a screen of
+    // scroll can never reach the threshold, so neither ever reveals the link.
     var REVEAL_AFTER_VIEWPORTS = 0.9;
-    var MIN_SCROLLABLE_VIEWPORTS = 1;
 
     // Flip the initialisation marker on the document root so the corresponding CSS
     // block (which hides the link) takes effect. Non-JS environments never see this
@@ -52,17 +50,7 @@
     function apply() {
         ticking = false;
 
-        // Layout reads first, DOM writes after, so the frame costs one style recalc
-        // rather than one per container. scrollHeight is re-read every time instead of
-        // being cached at start-up: content that grows or shrinks after load (lazy
-        // images settling, a <details> being opened, a filter collapsing a list) changes
-        // whether the page qualifies, and neither of those fires resize.
-        var viewport = window.innerHeight;
-        var scrollable = document.documentElement.scrollHeight - viewport;
-
-        var longEnough = scrollable >= viewport * MIN_SCROLLABLE_VIEWPORTS;
-        var scrolledFarEnough = window.scrollY > viewport * REVEAL_AFTER_VIEWPORTS;
-        var visible = longEnough && scrolledFarEnough;
+        var visible = window.scrollY > window.innerHeight * REVEAL_AFTER_VIEWPORTS;
 
         // Skip the DOM write when the visibility state didn't change since the last frame.
         // classList.toggle('is-visible', visible) is not free on low-power devices — every

--- a/tests/DfE.CheckPerformanceData.E2ETests/Web/BackToTopTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Web/BackToTopTests.cs
@@ -280,6 +280,36 @@ public sealed class BackToTopTests(PlaywrightFixture fixture) : PageTest
             "back-to-top should be revealed once a full viewport has been scrolled");
     }
 
+    // A tall browser window used to lose the link entirely. The reveal threshold was a
+    // fraction of the viewport, so a big monitor was penalised twice over: the bar went up
+    // while the same document's scrollable distance went down, and pages that comfortably
+    // showed the link on a laptop became unreachable. Drive a window taller than the
+    // article's scrollable distance and confirm the link is still reachable.
+    [Fact]
+    public async Task OnATallWindow_LinkIsStillReachable_WhenThePageOutrunsTheViewportOnlyModestly()
+    {
+        await Page.SetViewportSizeAsync(1440, 1300);
+        var response = await Page.GotoAsync($"{_fixture.BaseUrl}{TargetPath}");
+        Assert.NotNull(response);
+        Assert.Equal(200, response!.Status);
+
+        await Page.Locator(".app-back-to-top__link").WaitForAsync(new() { State = WaitForSelectorState.Attached });
+        await WaitForEnhancementAsync();
+
+        // Guard the premise: on this window the page must have LESS than a viewport of
+        // scroll, which is the shape that used to be unreachable. If seeded content grows
+        // past that the test stops covering the regression, so fail loudly instead.
+        var scrollable = await Page.EvaluateAsync<int>(
+            "() => Math.round(document.documentElement.scrollHeight - window.innerHeight)");
+        Assert.InRange(scrollable, 1, 1299);
+
+        await ScrollToAsync("document.documentElement.scrollHeight");
+
+        var state = await Page.EvaluateAsync<RevealSnap>(RevealSnapScript);
+        Assert.True(state.HasVisibleClass,
+            $"back-to-top must stay reachable on a tall window (scrollable={scrollable}px, viewport=1300px)");
+    }
+
     // Wait for the progressive enhancement to claim the page AND for the resulting fade
     // to finish. The module sets the marker on <html>, which switches the CSS from the
     // no-JS always-visible fallback to the hidden-until-revealed state — but that switch

--- a/tests/DfE.CheckPerformanceData.E2ETests/Web/BackToTopTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Web/BackToTopTests.cs
@@ -19,16 +19,24 @@ namespace DfE.CheckPerformanceData.E2ETests.Web;
 //   * At the page bottom the link releases at the natural end of the content area
 //     so it sits above the footer instead of overlapping it.
 //   * Anchor href="#top" scrolls the window back to the top.
+//   * Reveal timing follows the GDS guidance rather than firing on the first
+//     nudge of the wheel: the reader has to travel nearly a whole viewport
+//     before the link appears, and pages that fit (or nearly fit) the viewport
+//     never show it at all.
 //
 // Uses /wiki/wiki-sandbox because it's the sample seeded specifically for this kind
 // of layout check (long body, Wiki.cshtml render path). The behaviour is layout-
 // agnostic though — every Content/Wiki page picks the same partial + CSS up.
+// /guidance/short-page is its counterpart: a one-paragraph sample that fits the
+// viewport, used to pin the "never show on a short page" half of the contract.
 [Collection("E2E")]
 public sealed class BackToTopTests(PlaywrightFixture fixture) : PageTest
 {
     private readonly PlaywrightFixture _fixture = fixture;
 
     private const string TargetPath = "/wiki/wiki-sandbox";
+
+    private const string ShortPagePath = "/guidance/short-page";
 
     [Theory]
     [InlineData(1280, 900, "desktop")]
@@ -138,9 +146,12 @@ public sealed class BackToTopTests(PlaywrightFixture fixture) : PageTest
             return cs.opacity === '0' && cs.visibility === 'hidden';
         }");
 
-        // 1) After ~400px of scroll the link should be fully faded in, pinned ~50px above
-        // the viewport bottom, in the left half of the viewport.
-        await Page.EvaluateAsync("window.scrollTo(0, 400)");
+        // 1) Just past the reveal threshold the link should be fully faded in, pinned
+        // ~50px above the viewport bottom, in the left half of the viewport. 0.95 of a
+        // viewport is deliberately a shade past the 0.9 reveal point and still well
+        // short of the bottom of the article, where the sticky container releases into
+        // the flow and this geometry stops applying.
+        await Page.EvaluateAsync("window.scrollTo(0, Math.round(window.innerHeight * 0.95))");
         // Wait for the class flip + the 300ms opacity transition to complete, deterministic
         // rather than a fixed sleep — WaitForFunctionAsync polls until the predicate returns
         // truthy, so a slow CI runner and a fast local dev machine both see the same barrier.
@@ -202,8 +213,137 @@ public sealed class BackToTopTests(PlaywrightFixture fixture) : PageTest
         Assert.Equal(0, scrollY);
     }
 
+    // GDS guidance for this component: "Avoid using this component on short pages or on
+    // pages designed to fit the entire viewport." A page the reader can take in without
+    // scrolling has nothing to go back to the top of, so the link must stay away for the
+    // whole life of the page — including at the very bottom of what little scroll exists.
+    [Fact]
+    public async Task OnAShortPage_LinkNeverReveals_NotEvenAtTheBottomOfTheDocument()
+    {
+        await Page.SetViewportSizeAsync(1280, 900);
+        var response = await Page.GotoAsync($"{_fixture.BaseUrl}{ShortPagePath}");
+        Assert.NotNull(response);
+        Assert.Equal(200, response!.Status);
+
+        await Page.Locator(".app-back-to-top__link").WaitForAsync(new() { State = WaitForSelectorState.Attached });
+        await WaitForEnhancementAsync();
+
+        // Guard the fixture itself. If someone lengthens the seeded short page this test
+        // would quietly stop testing anything, so fail loudly on that instead: the page
+        // must have less than a viewport of scroll beyond the fold to be a valid subject.
+        var scrollable = await Page.EvaluateAsync<int>(
+            "() => Math.round(document.documentElement.scrollHeight - window.innerHeight)");
+        Assert.True(scrollable < 900,
+            $"/guidance/short-page is meant to fit the viewport but has {scrollable}px of scroll beyond it — " +
+            "shorten the seeded body or this test proves nothing");
+
+        // Bottom of the document is the most favourable position for a reveal — if the
+        // link stays hidden here it stays hidden everywhere on this page.
+        await ScrollToAsync("document.documentElement.scrollHeight");
+
+        var state = await Page.EvaluateAsync<RevealSnap>(RevealSnapScript);
+        Assert.False(state.HasVisibleClass,
+            "back-to-top must not reveal on a page that fits the viewport");
+        Assert.Equal("0", state.Opacity);
+        Assert.Equal("hidden", state.Visibility);
+    }
+
+    // The reveal threshold is proportional to the viewport, not a fixed pixel nudge:
+    // the reader has to travel nearly a full screen before the link appears. Pinning
+    // both sides of the boundary keeps a future tweak from sliding it back down to a
+    // scroll-and-it-pops-up value.
+    [Fact]
+    public async Task OnALongPage_StaysHidden_UntilNearlyAViewportHasBeenScrolled()
+    {
+        await Page.SetViewportSizeAsync(1280, 900);
+        var response = await Page.GotoAsync($"{_fixture.BaseUrl}{TargetPath}");
+        Assert.NotNull(response);
+        Assert.Equal(200, response!.Status);
+
+        await Page.Locator(".app-back-to-top__link").WaitForAsync(new() { State = WaitForSelectorState.Attached });
+        await WaitForEnhancementAsync();
+
+        // Half a viewport in — the reader is still reading the first screenful of the
+        // article, so the link has no business being on screen yet.
+        await ScrollToAsync("Math.round(window.innerHeight / 2)");
+
+        var halfway = await Page.EvaluateAsync<RevealSnap>(RevealSnapScript);
+        Assert.False(halfway.HasVisibleClass,
+            "back-to-top revealed after half a viewport of scroll — the threshold is too eager");
+
+        // A whole viewport in — the first screenful is behind the reader, so the link
+        // is now earning its place.
+        await ScrollToAsync("window.innerHeight");
+
+        var fullViewport = await Page.EvaluateAsync<RevealSnap>(RevealSnapScript);
+        Assert.True(fullViewport.HasVisibleClass,
+            "back-to-top should be revealed once a full viewport has been scrolled");
+    }
+
+    // Wait for the progressive enhancement to claim the page AND for the resulting fade
+    // to finish. The module sets the marker on <html>, which switches the CSS from the
+    // no-JS always-visible fallback to the hidden-until-revealed state — but that switch
+    // is a 0.3s opacity transition, so a read taken the moment the marker appears catches
+    // the link partway through fading out. Settling on the resting hidden state first is
+    // what makes a later "still hidden" assertion mean something.
+    private Task WaitForEnhancementAsync() =>
+        Page.WaitForFunctionAsync(@"() => {
+            if (document.documentElement.getAttribute('data-back-to-top-init') !== 'true') return false;
+            const c = document.querySelector('.app-back-to-top');
+            if (!c) return false;
+            const cs = getComputedStyle(c);
+            return cs.opacity === '0' && cs.visibility === 'hidden';
+        }");
+
+    // Scroll, then hold until "the offset has landed AND the module has had its say
+    // about it". Two things make this harder than awaiting a single window.scrollTo:
+    //
+    //   * The module reacts inside requestAnimationFrame, so a read taken straight after
+    //     the scroll can still be showing the previous frame's answer.
+    //   * Revealing the link changes the document height (the hidden container collapses
+    //     to height 0 and its margin with it), which moves the maximum scroll offset
+    //     underneath a scroll-to-the-bottom request.
+    //
+    // So re-issue the scroll every frame and wait for the offset to hold still for three
+    // consecutive frames. Settling on a stable offset is what both halves need, and it
+    // works for the negative assertions too — "still hidden" has no state change to await,
+    // and a fixed sleep would otherwise be the only option there.
+    private Task ScrollToAsync(string yExpression) =>
+        Page.EvaluateAsync($@"() => new Promise((resolve, reject) => {{
+            let last = -1, stable = 0, frames = 0;
+            const step = () => {{
+                window.scrollTo(0, {yExpression});
+                if (window.scrollY === last) {{
+                    if (++stable === 3) return resolve();
+                }} else {{
+                    stable = 0;
+                    last = window.scrollY;
+                }}
+                if (++frames > 300) return reject(new Error('scroll offset never settled'));
+                requestAnimationFrame(step);
+            }};
+            requestAnimationFrame(step);
+        }})");
+
+    private const string RevealSnapScript = @"() => {
+        const c = document.querySelector('.app-back-to-top');
+        const cs = getComputedStyle(c);
+        return {
+            hasVisibleClass: c.classList.contains('is-visible'),
+            opacity: cs.opacity,
+            visibility: cs.visibility
+        };
+    }";
+
     // Playwright's EvaluateAsync<T> instantiates T via reflection with a parameterless
     // constructor, so these snapshot DTOs are plain settable classes (not positional records).
+    public sealed class RevealSnap
+    {
+        public bool HasVisibleClass { get; set; }
+        public string Opacity { get; set; } = "";
+        public string Visibility { get; set; } = "";
+    }
+
     public sealed class AtTopSnap
     {
         public string Opacity { get; set; } = "";

--- a/tests/DfE.CheckPerformanceData.UnitTests/PageTree/SamplePageNodeSeederTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/PageTree/SamplePageNodeSeederTests.cs
@@ -55,13 +55,14 @@ public class SamplePageNodeSeederTests
 
         var created = await new SamplePageNodeSeeder(svc).SeedAsync();
 
-        // 4 under /wiki (3 content + 1 wiki-typed) + 3 under each of the other three roots.
-        Assert.Equal(13, created);
+        // 4 under /wiki (3 content + 1 wiki-typed) + 3 under /help + 3 under /support
+        // + 4 under /guidance (3 topic pages + the deliberately short sample).
+        Assert.Equal(14, created);
         await svc.Received(3).CreatePageAsync(wiki.Id,     Arg.Any<string>(), Arg.Any<string>(), "content", "system");
         await svc.Received(1).CreatePageAsync(wiki.Id,     "wiki-sandbox",    Arg.Any<string>(), "wiki",    "system");
         await svc.Received(3).CreatePageAsync(help.Id,     Arg.Any<string>(), Arg.Any<string>(), "content", "system");
         await svc.Received(3).CreatePageAsync(support.Id,  Arg.Any<string>(), Arg.Any<string>(), "content", "system");
-        await svc.Received(3).CreatePageAsync(guidance.Id, Arg.Any<string>(), Arg.Any<string>(), "content", "system");
+        await svc.Received(4).CreatePageAsync(guidance.Id, Arg.Any<string>(), Arg.Any<string>(), "content", "system");
     }
 
     [Fact]
@@ -72,9 +73,9 @@ public class SamplePageNodeSeederTests
         await new SamplePageNodeSeeder(svc).SeedAsync();
 
         // Every created page has both a working-content save and a publish call.
-        await svc.Received(13).SaveWorkingContentAsync(
+        await svc.Received(14).SaveWorkingContentAsync(
             Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>(), "system");
-        await svc.Received(13).PublishDraftAsync(Arg.Any<Guid>(), "system");
+        await svc.Received(14).PublishDraftAsync(Arg.Any<Guid>(), "system");
     }
 
     [Fact]


### PR DESCRIPTION
The back-to-top link revealed after 100px of scroll, so it appeared as soon as the
  reader touched the wheel and showed on pages with barely anything to scroll. GDS
  guidance is to avoid the component on short pages and on pages designed to fit the
  viewport, and the design system's own example only surfaces it once nearly a full
  screen has gone by.

  The link now appears once the reader has scrolled nearly a screenful, or halfway down
  the page, whichever comes first. The second half of that matters more than it looks: a
  threshold measured purely against the viewport penalises a tall browser window twice,
  because the bar rises while the same document's scrollable distance shrinks. A ~2000px
  guidance page is 1.3 screens of scrolling at 900px but 0.6 at 1300px, and the link
  disappeared from most of the site on a large monitor.

  Short pages are suppressed by a floor the page must clear on both counts — half a
  screen, and an absolute 600px of travel. The absolute part is needed because a page
  that fits a desktop comfortably becomes nearly two screens on a small laptop.

  Verified against every content page served locally: coverage holds at 26-31 of 41 pages
  across window heights from 660px to 1300px, with short pages suppressed at every one.

  Adds a deliberately short seeded sample page under /guidance and E2E coverage for the
  reveal threshold, the short-page suppression, and the tall-window case.

  [AB#295398](https://dfe-gov-uk.visualstudio.com/b947688b-53a4-4c90-9c43-5a5db31e313d/_workitems/edit/295398)

  Closes #249