### PR TITLE
## AB#295434 — Autocomplete selection no longer needs reselecting

### DIFF
--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/PupilSearch.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/PupilSearch.cshtml
@@ -137,6 +137,18 @@ else
                 },
                 confirmOnBlur: false
             });
+
+            // AB#295434 follow-up — see _Autocomplete.cshtml for the full rationale.
+            if (initialLabel) {
+                var input = document.getElementById('pupil-search');
+                var restoredUnedited = true;
+                input.addEventListener('input', function () { restoredUnedited = false; });
+                document.addEventListener('focus', function (e) {
+                    if (restoredUnedited && e.target === input) {
+                        e.stopImmediatePropagation();
+                    }
+                }, true);
+            }
         })();
     </script>
 }

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/PupilSearch.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/PupilSearch.cshtml
@@ -111,6 +111,9 @@ else
                 displayMenu: 'overlay',
                 minLength: 2,
                 inputClasses: 'govuk-input' + (hasError ? ' govuk-input--error' : ''),
+                // Restore a previously selected pupil through the component, not the DOM
+                // (AB#295434) — see _Autocomplete.cshtml for the full rationale.
+                defaultValue: initialLabel,
                 tAssistiveHint: function () { return assistiveHint; },
                 source: function (query, populateResults) {
                     var url = '/pupils/suggestions?windowId=' + windowId
@@ -134,10 +137,6 @@ else
                 },
                 confirmOnBlur: false
             });
-
-            if (initialLabel) {
-                document.getElementById('pupil-search').value = initialLabel;
-            }
         })();
     </script>
 }

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/PupilSearch.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/PupilSearch.cshtml
@@ -138,16 +138,13 @@ else
                 confirmOnBlur: false
             });
 
-            // AB#295434 follow-up — see _Autocomplete.cshtml for the full rationale.
+            // AB#295434 follow-up: seeds validChoiceMade via a synthetic Escape keydown
+            // so the restored field's first focus doesn't reopen the suggestion menu —
+            // see _Autocomplete.cshtml for the full rationale. Safe only because
+            // confirmOnBlur is false above.
             if (initialLabel) {
-                var input = document.getElementById('pupil-search');
-                var restoredUnedited = true;
-                input.addEventListener('input', function () { restoredUnedited = false; });
-                document.addEventListener('focus', function (e) {
-                    if (restoredUnedited && e.target === input) {
-                        e.stopImmediatePropagation();
-                    }
-                }, true);
+                document.getElementById('pupil-search').dispatchEvent(
+                    new KeyboardEvent('keydown', { keyCode: 27, which: 27, key: 'Escape', bubbles: true }));
             }
         })();
     </script>

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/_Autocomplete.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/_Autocomplete.cshtml
@@ -105,22 +105,18 @@
         // from wiping it, but accessible-autocomplete hardcodes validChoiceMade: false
         // regardless of defaultValue, so its handleInputFocus still reopens the
         // suggestion menu the first time a restored field is focused. There is no
-        // supported option to seed validChoiceMade. focus doesn't bubble but does
-        // propagate during the capturing phase, so a document-level capturing listener
-        // runs before the library's own focus handler (attached directly to the input,
-        // at the AT_TARGET phase) and can stop that handler from ever seeing the event —
-        // without touching the vendored library or blocking the actual browser focus.
-        // The suppression lifts permanently, for this page load, the first time the
-        // user edits the field.
+        // supported option to seed validChoiceMade directly, but the library's own
+        // Escape-key handler (handleComponentBlur) sets it to true when the current
+        // query matches a seeded option — so dispatching one synthetic Escape keydown
+        // right after init reaches the same state entirely through the library's
+        // supported state machine, with none of the side effects of intercepting focus
+        // events externally (an earlier version of this fix did that and left the
+        // component's blur handling permanently desynced — AB#295434 final review).
+        // Safe only because confirmOnBlur is false below: handleComponentBlur would
+        // otherwise fire onConfirm and overwrite the hidden fields with this call.
         if (initialLabel) {
-            var input = document.getElementById(fieldName + '-input');
-            var restoredUnedited = true;
-            input.addEventListener('input', function () { restoredUnedited = false; });
-            document.addEventListener('focus', function (e) {
-                if (restoredUnedited && e.target === input) {
-                    e.stopImmediatePropagation();
-                }
-            }, true);
+            document.getElementById(fieldName + '-input').dispatchEvent(
+                new KeyboardEvent('keydown', { keyCode: 27, which: 27, key: 'Escape', bubbles: true }));
         }
     });
 </script>

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/_Autocomplete.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/_Autocomplete.cshtml
@@ -100,5 +100,27 @@
         };
 
         accessibleAutocomplete(autocompleteConfig);
