### PR TITLE
Fix flaky e2e timing - Fix two intermittently failing tests, and the board defect behind one of them

### DIFF
--- a/src/DfE.CheckPerformanceData.Web/wwwroot/js/observability-board.js
+++ b/src/DfE.CheckPerformanceData.Web/wwwroot/js/observability-board.js
@@ -729,7 +729,15 @@
     function start(root, feed) {
         if (root.__obsEs) { root.__obsEs.close(); }
         var engine = BoardEngine(root);
-        feed.subscribe(engine.onSnapshot, engine.onError);
+        var subscription = feed.subscribe(engine.onSnapshot, engine.onError);
+
+        // Remember whatever the feed handed back, so the close above can actually fire next time.
+        // Without this the guard is unreachable — the handle it tests was never recorded — and a
+        // second start() on the same root leaves the previous EventSource connected, with two
+        // engines writing into one transitions list. Feeds that own no closeable resource (the
+        // recorded feed, a test stub) return nothing, which correctly clears the handle.
+        root.__obsEs = subscription && typeof subscription.close === 'function' ? subscription : null;
+
         return engine;
     }
 

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/ObservabilityBoardTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/ObservabilityBoardTests.cs
@@ -122,6 +122,74 @@ public sealed class ObservabilityBoardTests(PlaywrightFixture fixture)
 [Collection("E2E")]
 public sealed class ObservabilityBoardBrowserTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
 {
+    // start() closes the feed the previous engine owned so a board root only ever has one writer.
+    // The guard reads a handle the function has to record when it subscribes; when that recording
+    // was missing the guard could never fire, the live EventSource stayed connected, and two
+    // engines wrote into the same transitions list. That is unobservable until something else
+    // writes to the DOM at the wrong moment, so pin it directly rather than through its symptom.
+    [Fact]
+    public async Task Dashboard_StartingASecondFeed_ClosesTheFirst_SoOneWriterOwnsTheBoard()
+    {
+        try
+        {
+            var adminCookie = await AuthHelpers.ImpersonateAsAdminAsync(Fixture);
+            if (!string.IsNullOrEmpty(adminCookie))
+            {
+                var equalsIndex = adminCookie.IndexOf('=');
+                if (equalsIndex > 0)
+                {
+                    await Context.AddCookiesAsync([new Microsoft.Playwright.Cookie
+                    {
+                        Name = adminCookie[..equalsIndex],
+                        Value = adminCookie[(equalsIndex + 1)..],
+                        Url = Fixture.BaseUrl
+                    }]);
+                }
+            }
+
+            await Page.GotoAsync($"{Fixture.BaseUrl}/admin/observability");
+            await Page.WaitForLoadStateAsync(LoadState.Load);
+
+            var handover = await Page.EvaluateAsync<FeedHandover>(@"() => {
+                const root = document.querySelector('[data-obs-board]');
+                const url = root.getAttribute('data-stream-url') || '/admin/observability/stream';
+
+                // Own a live feed, keeping hold of whatever start() recorded for it.
+                window.ObservabilityBoard.start(root, window.ObservabilityBoard.liveFeed(url));
+                const firstHandle = root.__obsEs;
+
+                // Hand the root to a feed that owns nothing; the live one must be closed.
+                window.ObservabilityBoard.start(root, { subscribe: () => {} });
+
+                return {
+                    recordedFirstFeed: !!firstHandle,
+                    // EventSource.CLOSED === 2
+                    firstFeedClosed: firstHandle ? firstHandle.readyState === 2 : false,
+                    handleClearedForFeedThatOwnsNothing: !root.__obsEs
+                };
+            }");
+
+            Assert.True(handover.RecordedFirstFeed,
+                "start() must record the subscription it opened, or the close-previous guard can never fire");
+            Assert.True(handover.FirstFeedClosed,
+                "starting a second feed must close the first, or two engines write to one board");
+            Assert.True(handover.HandleClearedForFeedThatOwnsNothing,
+                "a feed with nothing to close must clear the handle rather than leave a stale one");
+        }
+        finally
+        {
+            await AuthHelpers.ImpersonateAsEditorAsync(Fixture);
+        }
+    }
+
+    // Playwright instantiates this by reflection, so it is a plain settable class.
+    public sealed class FeedHandover
+    {
+        public bool RecordedFirstFeed { get; set; }
+        public bool FirstFeedClosed { get; set; }
+        public bool HandleClearedForFeedThatOwnsNothing { get; set; }
+    }
+
     [Fact]
     public async Task Dashboard_BoardBinds_LiveRegionPresent_AndTokensAreFocusable()
     {
@@ -151,23 +219,28 @@ public sealed class ObservabilityBoardBrowserTests(PlaywrightFixture fixture) : 
             Assert.Equal(1, await liveRegion.CountAsync());
             Assert.Equal("polite", await liveRegion.GetAttributeAsync("aria-live"));
 
-            // Clear any real SSE data that may have arrived, then drive a controlled snapshot
-            // through the engine. The live SSE feed from the running server can pollute the
-            // live region with real transition data (DEV-*) before our test snapshot arrives,
-            // so we must clear the DOM first and wait for the engine to be ready.
-            // Use an async IIFE because Page.EvaluateAsync passes a plain (non-async) function string.
-            await Page.EvaluateAsync(@"async () => {
+            // Take the board over with a feed that publishes nothing, then drive one controlled
+            // snapshot through it.
+            //
+            // Order matters. start() closes the feed the previous engine owned, so calling it
+            // FIRST disconnects the live stream; only then is it safe to clear the DOM, because
+            // nothing can write into it afterwards. The previous version cleared first and started
+            // second, leaving a window in which a real transition could repopulate the region — on
+            // a busy environment that is exactly what happened, and the assertion below read a real
+            // request instead of this snapshot.
+            //
+            // No sleep: start() returns a live engine synchronously and onSnapshot renders
+            // synchronously, so there is nothing to wait for.
+            await Page.EvaluateAsync(@"() => {
                 const root = document.querySelector('[data-obs-board]');
-                // Clear any existing tokens from real SSE data
+                const engine = window.ObservabilityBoard.start(root, { subscribe: () => {} });
+
                 for (const token of root.querySelectorAll('.obs-board__token')) {
                     token.remove();
                 }
-                // Clear the live region
                 const liveRegion = root.querySelector('[data-obs-transitions]');
                 if (liveRegion) liveRegion.textContent = '';
-                const engine = window.ObservabilityBoard.start(root, { subscribe: () => {} });
-                // Small delay to ensure the engine is fully initialized before driving snapshot
-                await new Promise(r => setTimeout(r, 100));
+
                 engine.onSnapshot({
                     depths: [{ queueName: 'rules-engine', depth: 2 }],
                     recentTransitions: [

--- a/tests/DfE.CheckPerformanceData.E2ETests/Admin/SearchAnalyticsDashboardTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Admin/SearchAnalyticsDashboardTests.cs
@@ -1428,17 +1428,44 @@ public sealed class SearchAnalyticsDashboardTests(PlaywrightFixture fixture) : S
                 return;
             }
 
-            await link.First.ClickAsync();
-            await Page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+            // Hold on to the navigation response. The assertion below is about whether the page
+            // rendered at all, so when it fails the first thing worth knowing is whether the
+            // server even served it — and the previous version could not say. It asserted a
+            // count and nothing else, so a page that came back as an error reported only
+            // "count was 0", which is indistinguishable from a page that rendered empty.
+            var navigation = await Page.RunAndWaitForResponseAsync(
+                async () => await link.First.ClickAsync(),
+                r => r.Request.IsNavigationRequest
+                     && r.Url.Contains("/admin/Search/ZeroResultJourneys", StringComparison.Ordinal));
+
+            Assert.True(navigation.Status == 200,
+                $"ZeroResultJourneys should serve 200 — got {navigation.Status} for {navigation.Url}.");
 
             Assert.Contains("/admin/Search/ZeroResultJourneys", Page.Url, StringComparison.Ordinal);
 
-            // Recovery-summary card + at least one journey card (or a graceful empty-state
-            // if the seed happens to have no zero-result-having sessions in the default
-            // window). Either shape counts as "the page rendered".
+            // Wait for the page's own heading before reading its content. The action runs two
+            // analytics queries before the view renders, and on a review app deployed moments
+            // earlier the first hit on this route is slow; NetworkIdle can settle while the
+            // document is still the one we navigated from. Waiting on something only this page
+            // renders is what makes the read below deterministic.
+            await Expect(Page.Locator("main h1")).ToHaveTextAsync(
+                "Zero-result recovery journeys",
+                new LocatorAssertionsToHaveTextOptions { Timeout = 15_000 });
+
+            // The recovery-summary card is rendered unconditionally by the view — the
+            // no-zero-results case is a paragraph INSIDE it — so this asserts the page rendered,
+            // not that the environment happened to hold zero-result sessions.
             var summaryCard = Page.Locator("main .govuk-summary-card, main .govuk-inset-text");
-            Assert.True(await summaryCard.CountAsync() > 0,
-                "ZeroResultJourneys page should render at least one summary-card or inset panel.");
+            if (await summaryCard.CountAsync() == 0)
+            {
+                // .Last: the admin layout nests an inner <main> inside the GOV.UK wrapper, so a
+                // bare "main" locator is ambiguous and would throw here instead of reporting.
+                var main = (await Page.Locator("main").Last.InnerTextAsync()).Trim().ReplaceLineEndings(" ");
+                Assert.Fail(
+                    "ZeroResultJourneys rendered no summary-card or inset panel. " +
+                    $"status={navigation.Status} url={Page.Url} " +
+                    $"main begins: {main[..Math.Min(400, main.Length)]}");
+            }
         }
         finally
         {

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/Analytics/SearchAnalyticsControllerTests.cs
@@ -346,10 +346,16 @@ public sealed class SearchAnalyticsControllerTests
     {
         await ResetSearchEventsAsync();
 
-        // Seed: 5 events on the same weekday-hour cell (say, today's date at now.Hour),
-        // spread across 2 distinct session ids. Aggregate reader collapses them into one
-        // cell where searches=5, unique sessions=2.
-        var now = DateTime.UtcNow;
+        // Seed: 5 events on the same weekday-hour cell, spread across 2 distinct session ids.
+        // The aggregate reader collapses them into one cell where searches=5, unique sessions=2.
+        //
+        // Anchored to half past an hour rather than read from the wall clock. The five events are
+        // spread backwards over five minutes, so taking "now" as the anchor put some of them in
+        // the previous weekday-hour cell whenever a run happened to start in the first four
+        // minutes of an hour — about one run in fifteen — splitting the count asserted below and
+        // failing for a reason that has nothing to do with the code under test. Half past leaves
+        // half an hour of clearance either side, so the cell is the same whatever time CI starts.
+        var now = HourAligned(DateTime.UtcNow).AddMinutes(-30);
         var events = new List<SearchEvent>();
         for (var i = 0; i < 5; i++)
         {
@@ -390,6 +396,11 @@ public sealed class SearchAnalyticsControllerTests
     }
 
     // --- Helpers ---
+
+    // Truncates to the top of the hour, so a test can anchor seeded events a known distance from
+    // a bucket edge instead of wherever the wall clock happens to sit.
+    private static DateTime HourAligned(DateTime value) =>
+        DateTime.SpecifyKind(new DateTime(value.Year, value.Month, value.Day, value.Hour, 0, 0), DateTimeKind.Utc);
 
     private SearchAnalyticsController Sut()
     {


### PR DESCRIPTION
Two tests failed intermittently in CI regardless of the branch under test, most recently
  taking a reviewer's time on PR 272 and PR 274. Neither indicated a defect in the code it
  covered, but one of them turned out to be sitting on top of a real one.

  ## The observability board had a guard that could never fire

  `start()` in `observability-board.js` closes the feed the previous engine owned, so a board
  root only ever has one writer. Its comment says as much: "prevents two engines fighting over
  the transitions list". It tests `root.__obsEs` — which nothing ever assigned. `subscribe()`
  returns the EventSource and `start()` discarded it, so the handle was always undefined and
  the close was unreachable. Replacing a feed left the previous EventSource connected, with two
  engines rendering into the same transitions list.

  Recording the subscription makes the existing guard reachable. Feeds that own no closeable
  resource return nothing, which clears the handle rather than leaving a stale one behind.

  Only `init()` starts a feed today, so the user-visible impact is limited, but the guard was
  written for a case the code already exercises and it was silently doing nothing.

  ## That defect was what made the board test flaky

  `Dashboard_BoardBinds_LiveRegionPresent_AndTokensAreFocusable` cleared the transitions list
  and then started a stub feed, so the live stream stayed connected across the gap between the
  two. Because the stream yields a snapshot immediately on subscribe as well as on every
  heartbeat, a real transition could repopulate the list before the assertion ran, which then
  read a live request instead of the snapshot the test had driven:

      Assert.Contains() Failure: Sub-string not found
      String:    "Request DEV-e1299ac40cf9, at RulesEvaluat"···
      Not found: "REF-1042"

  Starting the stub feed first now closes the stream, so clearing is final. The fixed 100ms
  sleep that tried to paper over this is gone — `start()` returns a live engine synchronously
  and `onSnapshot` renders synchronously, so there was never anything to wait for.

  Measured with the snapshot heartbeat forced to one second instead of thirty, to widen the
  race as far as it goes:

    before, on main   1 failure in 12 runs
    after             0 failures in 25 runs

  A new test covers the handover itself — that the first feed is recorded, that starting a
  second closes it, and that a feed owning nothing clears the handle — rather than covering it
  only through the symptom.

  ## The aggregate volume test straddled a bucket edge

  `Index_AggregateMode_VolumeSeries_CarriesBothSearchesAndUniqueSessions` seeds five events
  spread backwards over five minutes and asserts they collapse into a single weekday-hour cell,
  but took its anchor from the wall clock. A run starting in the first four minutes of an hour
  pushed some of those events into the previous cell, and the assertion saw a partial count —
  about one run in fifteen.

  Confirmed by pinning the anchor two minutes past an hour, where the count arrives as 3 rather
  than 5. Anchoring at half past an hour leaves thirty minutes of clearance either side, so the
  events span :26 to :30 and cannot cross an edge whatever time the suite starts. The chart
  tests in `SearchAnalyticsChartTests` were already anchored this way; this one had been missed.

  ## Verification

    Release build   clean
    Unit            3538 passed
    Integration      606 passed
    E2E (non-VR)     126 passed, run five consecutive times with no failures

  Neither fix widens a timing window or adds a retry: the board test no longer has a competing
  writer, and the aggregate test no longer depends on what time of day it runs.

  Closes #276