### PR TITLE
Seed sample CMS content from an import bundle

### DIFF
--- a/src/DfE.CheckPerformanceData.Application/DfE.CheckPerformanceData.Application.csproj
+++ b/src/DfE.CheckPerformanceData.Application/DfE.CheckPerformanceData.Application.csproj
@@ -17,4 +17,11 @@
     <ItemGroup>
       <ProjectReference Include="..\DfE.CheckPerformanceData.Domain\DfE.CheckPerformanceData.Domain.csproj" />
     </ItemGroup>
+
+    <ItemGroup>
+      <!-- Sample CMS content, shipped as a content-staging bundle and replayed through the
+           importer by SamplePageNodeSeeder. Embedded so it travels with the assembly and
+           needs no deployment-relative file path. -->
+      <EmbeddedResource Include="PageTree/SeedContent/sample-content.json" />
+    </ItemGroup>
 </Project>

--- a/src/DfE.CheckPerformanceData.Application/PageTree/SampleContentSeedBundle.cs
+++ b/src/DfE.CheckPerformanceData.Application/PageTree/SampleContentSeedBundle.cs
@@ -1,0 +1,44 @@
+using System.Reflection;
+using DfE.CheckPerformanceData.Application.ContentStaging;
+
+namespace DfE.CheckPerformanceData.Application.PageTree;
+
+// Loads the sample CMS content shipped with the application. The content is a content-staging
+// bundle embedded in this assembly rather than pages assembled in C#, so what a developer gets
+// after seeding is exactly what the CMS produced when the bundle was exported — there is no
+// second, hand-written notion of what a page looks like that can drift from the editor's output.
+//
+// The file carries the sample pages only. Their parents — the four root nodes and /help/not-found
+// — are created at start-up by DefaultPageNodeSeeder and are deliberately absent here, so seeding
+// never competes with that seeder for ownership of the roots. Parentage is by the pinned root
+// Guids in DefaultPageNodeRoots, which is what lets a static file resolve against a fresh
+// database.
+//
+// To change the samples: seed an environment, edit the pages through the CMS, export a bundle
+// from /admin/content-staging, strip the roots and /help/not-found, and replace this file. Editing
+// the JSON by hand works but bypasses the guarantee above — the point of the format is that the
+// application wrote it.
+public static class SampleContentSeedBundle
+{
+    // Suffix rather than the full manifest name: the resource is prefixed with the assembly's
+    // root namespace and its folder path, and pinning the whole string here would break on a
+    // folder rename with a runtime error rather than a compile error.
+    private const string ResourceSuffix = "SeedContent.sample-content.json";
+
+    public static ContentBundle Load()
+    {
+        var assembly = typeof(SampleContentSeedBundle).Assembly;
+        var name = assembly.GetManifestResourceNames().SingleOrDefault(n => n.EndsWith(ResourceSuffix, StringComparison.Ordinal))
+            ?? throw new InvalidOperationException(
+                $"The sample content bundle is missing from {assembly.GetName().Name}. It must be declared as an " +
+                $"EmbeddedResource whose path ends with '{ResourceSuffix}'.");
+
+        using var stream = assembly.GetManifestResourceStream(name)!;
+        using var reader = new StreamReader(stream);
+        var json = reader.ReadToEnd();
+
+        return ContentStagingJson.Deserialize(json)
+            ?? throw new InvalidOperationException(
+                "The sample content bundle is present but could not be parsed as a content-staging bundle.");
+    }
+}

--- a/src/DfE.CheckPerformanceData.Application/PageTree/SamplePageNodeSeeder.cs
+++ b/src/DfE.CheckPerformanceData.Application/PageTree/SamplePageNodeSeeder.cs
@@ -1,184 +1,30 @@
-using System.Text.Json;
-using DfE.CheckPerformanceData.Application.ContentPages;
+using DfE.CheckPerformanceData.Application.ContentStaging;
 
 namespace DfE.CheckPerformanceData.Application.PageTree;
 
-// Additive, idempotent seed of a handful of published pages under each of the four default
-// root nodes (/wiki, /help, /support, /guidance). Skips any sample whose (root, segment) path
-// already exists, so re-running only fills in what has been removed. Returns the number of
-// pages actually created. Most samples are content-type (widget-tree body); a small number
-// are wiki-type (raw HTML body) so the legacy wiki render path stays exercised by tests and
-// manual browsing.
+// Additive, idempotent seed of the sample pages that ship with the application, hanging off the
+// four default root nodes (/wiki, /help, /support, /guidance). Returns the number of pages
+// actually created so the admin screen can report it.
 //