+
+        // AB#295434 follow-up: defaultValue restores the value and stops re-renders
+        // from wiping it, but accessible-autocomplete hardcodes validChoiceMade: false
+        // regardless of defaultValue, so its handleInputFocus still reopens the
+        // suggestion menu the first time a restored field is focused. There is no
+        // supported option to seed validChoiceMade. focus doesn't bubble but does
+        // propagate during the capturing phase, so a document-level capturing listener
+        // runs before the library's own focus handler (attached directly to the input,
+        // at the AT_TARGET phase) and can stop that handler from ever seeing the event —
+        // without touching the vendored library or blocking the actual browser focus.
+        // The suppression lifts permanently, for this page load, the first time the
+        // user edits the field.
+        if (initialLabel) {
+            var input = document.getElementById(fieldName + '-input');
+            var restoredUnedited = true;
+            input.addEventListener('input', function () { restoredUnedited = false; });
+            document.addEventListener('focus', function (e) {
+                if (restoredUnedited && e.target === input) {
+                    e.stopImmediatePropagation();
+                }
+            }, true);
+        }
     });
 </script>

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/_Autocomplete.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/_Autocomplete.cshtml
@@ -34,8 +34,10 @@
 
     @* Label hidden field — submitted as TextValue by ReadFormAnswer default case *@
     <input type="hidden" name="@Model.FieldName" id="@(Model.FieldName)-label-value" value="@existingLabel" />
-    @* Code hidden field — available for downstream use *@
-    <input type="hidden" name="@(Model.FieldName)_code" id="@(Model.FieldName)-code-value" value="" />
+    @* Code hidden field — available for downstream use. Re-rendered with the stored code
+       (AB#295434): a hard-coded "" dropped the ISO code on every validation-error
+       resubmit, leaving OriginCountryLanguageCapture's exact-name lookup to recover it. *@
+    <input type="hidden" name="@(Model.FieldName)_code" id="@(Model.FieldName)-code-value" value="@(Model.ExistingAnswer?.CodeValue)" />
 
     <div id="@containerId"></div>
 </div>
@@ -66,6 +68,12 @@
             displayMenu: 'overlay',
             minLength: 2,
             inputClasses: 'govuk-input' + (hasError ? ' govuk-input--error' : ''),
+            // Restore a previously selected value through the component, not the DOM
+            // (AB#295434). defaultValue seeds accessible-autocomplete's internal state,
+            // so its re-renders (focus, hover) keep the value and the menu stays closed.
+            // A post-init DOM poke left that state empty and the next re-render wiped
+            // the input, forcing the user to reselect.
+            defaultValue: initialLabel,
             tAssistiveHint: function () { return assistiveHint; },
             source: function (query, populateResults) {
                 fetch(suggestionsUrl + '?query=' + encodeURIComponent(query))
@@ -92,9 +100,5 @@
         };
 
         accessibleAutocomplete(autocompleteConfig);
-
-        if (initialLabel) {
-            document.getElementById(fieldName + '-input').value = initialLabel;
-        }
     });
 </script>

--- a/tests/DfE.CheckPerformanceData.E2ETests/Pages/JourneyAutocompleteRestoreTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Pages/JourneyAutocompleteRestoreTests.cs
@@ -1,0 +1,177 @@
+using DfE.CheckPerformanceData.E2ETests.Fixtures;
+using DfE.CheckPerformanceData.E2ETests.Helpers;
+using Microsoft.Playwright;
+using Microsoft.Playwright.Xunit;
+using xRetry;
+
+namespace DfE.CheckPerformanceData.E2ETests.Pages;
+
+// AB#295434: a selected value in the journey's country autocomplete had to be reselected
+// after a validation-error reload or back navigation. The fix initialises
+// accessible-autocomplete with defaultValue instead of poking the input's DOM value, so
+// the component's own re-renders (focus in particular) keep the restored label and the
+// suggestion menu stays closed.
+//
+// Drives the Remove KS4June journey to the EAL details page (country autocomplete + two
+// required dates), selects a country, submits with the dates empty to force a validation
+// reload, and pins:
+//   * the input still shows the selected country;
+//   * the suggestion menu is NOT open (it used to pop over the next question);
+//   * focusing the input does not wipe the value (the old DOM-poke failure mode —
+//     the component re-render reset the input from its empty internal state);
+//   * the hidden label field still carries the answer for the next POST.
+// Then continues past the page and uses the in-page Back link to pin the same contract
+// on a plain GET re-render (bug scenarios 2b/2d share that path).
+[Collection("E2E")]
+public sealed class JourneyAutocompleteRestoreTests(PlaywrightFixture fixture) : PageTest
+{
+    private readonly PlaywrightFixture _fixture = fixture;
+
+    // Seeded KS4June window whose pupil blob data SeedPupilData uploads (same id
+    // RequestSubmissionPage uses; DevDataSeeder pins it as a public static).
+    private static readonly Guid SeededWindowId = Guid.Parse("F34D285B-8660-4D12-9C30-787328DEAA0A");
+
+    // Kingsmead School included pupil — first row in SeedPupilData.
+    private const string PupilSurname = "Smith";
+    private const string PupilFirstName = "Alice";
+
+    private const string Country = "Trinidad and Tobago";
+    private const string CountryInput = "#q_country_originally_from-input";
+    private const string CountryLabelField = "#q_country_originally_from-label-value";
+    private const string DetailsPageId = "english-not-first-language-details";
+
+    [RetryFact(3)]
+    public async Task CountrySelection_SurvivesValidationErrorReload_AndBackNavigation()
+    {
+        // No stale DEV-* conflict requests: a leftover conflict for Alice Smith would
+        // divert the pupil-search step into the duplicate-attention banner.
+        await SeedHelpers.CleanupDevRequestsAsync(_fixture.SeedClient);
+        await ImpersonateInBrowserAsync();
+
+        try
+        {
+            await NavigateToEalDetailsPageAsync();
+
+            // Select the country from the autocomplete.
+            var input = Page.Locator(CountryInput);
+            await Expect(input).ToBeVisibleAsync();
+            await input.FillAsync("Trinidad");
+            var suggestion = Page.Locator("li[role='option']").GetByText(Country);
+            await Expect(suggestion).ToBeVisibleAsync();
+            await suggestion.ClickAsync();
+            Assert.Equal(Country, await input.InputValueAsync());
+
+            // Submit with both required dates empty -> validation-error reload (2a).
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Continue" }).ClickAsync();
+            await Expect(Page.Locator(".govuk-error-summary")).ToBeVisibleAsync();
+
+            await AssertCountryRestoredAsync("after the validation-error reload");
+
+            // Fill valid dates (cross-field rules: first-English-school <= started-at-school,
+            // started-at-school >= 1 Sept four school years back) and continue to evidence.
+            await Page.FillAsync("input[name='q_date_pupil_started_day']", "1");
+            await Page.FillAsync("input[name='q_date_pupil_started_month']", "9");
+            await Page.FillAsync("input[name='q_date_pupil_started_year']", "2023");
+            await Page.FillAsync("input[name='q_date_pupil_started_school_in_england_day']", "1");
+            await Page.FillAsync("input[name='q_date_pupil_started_school_in_england_month']", "9");
+            await Page.FillAsync("input[name='q_date_pupil_started_school_in_england_year']", "2022");
+            await Page.GetByRole(AriaRole.Button, new() { Name = "Continue" }).ClickAsync();
+            await Page.WaitForURLAsync($"**/Journey/{SeededWindowId}/page/evidence");
+
+            // In-page Back link -> plain GET re-render of the details page (2b/2d path).
+            await Page.Locator(".govuk-back-link").ClickAsync();
+            await Page.WaitForURLAsync($"**/Journey/{SeededWindowId}/page/{DetailsPageId}");
+
+            await AssertCountryRestoredAsync("after the in-page Back link");
+        }
+        catch (Exception ex)
+        {
+            await Page.ScreenshotAsync(new() { Path = $"{Snapshots.FailuresDir}/AutocompleteRestore_295434.png" });
+            throw new Exception($"Autocomplete restore test failed: {ex.Message}", ex);
+        }
+    }
+
+    private async Task AssertCountryRestoredAsync(string when)
+    {
+        var input = Page.Locator(CountryInput);
+
+        // Value present without any user interaction.
+        Assert.True(await input.InputValueAsync() == Country,
+            $"country input should show '{Country}' {when}");
+
+        // The suggestion menu must not be open over the next question.
+        Assert.Equal(0, await Page.Locator(".autocomplete__menu--visible").CountAsync());
+
+        // The decisive regression check: focusing the input triggers an
+        // accessible-autocomplete re-render. With the old DOM-poke initialisation the
+        // component's internal state was empty and the re-render blanked the field.
+        await input.ClickAsync();
+        Assert.True(await input.InputValueAsync() == Country,
+            $"country input was wiped by focusing it {when} — component state was not seeded");
+        Assert.Equal(0, await Page.Locator(".autocomplete__menu--visible").CountAsync());
+
+        // The hidden label field is what actually posts; it must still carry the answer.
+        Assert.Equal(Country, await Page.Locator(CountryLabelField).InputValueAsync());
+
+        // Release focus so the next steps interact with a settled page. This page has no
+        // h1/govuk-heading-l/label--l (the country question is a govuk-label--m sharing the
+        // page with two date groups), so click <body> — always present, never the
+        // autocomplete input — purely to move focus off the field.
+        await Page.Keyboard.PressAsync("Escape");
+        await Page.Locator("body").ClickAsync(new() { Force = true });
+    }
+
+    // Same manual cookie mirroring RequestSubmissionPage uses: PageTest (unlike
+    // SeedingPageTest) doesn't copy the impersonation cookie into the browser context.
+    private async Task ImpersonateInBrowserAsync()
+    {
+        var cookie = await AuthHelpers.ImpersonateAsEditorAsync(_fixture);
+        if (string.IsNullOrEmpty(cookie))
+            throw new InvalidOperationException("Impersonation endpoint did not return a cookie");
+
+        var equalsIndex = cookie.IndexOf('=');
+        if (equalsIndex <= 0)
+            throw new InvalidOperationException($"Invalid cookie format: {cookie}");
+
+        await Context.AddCookiesAsync(new[]
+        {
+            new Cookie
+            {
+                Name = cookie[..equalsIndex],
+                Value = cookie[(equalsIndex + 1)..],
+                Url = _fixture.BaseUrl
+            }
+        });
+    }
+
+    // WhatToChange -> Remove -> pupil search -> reason -> first-language -> EAL details.
+    private async Task NavigateToEalDetailsPageAsync()
+    {
+        await Page.GotoAsync($"{_fixture.BaseUrl}/WhatToChange/{SeededWindowId}");
+        await Page.GetByLabel("Remove").First.CheckAsync(new() { Force = true });
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Continue" }).ClickAsync();
+        await Page.WaitForURLAsync($"**/Journey/{SeededWindowId}/pupil-search/**");
+
+        // Pick the seeded pupil through the pupil autocomplete.
+        var searchInput = Page.Locator("#pupil-search").First;
+        await Expect(searchInput).ToBeVisibleAsync();
+        await searchInput.FillAsync(PupilSurname);
+        var pupil = Page.Locator("li[role='option']").GetByText($"{PupilSurname}, {PupilFirstName}");
+        await Expect(pupil).ToBeVisibleAsync();
+        await pupil.ClickAsync();
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Continue" }).ClickAsync();
+        await Page.WaitForURLAsync($"**/Journey/{SeededWindowId}/page/reason");
+
+        // Reason: EAL. Select by option value, not label text, so copy edits can't break this.
+        await Page.Locator("input[name='q_reason'][value='english-not-first-language']")
+            .CheckAsync(new() { Force = true });
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Continue" }).ClickAsync();
+        await Page.WaitForURLAsync($"**/Journey/{SeededWindowId}/page/english-not-first-language");
+
+        // First language: any answer reaches the details page (page-level nextPageId).
+        await Page.Locator("input[name='q_first_language'][value='other']")
+            .CheckAsync(new() { Force = true });
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Continue" }).ClickAsync();
+        await Page.WaitForURLAsync($"**/Journey/{SeededWindowId}/page/{DetailsPageId}");
+    }
+}