-// Seeds PageNode / PageNodeVersion rows via IPageNodeService.CreatePageAsync ->
-// SaveWorkingContentAsync -> PublishDraftAsync (NOT the retired WikiPage /
-// WikiPageVersion entities, which the DropWikiPagePlumbing migration removed).
-// "wiki" here is the PageType discriminator on PageNode, not the old WikiPage
-// entity — see PageNodeService.CreatePageAsync + the wiki-typed Content saved as
-// raw HTML for Wiki.cshtml consumption.
-public sealed class SamplePageNodeSeeder(IPageNodeService pageNodes)
+// The content itself lives in an embedded content-staging bundle (see SampleContentSeedBundle)
+// and is replayed through the ordinary import path, so seeded pages are created by exactly the
+// code that handles a bundle uploaded by an administrator. Nothing here knows how a page is
+// built — which is the point: the previous version assembled widget-tree JSON itself, and that
+// hand-rolled shape could drift from what the editor actually produces.
+//
+// Skip on collision is what makes the seed button safe to press twice: anything already sitting
+// at one of the sample identities — a developer's edits, or real content in an environment that
+// happens to share a path — is left exactly as it is. Missing items are created.
+public sealed class SamplePageNodeSeeder(IContentStagingService staging)
 {
-    public async Task<int> SeedAsync(string? userId = "system")
+    public async Task<int> SeedAsync()
     {
-        var created = 0;
-        foreach (var (rootSegment, samples) in SamplesByRoot)
-        {
-            var root = await pageNodes.GetNodeByPathAsync(rootSegment);
-            if (root is null) continue;   // DefaultPageNodeSeeder should have created it.
+        var result = await staging.ImportAsync(
+            SampleContentSeedBundle.Load(),
+            mode: ContentImportMode.Skip,
+            decisions: null,
+            newItemMode: ContentImportMode.Replace);
 
-            foreach (var sample in samples)
-            {
-                var samplePath = $"{rootSegment}/{sample.Segment}";
-                if (await pageNodes.GetNodeByPathAsync(samplePath) is not null) continue;
-
-                var node = await pageNodes.CreatePageAsync(
-                    root.Id, sample.Segment, sample.Title, sample.PageType, userId);
-
-                // Wiki pages persist the raw HTML directly; content pages persist a widget-tree
-                // JSON. Wiki.cshtml pipes the stored string through IHtmlRenderingService, and
-                // Content.cshtml deserialises via ContentPageJson — so the two shapes are mutually
-                // exclusive and the seeder must pick the right one per PageType.
-                var content   = sample.PageType == "wiki"
-                    ? sample.HtmlBody
-                    : BuildContentJson(sample.Heading, sample.HtmlBody);
-                var plainText = sample.Heading + " " + StripTags(sample.HtmlBody);
-
-                await pageNodes.SaveWorkingContentAsync(node.Id, content, plainText, userId);
-                await pageNodes.PublishDraftAsync(node.Id, userId);
-                created++;
-            }
-        }
-
-        return created;
+        return result.PageNodesCreated;
     }
-
-    // ── content builders ────────────────────────────────────────────────────
-
-    // Single-column region containing a Heading widget and a RichText widget. The shape mirrors
-    // what the editor would produce for a page authored by hand.
-    private static string BuildContentJson(string heading, string htmlBody)
-    {
-        var tree = new List<ContentNode>
-        {
-            new RegionNode
-            {
-                Layout  = RegionLayout.Single,
-                Columns =
-                [
-                    [
-                        new WidgetNode { Type = "heading",  Props = ParseProps($"{{\"level\":2,\"text\":{JsonSerializer.Serialize(heading)}}}") },
-                        new WidgetNode { Type = "richtext", Props = ParseProps($"{{\"html\":{JsonSerializer.Serialize(htmlBody)}}}") }
-                    ]
-                ]
-            }
-        };
-
-        return ContentPageJson.Serialize(tree);
-    }
-
-    private static System.Text.Json.Nodes.JsonObject ParseProps(string json) =>
-        System.Text.Json.Nodes.JsonNode.Parse(json)!.AsObject();
-
-    // Rudimentary tag stripper for the plain-text index — good enough for the tightly-scoped
-    // seed content in this file, which is authored inline without ambiguous markup (no CDATA,
-    // no <script>, no HTML comments). TODO: swap for the same HtmlToPlainText path used by
-    // IHtmlRenderingService for editor-authored content — that already handles the edge cases
-    // (CDATA sections, embedded scripts, entities) that this walker will happily misparse.
-    private static string StripTags(string html)
-    {
-        var sb = new System.Text.StringBuilder(html.Length);
-        var inTag = false;
-        foreach (var c in html)
-        {
-            if (c == '<') inTag = true;
-            else if (c == '>') inTag = false;
-            else if (!inTag) sb.Append(c);
-        }
-        return sb.ToString();
-    }
-
-    // ── sample catalogue ────────────────────────────────────────────────────
-
-    private readonly record struct SamplePage(
-        string Segment,
-        string Title,
-        string Heading,
-        string HtmlBody,
-        string PageType = "content");
-
-    // Kept as a static array of (root segment, sample list) so the enumeration order is stable —
-    // useful for tests that assert the created count and root-parenting.
-    private static readonly (string RootSegment, SamplePage[] Samples)[] SamplesByRoot =
-    [
-        ("wiki",
-        [
-            new("dsi-roles",        "DSI roles and permissions",
-                "DSI roles and permissions",
-                "<p>The service uses two DfE Sign-In roles: <strong>cypmd_content_access_user</strong> for content editors and <strong>cypmd_admin</strong> for administrators. Admin implies editor.</p>"),
-            new("rules-engine",     "Rules engine snapshot",
-                "Rules engine snapshot",
-                "<p>The rules engine picks jobs off a Postgres queue, evaluates them against a versioned rules snapshot pulled from Azure Blob Storage, and writes a decision back to the change request.</p>"),
-            new("data-pipeline",    "Data pipeline overview",
-                "Data pipeline overview",
-                "<p>Requests flow from the web app into a Postgres queue, are processed by the rules engine worker, and matched decisions raise a Zendesk ticket via the outbox.</p>"),
-            // Wiki-typed sample so Wiki.cshtml has a real page to exercise. Long-ish body with
-            // multiple headings + paragraphs so scroll-dependent features (back-to-top, in-page
-            // nav) have somewhere to breathe.
-            new("wiki-sandbox",     "Wiki sandbox page",
-                "Wiki sandbox page",
-                "<p>This page is seeded specifically so the wiki render path has real content to exercise. It stores raw HTML in the version body, unlike the widget-tree JSON that content-type pages use.</p>" +
-                "<h2>Why a dedicated wiki sample?</h2>" +
-                "<p>Most CMS pages are content-typed and rendered through <code>Content.cshtml</code>. Wiki pages take a separate code path (<code>Wiki.cshtml</code>, <code>IHtmlRenderingService</code>), and without a live wiki page nothing exercises it — regressions there wouldn't surface until someone manually created one.</p>" +
-                "<h2>Layout</h2>" +
-                "<p>Wiki pages use a 1/3–2/3 grid with a sibling-nav in the left column and the article body in the right.</p>" +
-                "<ul><li>Left column: sibling navigation</li><li>Right column: heading, subtitle, body HTML</li></ul>" +
-                "<h2>Enough words for a good scroll</h2>" +
-                "<p>The body deliberately runs long enough that a typical laptop viewport can scroll comfortably. If you want to add more test content just extend this HTML string.</p>" +
-                "<p>Paragraph two — filler so the page has scroll depth for exercising the back-to-top link and any future long-form nav behaviour.</p>" +
-                "<p>Paragraph three — additional filler so the section headings are far enough apart that the sibling nav in the sidebar has room to render the whole tree without collapsing.</p>" +
-                "<p>Paragraph four — the final paragraph before the closing heading. When you click the back-to-top link from anywhere on the page, the browser should jump straight back to the H1 at the top of this article.</p>" +
-                "<h2>End</h2>" +
-                "<p>You have reached the end. Try the back-to-top link.</p>",
-                PageType: "wiki")
-        ]),
-
-        ("help",
-        [
-            new("getting-started",  "Getting started",
-                "Getting started",
-                "<p>Sign in with your DfE Sign-In account. Once signed in you can view your school's provisional performance data and submit amendments while the checking window is open.</p>"),
-            new("submit-amendment", "Submit an amendment",
-                "Submit an amendment",
-                "<p>Open the record you want to change, click <strong>Amend</strong>, describe what should change and why, then submit. You will be notified by email when a reviewer picks it up.</p>"),
-            new("faq",              "Frequently asked questions",
-                "Frequently asked questions",
-                "<p>Common questions about account access, the checking exercise and the amendment process. Try the search box on the top of this page if you cannot find your question.</p>")
-        ]),
-
-        ("support",
-        [
-            new("contact-helpline", "Contact the helpline",
-                "Contact the helpline",
-                "<p>Raise a <strong>Contact us</strong> request from the home page, or telephone the schools' helpline during opening hours. Include your DfE number so we can find your school's records.</p>"),
-            new("common-issues",    "Common issues",
-                "Common issues",
-                "<p>Sign-in problems, missing school records, and unexpected performance figures are the three most common tickets. Check the guidance before raising a helpline request.</p>"),
-            new("security-advice",  "Security advice",
-                "Security advice",
-                "<p>Follow DfE security guidance when handling pupil-level data. Do not share your sign-in credentials and only access the service from a trusted device.</p>")
-        ]),
-
-        ("guidance",
-        [
-            new("ks2-checking",     "KS2 checking window",
-                "KS2 checking window",
-                "<p>The KS2 checking exercise runs each year for primary schools. Review the provisional results for your school and submit amendments where the data looks wrong.</p>"),
-            new("ks4-checking",     "KS4 checking window",
-                "KS4 checking window",
-                "<p>The main KS4 checking exercise covers secondary school results. A separate re-checking window opens in June for results affected by appeals and re-marks.</p>"),
-            new("post-16",          "Post-16 performance data",
-                "Post-16 performance data",
-                "<p>Performance results for sixth-form colleges, FE colleges and school sixth forms. Data is provisional until the checking window closes.</p>")
-        ])
-    ];
 }