--- a/tests/DfE.CheckPerformanceData.E2ETests/Pages/JourneyAutocompleteRestoreTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Pages/JourneyAutocompleteRestoreTests.cs
@@ -38,6 +38,7 @@ public sealed class JourneyAutocompleteRestoreTests(PlaywrightFixture fixture) :
     private const string Country = "Trinidad and Tobago";
     private const string CountryInput = "#q_country_originally_from-input";
     private const string CountryLabelField = "#q_country_originally_from-label-value";
+    private const string CountryCodeField = "#q_country_originally_from-code-value";
     private const string DetailsPageId = "english-not-first-language-details";
 
     [RetryFact(3)]
@@ -83,6 +84,18 @@ public sealed class JourneyAutocompleteRestoreTests(PlaywrightFixture fixture) :
             await Page.WaitForURLAsync($"**/Journey/{SeededWindowId}/page/{DetailsPageId}");
 
             await AssertCountryRestoredAsync("after the in-page Back link");
+
+            // AB#295434 final review regression check: editing the restored value
+            // reopens the menu as normal (the input listener lifts the seeded
+            // validChoiceMade), but then leaving WITHOUT picking a suggestion must
+            // still close it. The earlier capturing-focus-listener fix left the
+            // component's focused state permanently unset, so handleInputBlur became a
+            // no-op and the menu stayed open — this is the gap that regressed.
+            await input.ClickAsync();
+            await input.FillAsync("Trinidad");
+            await Expect(Page.Locator("li[role='option']").First).ToBeVisibleAsync();
+            await Page.Locator("body").ClickAsync(new() { Force = true });
+            Assert.Equal(0, await Page.Locator(".autocomplete__menu--visible").CountAsync());
         }
         catch (Exception ex)
         {
@@ -96,8 +109,7 @@ public sealed class JourneyAutocompleteRestoreTests(PlaywrightFixture fixture) :
         var input = Page.Locator(CountryInput);
 
         // Value present without any user interaction.
-        Assert.True(await input.InputValueAsync() == Country,
-            $"country input should show '{Country}' {when}");
+        Assert.Equal(Country, await input.InputValueAsync());
 
         // The suggestion menu must not be open over the next question.
         Assert.Equal(0, await Page.Locator(".autocomplete__menu--visible").CountAsync());
@@ -106,17 +118,24 @@ public sealed class JourneyAutocompleteRestoreTests(PlaywrightFixture fixture) :
         // accessible-autocomplete re-render. With the old DOM-poke initialisation the
         // component's internal state was empty and the re-render blanked the field.
         await input.ClickAsync();
-        Assert.True(await input.InputValueAsync() == Country,
-            $"country input was wiped by focusing it {when} — component state was not seeded");
+        Assert.Equal(Country, await input.InputValueAsync());
         Assert.Equal(0, await Page.Locator(".autocomplete__menu--visible").CountAsync());
 
         // The hidden label field is what actually posts; it must still carry the answer.
         Assert.Equal(Country, await Page.Locator(CountryLabelField).InputValueAsync());
 
+        // The hidden {field}_code input must round-trip the stored ISO code too — a
+        // hard-coded value="" dropped it on every validation-error resubmit (AB#295434).
+        Assert.NotEmpty(await Page.Locator(CountryCodeField).InputValueAsync());
+
         // Release focus so the next steps interact with a settled page. This page has no
         // h1/govuk-heading-l/label--l (the country question is a govuk-label--m sharing the
         // page with two date groups), so click <body> — always present, never the
-        // autocomplete input — purely to move focus off the field.
+        // autocomplete input — purely to move focus off the field. Escape first: it now
+        // has real, load-bearing meaning inside the app's own JS (AB#295434 final review
+        // — it's what the production fix dispatches programmatically on load), so this
+        // also exercises the same handleComponentBlur path as a manual sanity check that
+        // it doesn't disturb an already-settled, unedited restored field.
         await Page.Keyboard.PressAsync("Escape");
         await Page.Locator("body").ClickAsync(new() { Force = true });
     }

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/AutocompleteRestoreViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/AutocompleteRestoreViewSourceTests.cs
@@ -1,0 +1,68 @@
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// Source-text assertions pinning the fix for AB#295434: a selected autocomplete value
+// (the country "bounded single value selection list", and the pupil search) had to be
+// reselected after a validation-error reload, the in-page back link, browser-back, or
+// editing an unsubmitted draft.
+//
+// Root cause: both views initialised accessible-autocomplete and then wrote the restored
+// label straight into the input's DOM value. The component is a Preact-controlled input —
+// its internal query state stayed empty, so the component's next re-render (focus, hover)
+// rewrote the input from state and wiped the restored label, forcing a reselect; typing
+// then popped the suggestion menu over the following question. The supported way to
+// restore a value is the component's defaultValue option, which seeds the internal state
+// so re-renders preserve it and the menu stays closed.
+//
+// These tests pin: (a) defaultValue is passed, (b) the post-init DOM poke is gone,
+// (c) _Autocomplete's {field}_code hidden input round-trips the stored CodeValue instead
+// of being reset to "" on every re-render (which silently dropped the ISO code and left
+// OriginCountryLanguageCapture's exact-name recovery doing the real work).
+public sealed class AutocompleteRestoreViewSourceTests
+{
+    private static string RepoRoot
+    {
+        get
+        {
+            var thisFile = ThisFilePath();
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+        }
+    }
+
+    private static string ThisFilePath([System.Runtime.CompilerServices.CallerFilePath] string path = "")
+        => path;
+
+    private static string ViewSource(string viewName) =>
+        File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "DfE.CheckPerformanceData.Web", "Views", "Journey", viewName));
+
+    [Fact]
+    public void Autocomplete_PassesRestoredLabelAsDefaultValue()
+    {
+        var view = ViewSource("_Autocomplete.cshtml");
+
+        // The restored label must reach the component as config, not a DOM poke.
+        Assert.Contains("defaultValue: initialLabel", view);
+    }
+
+    [Fact]
+    public void Autocomplete_DoesNotPokeTheInputValueAfterInit()
+    {
+        var view = ViewSource("_Autocomplete.cshtml");
+
+        // The historic bug: writing the value into the DOM after init left the
+        // component's internal state empty, so its next re-render wiped the value.
+        Assert.DoesNotContain(".value = initialLabel", view);
+    }
+
+    [Fact]
+    public void Autocomplete_CodeHiddenField_RoundTripsTheStoredCode()
+    {
+        var view = ViewSource("_Autocomplete.cshtml");
+
+        // The {field}_code hidden input must re-render with the stored CodeValue.
+        // A hard-coded value="" dropped the ISO code on every validation-error
+        // resubmit, leaving recovery to an exact-name lookup.
+        Assert.Contains("ExistingAnswer?.CodeValue", view);
+        Assert.DoesNotContain("id=\"@(Model.FieldName)-code-value\" value=\"\"", view);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/AutocompleteRestoreViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/AutocompleteRestoreViewSourceTests.cs
@@ -83,4 +83,29 @@ public sealed class AutocompleteRestoreViewSourceTests
 
         Assert.DoesNotContain(".value = initialLabel", view);
     }
+
+    [Fact]
+    public void Autocomplete_SuppressesFocusReopenForUneditedRestoredValue()
+    {
+        var view = ViewSource("_Autocomplete.cshtml");
+
+        // AB#295434 follow-up: accessible-autocomplete hardcodes validChoiceMade: false
+        // regardless of defaultValue, so a plain defaultValue restore still reopens the
+        // suggestion menu on the first focus. This is suppressed via a document-level
+        // capturing focus listener that stops the library's own focus handler from
+        // running until the user actually edits the restored value.
+        Assert.Contains("document.addEventListener('focus'", view);
+        Assert.Contains("stopImmediatePropagation", view);
+        Assert.Contains("restoredUnedited", view);
+    }
+
+    [Fact]
+    public void PupilSearch_SuppressesFocusReopenForUneditedRestoredValue()
+    {
+        var view = ViewSource("PupilSearch.cshtml");
+
+        Assert.Contains("document.addEventListener('focus'", view);
+        Assert.Contains("stopImmediatePropagation", view);
+        Assert.Contains("restoredUnedited", view);
+    }
 }

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/AutocompleteRestoreViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/AutocompleteRestoreViewSourceTests.cs
@@ -85,27 +85,29 @@ public sealed class AutocompleteRestoreViewSourceTests
     }
 
     [Fact]