--- a/src/DfE.CheckPerformanceData.Application/PageTree/SeedContent/sample-content.json
+++ b/src/DfE.CheckPerformanceData.Application/PageTree/SeedContent/sample-content.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "cpd-content-v2",
+  "schemaVersion": 2,
+  "pageNodes": [
+    {
+      "id": "6d050397-1874-4744-85f6-10cb5437827a",
+      "parentId": "00000000-cd94-4a01-8f01-000000000001",
+      "segment": "contact-helpline",
+      "title": "Contact the helpline",
+      "pageType": "content",
+      "sortOrder": 0,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:36.120072Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"Contact the helpline\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003ERaise a \\u003Cstrong\\u003EContact us\\u003C/strong\\u003E request from the home page, or telephone the schools\\u0027 helpline during opening hours. Include your DfE number so we can find your school\\u0027s records.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "Contact the helpline Raise a Contact us request from the home page, or telephone the schools' helpline during opening hours. Include your DfE number so we can find your school's records."
+        }
+      ]
+    },
+    {
+      "id": "d0e26a32-c0b2-466c-a1c5-a518f1ecb406",
+      "parentId": "00000000-cd94-4a01-8f01-000000000001",
+      "segment": "common-issues",
+      "title": "Common issues",
+      "pageType": "content",
+      "sortOrder": 1,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:36.200998Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"Common issues\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003ESign-in problems, missing school records, and unexpected performance figures are the three most common tickets. Check the guidance before raising a helpline request.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "Common issues Sign-in problems, missing school records, and unexpected performance figures are the three most common tickets. Check the guidance before raising a helpline request."
+        }
+      ]
+    },
+    {
+      "id": "62207346-eedb-449c-bce3-edca2dce8c3c",
+      "parentId": "00000000-cd94-4a01-8f01-000000000001",
+      "segment": "security-advice",
+      "title": "Security advice",
+      "pageType": "content",
+      "sortOrder": 2,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:36.252392Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"Security advice\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003EFollow DfE security guidance when handling pupil-level data. Do not share your sign-in credentials and only access the service from a trusted device.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "Security advice Follow DfE security guidance when handling pupil-level data. Do not share your sign-in credentials and only access the service from a trusted device."
+        }
+      ]
+    },
+    {
+      "id": "b4390cb5-b5f2-4de8-933b-c7ac35e6d1f6",
+      "parentId": "00000000-cd94-4a01-8f01-000000000002",
+      "segment": "dsi-roles",
+      "title": "DSI roles and permissions",
+      "pageType": "content",
+      "sortOrder": 0,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:35.668818Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"DSI roles and permissions\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003EThe service uses two DfE Sign-In roles: \\u003Cstrong\\u003Ecypmd_content_access_user\\u003C/strong\\u003E for content editors and \\u003Cstrong\\u003Ecypmd_admin\\u003C/strong\\u003E for administrators. Admin implies editor.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "DSI roles and permissions The service uses two DfE Sign-In roles: cypmd_content_access_user for content editors and cypmd_admin for administrators. Admin implies editor."
+        }
+      ]
+    },
+    {
+      "id": "83d8f8ec-52d0-4673-b324-8d1e9cd6f940",
+      "parentId": "00000000-cd94-4a01-8f01-000000000002",
+      "segment": "rules-engine",
+      "title": "Rules engine snapshot",
+      "pageType": "content",
+      "sortOrder": 1,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:35.711079Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"Rules engine snapshot\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003EThe rules engine picks jobs off a Postgres queue, evaluates them against a versioned rules snapshot pulled from Azure Blob Storage, and writes a decision back to the change request.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "Rules engine snapshot The rules engine picks jobs off a Postgres queue, evaluates them against a versioned rules snapshot pulled from Azure Blob Storage, and writes a decision back to the change request."
+        }
+      ]
+    },
+    {
+      "id": "26a8a9a5-de81-4ef0-bc3e-0f2a343917e2",
+      "parentId": "00000000-cd94-4a01-8f01-000000000002",
+      "segment": "data-pipeline",
+      "title": "Data pipeline overview",
+      "pageType": "content",
+      "sortOrder": 2,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:35.759572Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"Data pipeline overview\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003ERequests flow from the web app into a Postgres queue, are processed by the rules engine worker, and matched decisions raise a Zendesk ticket via the outbox.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "Data pipeline overview Requests flow from the web app into a Postgres queue, are processed by the rules engine worker, and matched decisions raise a Zendesk ticket via the outbox."
+        }
+      ]
+    },
+    {
+      "id": "4cfa30c7-ee17-4c28-a540-67f4c6402b21",
+      "parentId": "00000000-cd94-4a01-8f01-000000000002",
+      "segment": "wiki-sandbox",
+      "title": "Wiki sandbox page",
+      "pageType": "wiki",
+      "sortOrder": 3,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:35.812918Z",
+          "content": "<p>This page is seeded specifically so the wiki render path has real content to exercise. It stores raw HTML in the version body, unlike the widget-tree JSON that content-type pages use.</p><h2>Why a dedicated wiki sample?</h2><p>Most CMS pages are content-typed and rendered through <code>Content.cshtml</code>. Wiki pages take a separate code path (<code>Wiki.cshtml</code>, <code>IHtmlRenderingService</code>), and without a live wiki page nothing exercises it — regressions there wouldn't surface until someone manually created one.</p><h2>Layout</h2><p>Wiki pages use a 1/3–2/3 grid with a sibling-nav in the left column and the article body in the right.</p><ul><li>Left column: sibling navigation</li><li>Right column: heading, subtitle, body HTML</li></ul><h2>Enough words for a good scroll</h2><p>The body deliberately runs long enough that a typical laptop viewport can scroll comfortably. If you want to add more test content just extend this HTML string.</p><p>Paragraph two — filler so the page has scroll depth for exercising the back-to-top link and any future long-form nav behaviour.</p><p>Paragraph three — additional filler so the section headings are far enough apart that the sibling nav in the sidebar has room to render the whole tree without collapsing.</p><p>Paragraph four — the final paragraph before the closing heading. When you click the back-to-top link from anywhere on the page, the browser should jump straight back to the H1 at the top of this article.</p><h2>End</h2><p>You have reached the end. Try the back-to-top link.</p>",
+          "bodyPlainText": "Wiki sandbox page This page is seeded specifically so the wiki render path has real content to exercise. It stores raw HTML in the version body, unlike the widget-tree JSON that content-type pages use.Why a dedicated wiki sample?Most CMS pages are content-typed and rendered through Content.cshtml. Wiki pages take a separate code path (Wiki.cshtml, IHtmlRenderingService), and without a live wiki page nothing exercises it — regressions there wouldn't surface until someone manually created one.LayoutWiki pages use a 1/3–2/3 grid with a sibling-nav in the left column and the article body in the right.Left column: sibling navigationRight column: heading, subtitle, body HTMLEnough words for a good scrollThe body deliberately runs long enough that a typical laptop viewport can scroll comfortably. If you want to add more test content just extend this HTML string.Paragraph two — filler so the page has scroll depth for exercising the back-to-top link and any future long-form nav behaviour.Paragraph three — additional filler so the section headings are far enough apart that the sibling nav in the sidebar has room to render the whole tree without collapsing.Paragraph four — the final paragraph before the closing heading. When you click the back-to-top link from anywhere on the page, the browser should jump straight back to the H1 at the top of this article.EndYou have reached the end. Try the back-to-top link."
+        }
+      ]
+    },
+    {
+      "id": "12f200c0-576e-4196-9116-f201203314bb",
+      "parentId": "00000000-cd94-4a01-8f01-000000000003",
+      "segment": "getting-started",
+      "title": "Getting started",
+      "pageType": "content",
+      "sortOrder": 1,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:35.861562Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"Getting started\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003ESign in with your DfE Sign-In account. Once signed in you can view your school\\u0027s provisional performance data and submit amendments while the checking window is open.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "Getting started Sign in with your DfE Sign-In account. Once signed in you can view your school's provisional performance data and submit amendments while the checking window is open."
+        }
+      ]
+    },
+    {
+      "id": "85613342-0550-418a-ac0e-a9124d4ffa34",
+      "parentId": "00000000-cd94-4a01-8f01-000000000003",
+      "segment": "submit-amendment",
+      "title": "Submit an amendment",
+      "pageType": "content",
+      "sortOrder": 2,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:35.955237Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"Submit an amendment\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003EOpen the record you want to change, click \\u003Cstrong\\u003EAmend\\u003C/strong\\u003E, describe what should change and why, then submit. You will be notified by email when a reviewer picks it up.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "Submit an amendment Open the record you want to change, click Amend, describe what should change and why, then submit. You will be notified by email when a reviewer picks it up."
+        }
+      ]
+    },
+    {
+      "id": "e6e70976-be7c-4b8f-9a39-6265aaf73139",
+      "parentId": "00000000-cd94-4a01-8f01-000000000003",
+      "segment": "faq",
+      "title": "Frequently asked questions",
+      "pageType": "content",
+      "sortOrder": 3,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:36.070513Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"Frequently asked questions\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003ECommon questions about account access, the checking exercise and the amendment process. Try the search box on the top of this page if you cannot find your question.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "Frequently asked questions Common questions about account access, the checking exercise and the amendment process. Try the search box on the top of this page if you cannot find your question."
+        }
+      ]
+    },
+    {
+      "id": "dbb7c225-ffba-46b3-863a-18619cb29760",
+      "parentId": "00000000-cd94-4a01-8f01-000000000004",
+      "segment": "ks2-checking",
+      "title": "KS2 checking window",
+      "pageType": "content",
+      "sortOrder": 0,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:36.308689Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"KS2 checking window\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003EThe KS2 checking exercise runs each year for primary schools. Review the provisional results for your school and submit amendments where the data looks wrong.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "KS2 checking window The KS2 checking exercise runs each year for primary schools. Review the provisional results for your school and submit amendments where the data looks wrong."
+        }
+      ]
+    },
+    {
+      "id": "f47e9cd8-5bd5-4ef0-a215-01f1e25ed744",
+      "parentId": "00000000-cd94-4a01-8f01-000000000004",
+      "segment": "ks4-checking",
+      "title": "KS4 checking window",
+      "pageType": "content",
+      "sortOrder": 1,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:36.36472Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"KS4 checking window\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003EThe main KS4 checking exercise covers secondary school results. A separate re-checking window opens in June for results affected by appeals and re-marks.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "KS4 checking window The main KS4 checking exercise covers secondary school results. A separate re-checking window opens in June for results affected by appeals and re-marks."
+        }
+      ]
+    },
+    {
+      "id": "20966309-f74b-421c-aabd-7f68953bf6b7",
+      "parentId": "00000000-cd94-4a01-8f01-000000000004",
+      "segment": "post-16",
+      "title": "Post-16 performance data",
+      "pageType": "content",
+      "sortOrder": 2,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T18:56:36.441592Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"Post-16 performance data\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003EPerformance results for sixth-form colleges, FE colleges and school sixth forms. Data is provisional until the checking window closes.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "Post-16 performance data Performance results for sixth-form colleges, FE colleges and school sixth forms. Data is provisional until the checking window closes."
+        }
+      ]
+    }
+  ],
+  "contentBlocks": []
+}