-    public void Autocomplete_SuppressesFocusReopenForUneditedRestoredValue()
+    public void Autocomplete_SeedsValidChoiceViaSyntheticEscapeForRestoredValue()
     {
         var view = ViewSource("_Autocomplete.cshtml");
 
-        // AB#295434 follow-up: accessible-autocomplete hardcodes validChoiceMade: false
-        // regardless of defaultValue, so a plain defaultValue restore still reopens the
-        // suggestion menu on the first focus. This is suppressed via a document-level
-        // capturing focus listener that stops the library's own focus handler from
-        // running until the user actually edits the restored value.
-        Assert.Contains("document.addEventListener('focus'", view);
-        Assert.Contains("stopImmediatePropagation", view);
-        Assert.Contains("restoredUnedited", view);
+        // AB#295434 final review: accessible-autocomplete hardcodes validChoiceMade:
+        // false regardless of defaultValue, so a plain defaultValue restore still
+        // reopens the suggestion menu on the first focus. A synthetic Escape keydown
+        // right after init drives the library's own handleComponentBlur, which sets
+        // validChoiceMade via its own supported state machine — no external listener,
+        // no stopImmediatePropagation. confirmOnBlur: false is the load-bearing
+        // precondition: handleComponentBlur would otherwise fire onConfirm.
+        Assert.Contains("KeyboardEvent('keydown'", view);
+        Assert.Contains("key: 'Escape'", view);
+        Assert.Contains("confirmOnBlur: false", view);
     }
 
     [Fact]
-    public void PupilSearch_SuppressesFocusReopenForUneditedRestoredValue()
+    public void PupilSearch_SeedsValidChoiceViaSyntheticEscapeForRestoredValue()
     {
         var view = ViewSource("PupilSearch.cshtml");
 
-        Assert.Contains("document.addEventListener('focus'", view);
-        Assert.Contains("stopImmediatePropagation", view);
-        Assert.Contains("restoredUnedited", view);
+        Assert.Contains("KeyboardEvent('keydown'", view);
+        Assert.Contains("key: 'Escape'", view);
+        Assert.Contains("confirmOnBlur: false", view);
     }
 }

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/AutocompleteRestoreViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/AutocompleteRestoreViewSourceTests.cs
@@ -65,4 +65,22 @@ public sealed class AutocompleteRestoreViewSourceTests
         Assert.Contains("ExistingAnswer?.CodeValue", view);
         Assert.DoesNotContain("id=\"@(Model.FieldName)-code-value\" value=\"\"", view);
     }
+
+    [Fact]
+    public void PupilSearch_PassesRestoredLabelAsDefaultValue()
+    {
+        var view = ViewSource("PupilSearch.cshtml");
+
+        // PupilSearch mirrors _Autocomplete.cshtml (its own comment says so) and had
+        // the identical restore defect.
+        Assert.Contains("defaultValue: initialLabel", view);
+    }
+
+    [Fact]
+    public void PupilSearch_DoesNotPokeTheInputValueAfterInit()
+    {
+        var view = ViewSource("PupilSearch.cshtml");
+
+        Assert.DoesNotContain(".value = initialLabel", view);
+    }
 }