--- a/src/DfE.CheckPerformanceData.Application/PageTree/SeedContent/sample-content.json
+++ b/src/DfE.CheckPerformanceData.Application/PageTree/SeedContent/sample-content.json
@@ -235,6 +235,24 @@
           "bodyPlainText": "Post-16 performance data Performance results for sixth-form colleges, FE colleges and school sixth forms. Data is provisional until the checking window closes."
         }
       ]
+    },
+    {
+      "id": "ca9e1bc3-ed66-40d0-8313-cb6a28971d3a",
+      "parentId": "00000000-cd94-4a01-8f01-000000000004",
+      "segment": "short-page",
+      "title": "Short page",
+      "pageType": "content",
+      "sortOrder": 3,
+      "appearInSearch": true,
+      "versions": [
+        {
+          "versionId": 1,
+          "minorVersion": 0,
+          "publishFrom": "2026-08-10T19:53:42.999299Z",
+          "content": "[\n  {\n    \"kind\": \"region\",\n    \"layout\": \"single\",\n    \"columns\": [\n      [\n        {\n          \"kind\": \"widget\",\n          \"type\": \"heading\",\n          \"props\": {\n            \"level\": 2,\n            \"text\": \"Short page\"\n          }\n        },\n        {\n          \"kind\": \"widget\",\n          \"type\": \"richtext\",\n          \"props\": {\n            \"html\": \"\\u003Cp\\u003EA deliberately short page. There is not enough content here to scroll, so no back-to-top link should appear.\\u003C/p\\u003E\"\n          }\n        }\n      ]\n    ]\n  }\n]",
+          "bodyPlainText": "Short page A deliberately short page. There is not enough content here to scroll, so no back-to-top link should appear."
+        }
+      ]
     }
   ],
   "contentBlocks": []