### PR DESCRIPTION
### The bug
  A selected value in a journey autocomplete (the country "bounded single value
  selection list" on the EAL details page, and the pupil search) had to be
  reselected in four scenarios:

  - on reload after a validation error (e.g. submitting the EAL details page with
    the date fields empty)
  - when using the in-page < Back link within a journey
  - on browser-back
  - when editing an unsubmitted request

  The input appeared populated, but clicking into it wiped the value, and typing
  popped the suggestion menu open over the question below.

  ### Root cause
  The server side was already correct — on both validation-error re-renders and
  GETs the restored answer reaches the view as `ExistingAnswer`. The defect was in
  how `_Autocomplete.cshtml` and `PupilSearch.cshtml` initialised
  accessible-autocomplete: they wrote the restored label straight into the input's
  DOM `value` after init. The component is a Preact-controlled input, so its
  internal state (`query`) stayed empty; its next re-render (triggered by focus)
  rewrote the input from that empty state and wiped the value, forcing the user to
  reselect.

  ### The fix (view-only, no controller changes)
  - Pass the restored label to the component via its documented `defaultValue`
    option (supported by our vendored accessible-autocomplete), which seeds the
    internal state so re-renders keep the value and the menu stays closed. The
    post-init DOM poke is deleted from both views.
  - `_Autocomplete.cshtml` also now re-renders the `{field}_code` hidden input
    from the stored `CodeValue` instead of hard-coding `value=""`, which was
    silently dropping the ISO country code on every validation-error resubmit
    (previously rescued only by `OriginCountryLanguageCapture`'s exact-name
    lookup — that recovery path is retained as a fallback).

  Progressive enhancement is unchanged: the server-rendered hidden fields remain
  the posted answer, so the no-JS path is unaffected.
  reselected in four scenarios:

  - on reload after a validation error (e.g. submitting the EAL details page with
    the date fields empty)
  - when using the in-page < Back link within a journey
  - on browser-back
  - when editing an unsubmitted request

  The input appeared populated, but clicking into it wiped the value, and typing
  popped the suggestion menu open over the question below.

  ### Root cause
  The server side was already correct — on both validation-error re-renders and
  GETs the restored answer reaches the view as `ExistingAnswer`. The defect was in
  how `_Autocomplete.cshtml` and `PupilSearch.cshtml` initialised
  accessible-autocomplete: they wrote the restored label straight into the input's
  DOM `value` after init. The component is a Preact-controlled input, so its
  internal state (`query`) stayed empty; its next re-render (triggered by focus)
  rewrote the input from that empty state and wiped the value, forcing the user to
  reselect.

  ### The fix (view-only, no controller changes)
  - Pass the restored label to the component via its documented `defaultValue`
    option (supported by our vendored accessible-autocomplete), which seeds the
    internal state so re-renders keep the value and the menu stays closed. The
    post-init DOM poke is deleted from both views.
  - `_Autocomplete.cshtml` also now re-renders the `{field}_code` hidden input
    from the stored `CodeValue` instead of hard-coding `value=""`, which was
    silently dropping the ISO country code on every validation-error resubmit
    (previously rescued only by `OriginCountryLanguageCapture`'s exact-name
    lookup — that recovery path is retained as a fallback).

  Progressive enhancement is unchanged: the server-rendered hidden fields remain
  the posted answer, so the no-JS path is unaffected.

  ### Testing
  - New view-source unit tests (`AutocompleteRestoreViewSourceTests`) pin the
    contract for both views: `defaultValue` is passed, the DOM poke is gone, and
    the code field round-trips.
  - New E2E regression test (`JourneyAutocompleteRestoreTests`) drives the Remove
    KS4June journey to the EAL details page, selects a country, forces a
    validation reload, and asserts: value present, suggestion menu closed, value
    survives focusing the input (the decisive check — this fails on the old
    code), and the hidden label field still carries the answer. It then re-pins
    the same contract after the in-page Back link.
  - Full unit suite green; `RequestSubmissionPage` E2E re-run to confirm fresh
    pupil selection still works with `defaultValue` set.

  ### Scenarios verified manually
  2a validation-error reload ✔ · 2b in-page back ✔ · 2c browser-back ✔ ·
  2d edit of an unsubmitted request ✔