--- a/src/DfE.CheckPerformanceData.Web/Controllers/PageTreeAdminController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/PageTreeAdminController.cs
@@ -307,7 +307,7 @@ public sealed class PageTreeAdminController(
     [RequireAdminSection(AdminNavKeys.SeedSamplePages)]
     public async Task<IActionResult> SampleSeed()
     {
-        var created = await samplePageSeeder.SeedAsync(User?.Identity?.Name);
+        var created = await samplePageSeeder.SeedAsync();
         TempData["SampleSeedResult"] = created switch
         {
             0 => "Sample pages are already present. Nothing was added.",

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/PageTree/SamplePageNodeSeederEntityTypeTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/PageTree/SamplePageNodeSeederEntityTypeTests.cs
@@ -1,3 +1,5 @@
+using DfE.CheckPerformanceData.Application.Common;
+using DfE.CheckPerformanceData.Application.ContentStaging;
 using DfE.CheckPerformanceData.Application.PageTree;
 using DfE.CheckPerformanceData.IntegrationTests.Fixtures;
 using DfE.CheckPerformanceData.Persistence.Repositories;
@@ -9,9 +11,11 @@ namespace DfE.CheckPerformanceData.IntegrationTests.PageTree;
 // Verifies the sample-page seeder writes to the CURRENT content-type entities
 // (PageNode + PageNodeVersion) and NOT to the retired WikiPage / WikiPageVersion tables
 // that the DropWikiPagePlumbing migration removed. Guards against a future regression
-// where someone re-plumbs the seeder onto the old tables (there is no code path to do
-// so today — the seeder goes through IPageNodeService — but pinning the invariant on
-// a real Postgres schema catches the day someone would.
+// where someone re-plumbs the seeder onto the old tables.
+//
+// Also the end-to-end proof that the shipped bundle actually seeds: the samples are data in an
+// embedded file, so nothing at compile time guarantees they land as rows. Running the real
+// importer against a real Postgres schema is the only thing that does.
 [Collection(nameof(PostgresCollection))]
 public sealed class SamplePageNodeSeederEntityTypeTests
 {
@@ -34,28 +38,23 @@ public sealed class SamplePageNodeSeederEntityTypeTests
     {
         await ResetAsync();
 
-        // Seed the four root nodes the sample catalogue references (/wiki, /help, /support,
-        // /guidance). SamplePageNodeSeeder skips a whole root when its GetNodeByPathAsync
-        // lookup returns null, so without these the assertion below would be trivially zero.
+        // Create the roots exactly as production start-up does. This has to be DefaultPageNodeSeeder
+        // rather than ad-hoc CreatePageAsync calls: the bundle references its parents by the pinned
+        // Guids in DefaultPageNodeRoots, so roots created with fresh Guids would leave every sample
+        // an orphan and the seed would silently do nothing.
         await using (var ctx = _fixture.CreateContext())
         {
             var pageRepo = new PageNodeRepository(ctx);
-            var pageSvc = new PageNodeService(pageRepo);
-            foreach (var segment in new[] { "wiki", "help", "support", "guidance" })
-            {
-                await pageSvc.CreatePageAsync(null, segment, segment, "folder", userId: "seed");
-            }
+            await new DefaultPageNodeSeeder(new PageNodeService(pageRepo), pageRepo).SeedAsync();
         }
 
-        // Run the seeder against the same context factory as the production controller.
+        int created;
         await using (var ctx = _fixture.CreateContext())
         {
-            var pageRepo = new PageNodeRepository(ctx);
-            var pageSvc = new PageNodeService(pageRepo);
-            var seeder = new SamplePageNodeSeeder(pageSvc);
-            var created = await seeder.SeedAsync(userId: "seed-test");
-            Assert.True(created > 0,
-                $"Seeder should create at least one page under the four roots; got {created}.");
+            var seeder = new SamplePageNodeSeeder(BuildStaging(ctx));
+            created = await seeder.SeedAsync();
+            Assert.True(created >= 13,
+                $"Seeder should create every sample page under the four roots; got {created}.");
         }
 
         await using var conn = new NpgsqlConnection(_fixture.ConnectionString);
@@ -67,9 +66,16 @@ public sealed class SamplePageNodeSeederEntityTypeTests
         var pageNodeVersionCount = await ScalarLongAsync(conn,
             "SELECT COUNT(*) FROM \"PageNodeVersions\";");
         Assert.True(pageNodeCount >= 13,
-            $"Expected at least 13 sample-page PageNode rows (4 wiki + 3+3+3 others); got {pageNodeCount}.");
+            $"Expected at least 13 sample-page PageNode rows; got {pageNodeCount}.");
         Assert.True(pageNodeVersionCount >= 13,
-            $"Expected at least 13 PageNodeVersion rows (one working + one published per sample); got {pageNodeVersionCount}.");
+            $"Expected at least 13 PageNodeVersion rows; got {pageNodeVersionCount}.");
+
+        // Every sample must end up published, or it 404s on the front end and the samples are
+        // useless for browsing and for the browser tests that navigate to them.
+        var publishedCount = await ScalarLongAsync(conn,
+            "SELECT COUNT(*) FROM \"PageNodeVersions\" WHERE \"PublishFrom\" IS NOT NULL;");
+        Assert.True(publishedCount >= 13,
+            $"Expected every sample to have a published version; got {publishedCount}.");
 
         // Retired wiki tables must not exist in the current schema — the DropWikiPagePlumbing
         // migration removed them. Query information_schema.tables so the assertion works
@@ -80,6 +86,49 @@ public sealed class SamplePageNodeSeederEntityTypeTests
               AND table_name IN ('WikiPages', 'WikiPageVersions', 'wiki_pages', 'wiki_page_versions');");
         Assert.Equal(0L, wikiPagesTableExists);
     }
+
+    // Pressing the seed button twice must not duplicate pages or overwrite what is already there.
+    // The old seeder got this from a path-existence check; the replacement gets it from the
+    // importer's Skip mode, so the guarantee is worth re-pinning against a real database.
+    [Fact]
+    public async Task SeedAsync_IsIdempotent_AndLeavesExistingContentAlone()
+    {
+        await ResetAsync();
+
+        await using (var ctx = _fixture.CreateContext())
+        {
+            var pageRepo = new PageNodeRepository(ctx);
+            await new DefaultPageNodeSeeder(new PageNodeService(pageRepo), pageRepo).SeedAsync();
+        }
+
+        await using (var ctx = _fixture.CreateContext())
+        {
+            await new SamplePageNodeSeeder(BuildStaging(ctx)).SeedAsync();
+        }
+
+        long afterFirst;
+        await using (var conn0 = new NpgsqlConnection(_fixture.ConnectionString))
+        {
+            await conn0.OpenAsync();
+            afterFirst = await ScalarLongAsync(conn0, "SELECT COUNT(*) FROM \"PageNodes\";");
+        }
+
+        int createdOnSecondRun;
+        await using (var ctx = _fixture.CreateContext())
+        {
+            createdOnSecondRun = await new SamplePageNodeSeeder(BuildStaging(ctx)).SeedAsync();
+        }
+
+        Assert.Equal(0, createdOnSecondRun);
+
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionString);
+        await conn.OpenAsync();
+        var afterSecond = await ScalarLongAsync(conn, "SELECT COUNT(*) FROM \"PageNodes\";");
+        Assert.Equal(afterFirst, afterSecond);
+    }
+
+    private static ContentStagingService BuildStaging(DfE.CheckPerformanceData.Persistence.Contexts.IPortalDbContext ctx) =>
+        new(new PageNodeRepository(ctx), new ContentBlockRepository(ctx), new HtmlRenderingService());
 
     private static async Task<long> ScalarLongAsync(NpgsqlConnection conn, string sql)
     {

--- a/tests/DfE.CheckPerformanceData.UnitTests/PageTree/SampleContentSeedBundleTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/PageTree/SampleContentSeedBundleTests.cs
@@ -1,0 +1,102 @@
+using DfE.CheckPerformanceData.Application.ContentStaging;
+using DfE.CheckPerformanceData.Application.PageTree;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.PageTree;
+
+// The sample content shipped with the application is a content-staging bundle rather than pages
+// assembled in C#, so these tests guard the properties the loader and the import replay depend
+// on. A bundle is data: nothing in the compiler checks it, and a malformed or stale file would
+// otherwise surface as an empty page tree on a developer's first run.
+public class SampleContentSeedBundleTests
+{
+    [Fact]
+    public void Bundle_IsEmbeddedAndParses()
+    {
+        var bundle = SampleContentSeedBundle.Load();
+
+        Assert.NotNull(bundle);
+        Assert.NotEmpty(bundle.PageNodes);
+    }
+
+    // The bundle format is versioned and the importer rejects anything but the current shape.
+    // If the schema moves on, this fails immediately and points at the file that needs
+    // regenerating — rather than the application quietly seeding nothing.
+    [Fact]
+    public void Bundle_DeclaresTheSchemaVersionTheImporterAccepts()
+    {
+        var bundle = SampleContentSeedBundle.Load();
+
+        Assert.Equal(ContentBundle.CurrentSchemaVersion, bundle.SchemaVersion);
+    }
+
+    // Every sample hangs off one of the roots that DefaultPageNodeSeeder creates at start-up,
+    // referenced by the pinned Guid rather than by path. An import resolves parents by Guid, so a
+    // sample parented to anything else would be dropped as an orphan on a fresh database.
+    [Fact]
+    public void EverySamplePage_IsParentedToAPinnedRoot()
+    {
+        var bundle = SampleContentSeedBundle.Load();
+        var roots = DefaultPageNodeRoots.All.Select(r => r.Id).ToHashSet();
+
+        foreach (var page in bundle.PageNodes)
+        {
+            Assert.True(page.ParentId.HasValue,
+                $"sample '{page.Segment}' has no parent — the roots come from the start-up seeder, not this bundle");
+            Assert.True(roots.Contains(page.ParentId!.Value),
+                $"sample '{page.Segment}' is parented to {page.ParentId}, which is not one of the pinned roots");
+        }
+    }
+
+    // Samples exist so a developer or a browser test has real content to look at, which means
+    // published content — a draft-only page 404s on the front end.
+    [Fact]
+    public void EverySamplePage_HasAPublishedVersion()
+    {
+        var bundle = SampleContentSeedBundle.Load();
+
+        foreach (var page in bundle.PageNodes)
+        {
+            Assert.True(page.Versions.Any(v => v.PublishFrom is not null),
+                $"sample '{page.Segment}' has no published version, so it would 404 after seeding");
+        }
+    }
+
+    // The wiki render path takes a different code path from content pages (raw HTML through
+    // IHtmlRenderingService rather than a widget tree), and it only stays exercised while at
+    // least one wiki-typed sample exists.
+    [Fact]
+    public void Bundle_KeepsAWikiTypedSample_SoTheWikiRenderPathStaysCovered()
+    {
+        var bundle = SampleContentSeedBundle.Load();
+
+        Assert.Contains(bundle.PageNodes, p => p.PageType == "wiki");
+    }
+
+    // Two pages under the same parent with the same segment would collide on path. Nothing in
+    // the bundle format prevents it, and the failure at import time is obscure.
+    [Fact]
+    public void Bundle_HasNoDuplicateSegmentsUnderTheSameParent()
+    {
+        var bundle = SampleContentSeedBundle.Load();
+
+        var duplicates = bundle.PageNodes
+            .GroupBy(p => (p.ParentId, p.Segment.ToLowerInvariant()))
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key.Item2)
+            .ToList();
+
+        Assert.Empty(duplicates);
+    }
+
+    // Ids are baked into the committed file on purpose, for the same reason the roots are pinned:
+    // every environment seeded from this bundle gets the same page identities, so a later
+    // content-staging import updates those rows instead of adopting them via the path fallback.
+    [Fact]
+    public void EverySamplePage_HasAStableNonEmptyId()
+    {
+        var bundle = SampleContentSeedBundle.Load();
+
+        Assert.All(bundle.PageNodes, p => Assert.NotEqual(Guid.Empty, p.Id));
+        Assert.Equal(bundle.PageNodes.Count, bundle.PageNodes.Select(p => p.Id).Distinct().Count());
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/PageTree/SamplePageNodeSeederTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/PageTree/SamplePageNodeSeederTests.cs
@@ -1,136 +1,83 @@
+using DfE.CheckPerformanceData.Application.ContentStaging;
 using DfE.CheckPerformanceData.Application.PageTree;
 using NSubstitute;
 
 namespace DfE.CheckPerformanceData.Application.UnitTests.PageTree;
 
+// The seeder replays the shipped sample-content bundle through the content-staging importer
+// rather than assembling pages itself, so what is worth pinning here is the contract it hands to
+// the importer — the modes decide whether re-seeding is additive or destructive — and how it
+// reports back to the admin screen. What the bundle actually contains is covered by
+// SampleContentSeedBundleTests.
 public class SamplePageNodeSeederTests
 {
-    private static PageNodeDto Root(string segment) => new()
+    private static (SamplePageNodeSeeder Seeder, IContentStagingService Staging) Build(
+        ContentImportResult? result = null)
     {
-        Id       = Guid.NewGuid(),
-        Segment  = segment,
-        Path     = segment,
-        Title    = segment,
-        PageType = "content"
-    };
+        var staging = Substitute.For<IContentStagingService>();
+        staging.ImportAsync(
+                Arg.Any<ContentBundle>(),
+                Arg.Any<ContentImportMode>(),
+                Arg.Any<IReadOnlyDictionary<Guid, ContentImportMode>?>(),
+                Arg.Any<ContentImportMode>())
+            .Returns(result ?? new ContentImportResult { PageNodesCreated = 13 });
 
-    private static IPageNodeService WithRoots(params PageNodeDto[] roots)
+        return (new SamplePageNodeSeeder(staging), staging);
+    }
+
+    // Skip on collision is what makes re-seeding safe: a developer who has edited a sample page,
+    // or an environment carrying real content at the same path, must not have it overwritten by
+    // pressing the seed button. Replace for new items means "create the ones that are missing".
+    [Fact]
+    public async Task Seeds_Additively_LeavingExistingContentAlone()
     {
-        var svc = Substitute.For<IPageNodeService>();
+        var (seeder, staging) = Build();
 
-        // Root lookups return the supplied stubs.
-        foreach (var r in roots)
-        {
-            var captured = r;
-            svc.GetNodeByPathAsync(captured.Path).Returns(captured);
-        }
+        await seeder.SeedAsync();
 
-        // Any other path — the child sample lookups — returns null so the seeder creates them.
-        svc.GetNodeByPathAsync(Arg.Is<string>(p => !roots.Any(r => r.Path == p)))
-           .Returns((PageNodeDto?)null);
-
-        // Create returns a stub with a fresh id.
-        svc.CreatePageAsync(default, default!, default!, default!, default)
-           .ReturnsForAnyArgs(ci => new PageNodeDto
-           {
-               Id       = Guid.NewGuid(),
-               Segment  = (string)ci[1]!,
-               Path     = "x",
-               Title    = (string)ci[2]!,
-               PageType = (string)ci[3]!,
-               ParentId = (Guid?)ci[0]
-           });
-
-        return svc;
+        await staging.Received(1).ImportAsync(
+            Arg.Any<ContentBundle>(),
+            ContentImportMode.Skip,
+            Arg.Any<IReadOnlyDictionary<Guid, ContentImportMode>?>(),
+            ContentImportMode.Replace);
     }
 
     [Fact]
-    public async Task WhenAllRootsPresent_SeedsExpectedPagesUnderEachRoot()
+    public async Task PassesTheShippedBundle_ToTheImporter()
     {
-        var wiki     = Root("wiki");
-        var help     = Root("help");
-        var support  = Root("support");
-        var guidance = Root("guidance");
-        var svc = WithRoots(wiki, help, support, guidance);
+        var (seeder, staging) = Build();
 
-        var created = await new SamplePageNodeSeeder(svc).SeedAsync();
+        await seeder.SeedAsync();
 
-        // 4 under /wiki (3 content + 1 wiki-typed) + 3 under each of the other three roots.
-        Assert.Equal(13, created);
-        await svc.Received(3).CreatePageAsync(wiki.Id,     Arg.Any<string>(), Arg.Any<string>(), "content", "system");
-        await svc.Received(1).CreatePageAsync(wiki.Id,     "wiki-sandbox",    Arg.Any<string>(), "wiki",    "system");
-        await svc.Received(3).CreatePageAsync(help.Id,     Arg.Any<string>(), Arg.Any<string>(), "content", "system");
-        await svc.Received(3).CreatePageAsync(support.Id,  Arg.Any<string>(), Arg.Any<string>(), "content", "system");
-        await svc.Received(3).CreatePageAsync(guidance.Id, Arg.Any<string>(), Arg.Any<string>(), "content", "system");
+        await staging.Received(1).ImportAsync(
+            Arg.Is<ContentBundle>(b =>
+                b.SchemaVersion == ContentBundle.CurrentSchemaVersion && b.PageNodes.Count > 0),
+            Arg.Any<ContentImportMode>(),
+            Arg.Any<IReadOnlyDictionary<Guid, ContentImportMode>?>(),
+            Arg.Any<ContentImportMode>());
     }
 
+    // The admin screen reports "Added N sample pages", so the seeder returns pages created — not
+    // pages skipped, and not content blocks.
     [Fact]
-    public async Task EachCreatedPageIsPublishedWithAWorkingContentSave()
+    public async Task ReturnsTheNumberOfPagesCreated()
     {
-        var svc = WithRoots(Root("wiki"), Root("help"), Root("support"), Root("guidance"));
+        var (seeder, _) = Build(new ContentImportResult { PageNodesCreated = 4, PageNodesSkipped = 9 });
 
-        await new SamplePageNodeSeeder(svc).SeedAsync();
+        var created = await seeder.SeedAsync();
 
-        // Every created page has both a working-content save and a publish call.
-        await svc.Received(13).SaveWorkingContentAsync(
-            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>(), "system");
-        await svc.Received(13).PublishDraftAsync(Arg.Any<Guid>(), "system");
+        Assert.Equal(4, created);
     }
 
+    // Re-running on a fully seeded environment adds nothing, which the admin screen renders as
+    // "Sample pages are already present."
     [Fact]
-    public async Task WhenRootMissing_SkipsThatRootsSamples()
+    public async Task ReturnsZero_WhenEverySampleIsAlreadyPresent()
     {
-        // Only /wiki exists — the other three roots are missing.
-        var svc = WithRoots(Root("wiki"));
+        var (seeder, _) = Build(new ContentImportResult { PageNodesCreated = 0, PageNodesSkipped = 13 });
 
-        var created = await new SamplePageNodeSeeder(svc).SeedAsync();
-
-        Assert.Equal(4, created);   // 3 content + 1 wiki under /wiki
-        await svc.Received(3).CreatePageAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>(), "content", "system");
-        await svc.Received(1).CreatePageAsync(Arg.Any<Guid>(), "wiki-sandbox",    Arg.Any<string>(), "wiki",    "system");
-    }
-
-    [Fact]
-    public async Task IsIdempotent_SkipsSamplesWhosePathAlreadyExists()
-    {
-        // /wiki/dsi-roles already exists. The seeder should skip that one and create the rest of
-        // the /wiki set — 4 samples minus the pre-existing one.
-        var svc = Substitute.For<IPageNodeService>();
-        var wiki = Root("wiki");
-        var existing = new PageNodeDto
-        {
-            Id = Guid.NewGuid(), Segment = "dsi-roles", Path = "wiki/dsi-roles",
-            Title = "Existing", PageType = "content", ParentId = wiki.Id
-        };
-        svc.GetNodeByPathAsync("wiki").Returns(wiki);
-        svc.GetNodeByPathAsync("wiki/dsi-roles").Returns(existing);
-        svc.GetNodeByPathAsync(Arg.Is<string>(p => p != "wiki" && p != "wiki/dsi-roles")).Returns((PageNodeDto?)null);
-        svc.CreatePageAsync(default, default!, default!, default!, default)
-           .ReturnsForAnyArgs(ci => new PageNodeDto
-           {
-               Id = Guid.NewGuid(), Segment = (string)ci[1]!, Path = "x",
-               Title = (string)ci[2]!, PageType = (string)ci[3]!, ParentId = (Guid?)ci[0]
-           });
-
-        var created = await new SamplePageNodeSeeder(svc).SeedAsync();
-
-        Assert.Equal(3, created);
-        await svc.DidNotReceive().CreatePageAsync(wiki.Id, "dsi-roles", Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
-    }
-
-    [Fact]
-    public async Task ReRunOnFullyPopulatedTree_CreatesZero()
-    {
-        var svc = Substitute.For<IPageNodeService>();
-        svc.GetNodeByPathAsync(Arg.Any<string>()).Returns(ci => new PageNodeDto
-        {
-            Id = Guid.NewGuid(), Segment = "x", Path = (string)ci[0]!,
-            Title = "x", PageType = "content"
-        });
-
-        var created = await new SamplePageNodeSeeder(svc).SeedAsync();
+        var created = await seeder.SeedAsync();
 
         Assert.Equal(0, created);
-        await svc.DidNotReceiveWithAnyArgs().CreatePageAsync(default, default!, default!, default!, default);
     }
 }

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/PageTreeAdminControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/PageTreeAdminControllerTests.cs
@@ -24,7 +24,8 @@ public sealed class PageTreeAdminControllerTests
     private readonly IHtmlRenderingService _renderer = Substitute.For<IHtmlRenderingService>();
     private readonly IPageNodeContentEditor _contentEditor = Substitute.For<IPageNodeContentEditor>();
     private readonly ISettingService _settings = Substitute.For<ISettingService>();
-    private readonly SamplePageNodeSeeder _sampleSeeder = new(Substitute.For<IPageNodeService>());
+    private readonly SamplePageNodeSeeder _sampleSeeder =
+        new(Substitute.For<DfE.CheckPerformanceData.Application.ContentStaging.IContentStagingService>());
 
     private PageTreeAdminController Sut(PageNodePathValidator? validator = null)
     {


### PR DESCRIPTION
`SamplePageNodeSeeder` built its sample pages programmatically: it assembled each page's
  widget tree in C# and wrote it through CreatePageAsync -> SaveWorkingContentAsync ->
  PublishDraftAsync. That duplicated work the content-staging importer already does, and
  carried two liabilities.

  `BuildContentJson` hand-assembled a widget tree meant to mirror what the editor produces
  for a page authored by hand, with nothing enforcing the resemblance — if the editor's
  output shape changed, the seeder kept producing the old one and the drift was silent.
  `StripTags` built the plain-text search index with a naive tag walker whose own comment
  recorded that it misparses CDATA, embedded scripts and entities.

  The sample content is now a content-staging bundle embedded in the Application assembly,
  replayed through `IContentStagingService`. Seeded pages are created by exactly the code
  that handles a bundle uploaded by an administrator, and the plain text comes from the real
  rendering pipeline via the export. Both helpers are deleted; the seeder is twelve lines.

  Skip-on-collision preserves the existing guarantee that pressing the seed button twice is
  safe and never overwrites content already sitting at a sample's identity. The
  `/admin/pages/sample-seed` route, its auth and its response are unchanged.

  The bundle carries the sample pages only. Their parents — the four roots and
  /help/not-found — are created at start-up by `DefaultPageNodeSeeder` and are deliberately
  absent, so the two seeders do not compete for ownership of the roots. Parentage is by the
  pinned root GUIDs, which is what lets a static file resolve against a fresh database. The
  samples' own GUIDs are baked in for the same reason the roots are pinned: every environment
  seeded from this bundle gets the same page identities, so a later import updates those rows
  rather than adopting them through the path fallback.

  Verified equivalent: seeding a cleared database with each mechanism and comparing exports
  shows all fourteen sample pages identical field for field. The only differences are the page
  GUIDs, which are pinned here by design, and the publish instants, which the bundle replays
  from its recorded values where the old seeder stamped the current time. Every sample is
  published either way.

  To change the samples in future: seed an environment, edit through the CMS, export from
  /admin/content-staging, strip the roots and /help/not-found, and replace the file. Editing
  the JSON by hand works but forfeits the guarantee that the application wrote it.

  Adds tests covering the bundle as data — that it parses, declares the schema version the
  importer accepts, parents every sample to a pinned root, publishes every sample, keeps a
  wiki-typed sample so that render path stays exercised, and has no duplicate segments or
  GUIDs — plus a real-Postgres test proving a second seed creates zero and changes no rows.

  Refs #273

  Closes #273