### PR TITLE
Fix BigQuery custom analytics events failing QA (AB#286387)

### DIFF
--- a/docs/bigquery-analytics.md
+++ b/docs/bigquery-analytics.md
@@ -96,7 +96,7 @@ All custom events carry **no PII as plain fields**; a hidden field is noted belo
 | `draft_resumed` | `reference_number`, `what_to_change`, `checking_window_type` | `AmendmentRequestsController.Edit` | `reference_number` |
 | `request_submitted` | `what_to_change`, `checking_window_type`, `reference_number` | `JourneyController.SummaryConfirm` (success) | `reference_number` |
 | `request_submission_failed` | `failure_reason`, `what_to_change`, `checking_window_type` | `JourneyController.SummaryConfirm` (duplicate) | — |
-| `validation_error` | `error_count`, `error_codes`, `what_to_change`, `from_summary` | `JourneyController` (pupil search, page POST), `WhatToChangeController`, `CheckYourPupilDataController` | — |
+| `validation_error` | `error_count`, `error_codes`, `error_fields`, `what_to_change`, `from_summary` | `JourneyController` (pupil search, page POST), `WhatToChangeController`, `CheckYourPupilDataController` | — |
 | `evidence_upload_attempted` | `outcome`, `failure_reason`, `page_count`, `file_size_bytes` | `JourneyController.UploadFile` | — |
 | `evidence_continue` | `file_count`, `page_count`, `evidence_text_length` | `JourneyController.PagePost` (evidence page) | — |
 | `evidence_file_removed` | `files_before`, `files_after` | `JourneyController.RemoveFile` | — |
@@ -105,6 +105,11 @@ All custom events carry **no PII as plain fields**; a hidden field is noted belo
 | `amendment_request_deleted` | `reference_number`, `was_hard_deleted` | `SubmittedRequestController.Delete` (amendment row) | `reference_number` |
 | `confirmation_deleted` | `reference_number` | `SubmittedRequestController.Delete` (ConfirmCorrect row) | `reference_number` |
 | `request_decision` | `decision_status`, `outcome_key`, `matched_rule_id`, `rules_version`, `request_type_code`, `checking_window_type`, `is_synthetic_fallback` | `RulesConsumer` (worker) | — |
+| `search_result_count` | `result_count`, `scope` | `SearchController.Index` (query entered) | — |
+| `feedback_clicked` | `page_path` | `ContactController.FeedbackLink` (via `/feedback-link`) | — |
+| `help_details_expanded` | `expand_text`, `page_path` | `ClientEventsController` (JS beacon) | — |
+| `external_link_clicked` | `destination`, `page_path` | `ClientEventsController` (JS beacon) | — |
+| `evidence_file_selected` | `page_path` | `ClientEventsController` (JS beacon) | — |
 
 Plus the library-provided **`web_request`** event, emitted automatically per request and enriched with the user and organisation.
 
@@ -128,6 +133,8 @@ flowchart LR
 ## PII handling
 
 The `reference_number` is the only identifier currently sent, and only ever as a **hidden** field, pending its DPIA classification. In BigQuery the `hidden_data` column is protected by a policy tag and a SHA256 masking rule, so the raw value is masked at rest while its hash still links the funnel steps. Everything else — free-text reasons, file names, search terms, the pupil's name — is deliberately excluded from events. Counts and lengths (e.g. `evidence_text_length`) are sent in place of the content itself.
+
+The built-in `web_request` event's query string is also redacted: `QueryRedactionEventEnricher` strips the values of pupil-name-bearing query parameters (`includedSearch`, `nonIncludedSearch`, `query`) before the request is sent, so a pupil search term never reaches BigQuery via the request URL.
 
 ---
 

--- a/src/DfE.CheckPerformanceData.Application/Analytics/EvidenceFileSelectedEvent.cs
+++ b/src/DfE.CheckPerformanceData.Application/Analytics/EvidenceFileSelectedEvent.cs
@@ -1,0 +1,17 @@
+namespace DfE.CheckPerformanceData.Application.Analytics;
+
+/// <summary>
+/// Emitted when a user selects a file in the evidence upload picker (AB#286387 R23).
+/// page_path is the referring page's path only — never its query string.
+/// </summary>
+public sealed record EvidenceFileSelectedEvent : AnalyticsEvent
+{
+    public override string EventType => "evidence_file_selected";
+
+    public string? PagePath { get; init; }
+
+    public override IReadOnlyList<AnalyticsField> Fields =>
+    [
+        new("page_path", PagePath),
+    ];
+}

--- a/src/DfE.CheckPerformanceData.Application/Analytics/ExternalLinkClickedEvent.cs
+++ b/src/DfE.CheckPerformanceData.Application/Analytics/ExternalLinkClickedEvent.cs
@@ -1,0 +1,21 @@
+namespace DfE.CheckPerformanceData.Application.Analytics;
+
+/// <summary>
+/// Emitted when a user clicks a link that leaves the service (AB#286387 R19).
+/// page_path is the referring page's path only — never its query string.
+/// destination is a normalised, allowlist-mapped identifier — never a raw URL.
+/// </summary>
+public sealed record ExternalLinkClickedEvent : AnalyticsEvent
+{
+    public override string EventType => "external_link_clicked";
+
+    public required string Destination { get; init; }
+
+    public string? PagePath { get; init; }
+
+    public override IReadOnlyList<AnalyticsField> Fields =>
+    [
+        new("destination", Destination),
+        new("page_path", PagePath),
+    ];
+}

--- a/src/DfE.CheckPerformanceData.Application/Analytics/FeedbackClickedEvent.cs
+++ b/src/DfE.CheckPerformanceData.Application/Analytics/FeedbackClickedEvent.cs
@@ -1,0 +1,17 @@
+namespace DfE.CheckPerformanceData.Application.Analytics;
+
+/// <summary>
+/// Emitted when the phase-banner feedback link is clicked (AB#286387 R20).
+/// page_path is the referring page's path only — never its query string.
+/// </summary>
+public sealed record FeedbackClickedEvent : AnalyticsEvent
+{
+    public override string EventType => "feedback_clicked";
+
+    public string? PagePath { get; init; }
+
+    public override IReadOnlyList<AnalyticsField> Fields =>
+    [
+        new("page_path", PagePath),
+    ];
+}

--- a/src/DfE.CheckPerformanceData.Application/Analytics/HelpDetailsExpandedEvent.cs
+++ b/src/DfE.CheckPerformanceData.Application/Analytics/HelpDetailsExpandedEvent.cs
@@ -1,0 +1,22 @@
+namespace DfE.CheckPerformanceData.Application.Analytics;
+
+/// <summary>
+/// Emitted when a user expands a details/summary help toggle (AB#286387 R18).
+/// page_path is the referring page's path only — never its query string.
+/// expand_text is client-supplied free text and is truncated server-side before
+/// this record is constructed — never trust client input length.
+/// </summary>
+public sealed record HelpDetailsExpandedEvent : AnalyticsEvent
+{
+    public override string EventType => "help_details_expanded";
+
+    public string? ExpandText { get; init; }
+
+    public string? PagePath { get; init; }
+
+    public override IReadOnlyList<AnalyticsField> Fields =>
+    [
+        new("expand_text", ExpandText),
+        new("page_path", PagePath),
+    ];
+}

--- a/src/DfE.CheckPerformanceData.Application/Analytics/SearchResultCountEvent.cs
+++ b/src/DfE.CheckPerformanceData.Application/Analytics/SearchResultCountEvent.cs
@@ -1,0 +1,22 @@
+namespace DfE.CheckPerformanceData.Application.Analytics;
+
+/// <summary>
+/// Emitted after a site/guidance search runs, carrying the result total so
+/// zero-result searches are visible in BigQuery (AB#286387 R22).
+/// The search term itself is intentionally not a field — it is already
+/// visible in web_request.request_query for /search (accepted in QA, R21).
+/// </summary>
+public sealed record SearchResultCountEvent : AnalyticsEvent
+{
+    public override string EventType => "search_result_count";
+
+    public required int ResultCount { get; init; }
+
+    public string? Scope { get; init; }
+
+    public override IReadOnlyList<AnalyticsField> Fields =>
+    [
+        new("result_count", ResultCount),
+        new("scope", Scope),
+    ];
+}

--- a/src/DfE.CheckPerformanceData.Application/Analytics/ValidationErrorEvent.cs
+++ b/src/DfE.CheckPerformanceData.Application/Analytics/ValidationErrorEvent.cs
@@ -9,6 +9,7 @@ public sealed record ValidationErrorEvent : AnalyticsEvent
 {
     public required int ErrorCount { get; init; }
     public required IReadOnlyList<string> ErrorCodes { get; init; }
+    public IReadOnlyList<string>? ErrorFields { get; init; }
     public string? WhatToChange { get; init; }
     public bool? FromSummary { get; init; }
 
@@ -18,6 +19,7 @@ public sealed record ValidationErrorEvent : AnalyticsEvent
     [
         new("error_count", ErrorCount),
         new("error_codes", ErrorCodes),
+        new("error_fields", ErrorFields),
         new("what_to_change", WhatToChange),
         new("from_summary", FromSummary),
     ];

--- a/src/DfE.CheckPerformanceData.Web/Analytics/AnalyticsRequestFilter.cs
+++ b/src/DfE.CheckPerformanceData.Web/Analytics/AnalyticsRequestFilter.cs
@@ -27,6 +27,7 @@ public static class AnalyticsRequestFilter
         "/debug",                // technical/API
         "/docs",                 // technical/API
         "/favicon.ico",          // static asset
+        "/feedback-link",        // AB#286387 R20: emits feedback_clicked itself, then redirects to /contact
         "/graphql",              // technical/API
         "/ip",                   // technical/API
         "/openapi.json",         // technical/API

--- a/src/DfE.CheckPerformanceData.Web/Analytics/AnalyticsRequestFilter.cs
+++ b/src/DfE.CheckPerformanceData.Web/Analytics/AnalyticsRequestFilter.cs
@@ -24,6 +24,7 @@ public static class AnalyticsRequestFilter
         "/.vscode/sftp.json",    // exposed configuration
         "/api",                  // technical/API
         "/api-docs",             // technical/API
+        "/client-events",        // AB#286387 R18/R19/R23: beacon endpoint emits its own event; not a page view
         "/debug",                // technical/API
         "/docs",                 // technical/API
         "/favicon.ico",          // static asset

--- a/src/DfE.CheckPerformanceData.Web/Analytics/QueryRedaction.cs
+++ b/src/DfE.CheckPerformanceData.Web/Analytics/QueryRedaction.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace DfE.CheckPerformanceData.Web.Analytics;
+
+/// <summary>
+/// Masks the values of query-string parameters that carry pupil names before
+/// the web_request analytics event is sent (AB#286387 R3). The custom events
+/// already omit the term; this closes the request_query side channel.
+/// </summary>
+public static class QueryRedaction
+{
+    private static readonly HashSet<string> RedactedParams =
+        new(StringComparer.OrdinalIgnoreCase) { "includedSearch", "nonIncludedSearch", "query" };
+
+    public const string Mask = "[redacted]";
+
+    /// <summary>
+    /// Whether <paramref name="key"/> is one of the pupil-name-carrying params that
+    /// must be masked. Shared with <see cref="QueryRedactionEventEnricher"/>, which
+    /// applies the same denylist directly to <c>Event.RequestQuery</c>'s
+    /// dictionary shape rather than via this string helper.
+    /// </summary>
+    public static bool IsRedactedParam(string key) => RedactedParams.Contains(key);
+
+    public static string? Redact(string? query)
+    {
+        if (string.IsNullOrEmpty(query))
+        {
+            return query;
+        }
+
+        var parsed = QueryHelpers.ParseQuery(query.StartsWith('?') ? query : "?" + query);
+        if (!parsed.Keys.Any(IsRedactedParam))
+        {
+            return query;
+        }
+
+        var builder = new QueryBuilder();
+        foreach (var (key, values) in parsed)
+        {
+            foreach (var value in values)
+            {
+                var masked = IsRedactedParam(key) && !string.IsNullOrEmpty(value)
+                    ? Mask
+                    : value ?? string.Empty;
+                builder.Add(key, masked);
+            }
+        }
+
+        // QueryBuilder emits a leading '?'; mirror the input's shape.
+        var result = builder.ToQueryString().Value ?? string.Empty;
+        return query.StartsWith('?') ? result : result.TrimStart('?');
+    }
+}

--- a/src/DfE.CheckPerformanceData.Web/Analytics/QueryRedactionEventEnricher.cs
+++ b/src/DfE.CheckPerformanceData.Web/Analytics/QueryRedactionEventEnricher.cs
@@ -1,0 +1,41 @@
+using Dfe.Analytics.AspNetCore;
+
+namespace DfE.CheckPerformanceData.Web.Analytics;
+
+/// <summary>
+/// Masks pupil-name query-string values (AB#286387 R3) on the <c>web_request</c>
+/// event before it reaches BigQuery. <c>Event.RequestQuery</c> is populated by the
+/// library as an <c>IDictionary&lt;string, string[]&gt;</c> (see
+/// <c>AspNetCoreEventSender.PopulateEventFromRequest</c>), not a raw query string,
+/// so matching entries are masked in place on the real dictionary rather than via
+/// string parsing. <see cref="QueryRedaction"/> still owns the denylist and mask
+/// token as a pure, independently-tested unit (and as the raw-string fallback used
+/// e.g. for logging); this enricher only asks it which keys to mask.
+/// </summary>
+public sealed class QueryRedactionEventEnricher : IWebRequestEventEnricher
+{
+    public Task EnrichEventAsync(EnrichWebRequestEventContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var requestQuery = context.Event.RequestQuery;
+        if (requestQuery is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        foreach (var key in requestQuery.Keys.ToList())
+        {
+            if (!QueryRedaction.IsRedactedParam(key))
+            {
+                continue;
+            }
+
+            requestQuery[key] = requestQuery[key]
+                .Select(value => string.IsNullOrEmpty(value) ? value : QueryRedaction.Mask)
+                .ToArray();
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/DfE.CheckPerformanceData.Web/Analytics/QueryRedactionEventEnricher.cs
+++ b/src/DfE.CheckPerformanceData.Web/Analytics/QueryRedactionEventEnricher.cs
@@ -8,9 +8,15 @@ namespace DfE.CheckPerformanceData.Web.Analytics;
 /// library as an <c>IDictionary&lt;string, string[]&gt;</c> (see
 /// <c>AspNetCoreEventSender.PopulateEventFromRequest</c>), not a raw query string,
 /// so matching entries are masked in place on the real dictionary rather than via
-/// string parsing. <see cref="QueryRedaction"/> still owns the denylist and mask
-/// token as a pure, independently-tested unit (and as the raw-string fallback used
-/// e.g. for logging); this enricher only asks it which keys to mask.
+/// string parsing. <c>Event.RequestReferer</c> (the raw <c>Referer</c> header,
+/// populated verbatim by the same method) is a separate field that can carry the
+/// same pupil-name query string on the very next same-origin navigation after a
+/// search, so it is scrubbed too via <see cref="QueryRedaction.Redact(string?)"/>
+/// on its query portion.
+/// <see cref="QueryRedaction"/> owns the denylist and mask token as a pure,
+/// independently-tested unit in its own right; this enricher asks it which keys
+/// to mask for <c>RequestQuery</c>, and calls its string-based <c>Redact</c>
+/// directly to scrub <c>RequestReferer</c>'s query string.
 /// </summary>
 public sealed class QueryRedactionEventEnricher : IWebRequestEventEnricher
 {
@@ -19,23 +25,54 @@ public sealed class QueryRedactionEventEnricher : IWebRequestEventEnricher
         ArgumentNullException.ThrowIfNull(context);
 
         var requestQuery = context.Event.RequestQuery;
-        if (requestQuery is null)
+        if (requestQuery is not null)
         {
-            return Task.CompletedTask;
+            foreach (var key in requestQuery.Keys.ToList())
+            {
+                if (!QueryRedaction.IsRedactedParam(key))
+                {
+                    continue;
+                }
+
+                requestQuery[key] = requestQuery[key]
+                    .Select(value => string.IsNullOrEmpty(value) ? value : QueryRedaction.Mask)
+                    .ToArray();
+            }
         }
 
-        foreach (var key in requestQuery.Keys.ToList())
+        var redactedReferer = RedactReferer(context.Event.RequestReferer);
+        if (redactedReferer != context.Event.RequestReferer)
         {
-            if (!QueryRedaction.IsRedactedParam(key))
-            {
-                continue;
-            }
-
-            requestQuery[key] = requestQuery[key]
-                .Select(value => string.IsNullOrEmpty(value) ? value : QueryRedaction.Mask)
-                .ToArray();
+            context.Event.RequestReferer = redactedReferer;
         }
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Scrubs denylisted query-string params from a raw Referer header value.
+    /// Returns <paramref name="referer"/> unchanged when it is null/empty, has no
+    /// query string, is not a well-formed absolute URI, or has nothing to redact
+    /// — the enricher must never throw on an attacker-controlled header.
+    /// </summary>
+    private static string? RedactReferer(string? referer)
+    {
+        if (string.IsNullOrEmpty(referer))
+        {
+            return referer;
+        }
+
+        if (!Uri.TryCreate(referer, UriKind.Absolute, out var uri) || string.IsNullOrEmpty(uri.Query))
+        {
+            return referer;
+        }
+
+        var redactedQuery = QueryRedaction.Redact(uri.Query);
+        if (redactedQuery == uri.Query)
+        {
+            return referer;
+        }
+
+        return uri.GetLeftPart(UriPartial.Path) + redactedQuery + uri.Fragment;
     }
 }

--- a/src/DfE.CheckPerformanceData.Web/Analytics/RefererPagePath.cs
+++ b/src/DfE.CheckPerformanceData.Web/Analytics/RefererPagePath.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Http;
+
+namespace DfE.CheckPerformanceData.Web.Analytics;
+
+/// <summary>
+/// Derives a trustworthy <c>page_path</c> analytics value from the Referer header
+/// (AB#286387 whole-branch review Finding 2). Shared by
+/// <see cref="DfE.CheckPerformanceData.Web.Controllers.ClientEventsController"/> and
+/// <see cref="DfE.CheckPerformanceData.Web.Controllers.ContactController"/>, which
+/// previously duplicated an inline <c>Uri.TryCreate(...).AbsolutePath</c> that
+/// accepted any absolute URI (not just same-origin) with no length cap.
+/// </summary>
+public static class RefererPagePath
+{
+    /// <summary>
+    /// Matches <c>ClientEventsController.MaxTextLength</c>, the existing cap already
+    /// applied to <c>ExpandText</c> on the same beacon request — reusing it here keeps
+    /// every client-influenced analytics string field bounded by the same limit.
+    /// </summary>
+    public const int MaxLength = 100;
+
+    /// <summary>
+    /// Returns the Referer header's path, truncated to <see cref="MaxLength"/>, or
+    /// <see langword="null"/> when the header is missing, not a well-formed absolute
+    /// URI, or not same-origin with <paramref name="request"/>. Same-origin is
+    /// checked via <c>Authority</c>/<c>Host.Value</c> equality, matching the existing
+    /// convention in <c>ContactController.ResolveOpenerReturnUrl</c>.
+    /// </summary>
+    public static string? From(HttpRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!Uri.TryCreate(request.Headers.Referer.ToString(), UriKind.Absolute, out var referer))
+        {
+            return null;
+        }
+
+        if (!string.Equals(referer.Authority, request.Host.Value, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var path = referer.AbsolutePath;
+        return path.Length > MaxLength ? path[..MaxLength] : path;
+    }
+}

--- a/src/DfE.CheckPerformanceData.Web/Controllers/CheckYourPupilData/CheckYourPupilDataController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/CheckYourPupilData/CheckYourPupilDataController.cs
@@ -98,7 +98,7 @@ public sealed class CheckYourPupilDataController(ICheckYourPupilDataService chec
         if (viewModel.SelectedNextStep is null)
         {
             ModelState.AddModelError(nameof(CheckYourPupilDataViewModel.SelectedNextStep), "Select what you would like to do");
-            await analytics.TrackSafeAsync(new ValidationErrorEvent { ErrorCount = 1, ErrorCodes = [ValidationErrorCoding.NoSelection] });
+            await analytics.TrackSafeAsync(new ValidationErrorEvent { ErrorCount = 1, ErrorCodes = [ValidationErrorCoding.NoSelection], ErrorFields = [nameof(CheckYourPupilDataViewModel.SelectedNextStep)] });
             var model = await BuildIndexModelAsync(windowId, 0, 0, null, null);
             return View("Index", model);
         }

--- a/src/DfE.CheckPerformanceData.Web/Controllers/ClientEventsController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/ClientEventsController.cs
@@ -1,4 +1,5 @@
 using DfE.CheckPerformanceData.Application.Analytics;
+using DfE.CheckPerformanceData.Web.Analytics;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -8,7 +9,8 @@ namespace DfE.CheckPerformanceData.Web.Controllers;
 /// Beacon endpoint for client-side analytics (AB#286387 R18/R19/R23).
 /// Allowlisted event names only; the server constructs the typed event so
 /// clients cannot inject arbitrary fields. page_path comes from the Referer
-/// path — its query string is dropped because it can carry search terms.
+/// path via <see cref="RefererPagePath"/> — same-origin only, its query string
+/// dropped (it can carry search terms), and length-capped.
 /// </summary>
 [AllowAnonymous]
 public sealed class ClientEventsController(IAnalyticsService analytics) : Controller
@@ -55,10 +57,7 @@ public sealed class ClientEventsController(IAnalyticsService analytics) : Contro
         return NoContent();
     }
 
-    private string? RefererPath()
-        => Uri.TryCreate(Request.Headers.Referer.ToString(), UriKind.Absolute, out var referer)
-            ? referer.AbsolutePath
-            : null;
+    private string? RefererPath() => RefererPagePath.From(Request);
 
     private static string MapDestination(string hostname)
     {

--- a/src/DfE.CheckPerformanceData.Web/Controllers/ClientEventsController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/ClientEventsController.cs
@@ -1,0 +1,73 @@
+using DfE.CheckPerformanceData.Application.Analytics;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.CheckPerformanceData.Web.Controllers;
+
+/// <summary>
+/// Beacon endpoint for client-side analytics (AB#286387 R18/R19/R23).
+/// Allowlisted event names only; the server constructs the typed event so
+/// clients cannot inject arbitrary fields. page_path comes from the Referer
+/// path — its query string is dropped because it can carry search terms.
+/// </summary>
+[AllowAnonymous]
+public sealed class ClientEventsController(IAnalyticsService analytics) : Controller
+{
+    private const int MaxTextLength = 100;
+
+    public sealed class ClientEventRequest
+    {
+        public string? EventName { get; init; }
+        public string? ExpandText { get; init; }
+        public string? Destination { get; init; }
+    }
+
+    [HttpPost]
+    [Route("/client-events")]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Post([FromBody] ClientEventRequest? request)
+    {
+        var pagePath = RefererPath();
+
+        AnalyticsEvent? analyticsEvent = request?.EventName switch
+        {
+            "help_details_expanded" => new HelpDetailsExpandedEvent
+            {
+                ExpandText = Truncate(request.ExpandText),
+                PagePath = pagePath,
+            },
+            "external_link_clicked" when !string.IsNullOrWhiteSpace(request.Destination) =>
+                new ExternalLinkClickedEvent
+                {
+                    Destination = MapDestination(request.Destination),
+                    PagePath = pagePath,
+                },
+            "evidence_file_selected" => new EvidenceFileSelectedEvent { PagePath = pagePath },
+            _ => null,
+        };
+
+        if (analyticsEvent is null)
+        {
+            return BadRequest();
+        }
+
+        await analytics.TrackSafeAsync(analyticsEvent, HttpContext.RequestAborted);
+        return NoContent();
+    }
+
+    private string? RefererPath()
+        => Uri.TryCreate(Request.Headers.Referer.ToString(), UriKind.Absolute, out var referer)
+            ? referer.AbsolutePath
+            : null;
+
+    private static string MapDestination(string hostname)
+    {
+        var host = hostname.Trim().ToLowerInvariant();
+        return host is "get-information-schools.service.gov.uk" or "www.get-information-schools.service.gov.uk"
+            ? "gias"
+            : Truncate(host)!;
+    }
+
+    private static string? Truncate(string? value)
+        => value is { Length: > MaxTextLength } ? value[..MaxTextLength] : value;
+}

--- a/src/DfE.CheckPerformanceData.Web/Controllers/ContactController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/ContactController.cs
@@ -30,6 +30,23 @@ public sealed class ContactController(
         return View(vm);
     }
 
+    // The Beta phase-banner "feedback" link routes through here so we can record the
+    // click server-side before handing off to the same Contact Us form. page_path is
+    // the referer's path only — never its query string, which may carry a search term.
+    [HttpGet("/feedback-link")]
+    public async Task<IActionResult> FeedbackLink()
+    {
+        string? pagePath = null;
+        if (Uri.TryCreate(Request.Headers.Referer.ToString(), UriKind.Absolute, out var referer))
+        {
+            pagePath = referer.AbsolutePath;
+        }
+
+        await analytics.TrackSafeAsync(new FeedbackClickedEvent { PagePath = pagePath }, HttpContext.RequestAborted);
+
+        return RedirectToAction(nameof(Index));
+    }
+
     [HttpPost("/contact")]
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> Submit(ContactViewModel form)

--- a/src/DfE.CheckPerformanceData.Web/Controllers/ContactController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/ContactController.cs
@@ -43,6 +43,7 @@ public sealed class ContactController(
             {
                 ErrorCount = 1,
                 ErrorCodes = [ValidationErrorCoding.NoSelection],
+                ErrorFields = [nameof(ContactViewModel.EnquiryType)],
             });
 
             var redisplay = await BuildViewModelAsync();

--- a/src/DfE.CheckPerformanceData.Web/Controllers/ContactController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/ContactController.cs
@@ -36,11 +36,7 @@ public sealed class ContactController(
     [HttpGet("/feedback-link")]
     public async Task<IActionResult> FeedbackLink()
     {
-        string? pagePath = null;
-        if (Uri.TryCreate(Request.Headers.Referer.ToString(), UriKind.Absolute, out var referer))
-        {
-            pagePath = referer.AbsolutePath;
-        }
+        var pagePath = RefererPagePath.From(Request);
 
         await analytics.TrackSafeAsync(new FeedbackClickedEvent { PagePath = pagePath }, HttpContext.RequestAborted);
 

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyController.cs
@@ -108,6 +108,7 @@ public sealed class JourneyController(
             {
                 ErrorCount = 1,
                 ErrorCodes = [ValidationErrorCoding.NoSelection],
+                ErrorFields = ["selectedPupilId"],
                 WhatToChange = journey.SelectedWhatToChange?.ToString(),
             });
             return View("PupilSearch", viewModelBuilder.BuildPupilSearchVm(windowId, pageId, page, journey, config));
@@ -123,6 +124,7 @@ public sealed class JourneyController(
             {
                 ErrorCount = 1,
                 ErrorCodes = [ValidationErrorCoding.SamePupil],
+                ErrorFields = ["selectedPupilId"],
                 WhatToChange = journey.SelectedWhatToChange?.ToString(),
             });
             return View("PupilSearch", viewModelBuilder.BuildPupilSearchVm(windowId, pageId, page, journey, config));
@@ -164,6 +166,7 @@ public sealed class JourneyController(
                 {
                     ErrorCount = 1,
                     ErrorCodes = [ValidationErrorCoding.Conflict],
+                    ErrorFields = ["selectedPupilId"],
                     WhatToChange = journey.SelectedWhatToChange?.ToString(),
                 });
                 var pupilName = $"{pupil.Firstname} {pupil.Surname}".Trim();
@@ -344,22 +347,25 @@ public sealed class JourneyController(
         if (!isValid)
         {
             var codes = new List<string>();
+            var fields = new List<string>();
             foreach (var q in page.Questions)
             {
                 if (!ModelState.TryGetValue(q.Id, out var entry) || entry.Errors.Count == 0) continue;
-                if (q.Type == QuestionType.FileUpload) { codes.Add(ValidationErrorCoding.FileRequired); continue; }
+                if (q.Type == QuestionType.FileUpload) { codes.Add(ValidationErrorCoding.FileRequired); fields.Add(q.Id); continue; }
                 // A cross-field failure is a well-formed date in the wrong place, not a malformed
                 // one — coding it as bad_date would hide the distinction the rule exists to make.
-                if (dateRuleQuestionIds.Contains(q.Id)) { codes.Add(ValidationErrorCoding.DateInconsistent); continue; }
+                if (dateRuleQuestionIds.Contains(q.Id)) { codes.Add(ValidationErrorCoding.DateInconsistent); fields.Add(q.Id); continue; }
                 newAnswers.TryGetValue(q.Id, out var ans);
                 var answered = ans is not null && journeyService.IsAnswered(q, ans);
                 codes.Add(ValidationErrorCoding.ForQuestion(q, answered));
+                fields.Add(q.Id);
             }
-            if (atLeastOne is not null) codes.Add(ValidationErrorCoding.AtLeastOne);
+            if (atLeastOne is not null) { codes.Add(ValidationErrorCoding.AtLeastOne); fields.Add("page"); }
             await analytics.TrackSafeAsync(new ValidationErrorEvent
             {
                 ErrorCount = ModelState.ErrorCount,
                 ErrorCodes = codes,
+                ErrorFields = fields,
                 WhatToChange = journey.SelectedWhatToChange?.ToString(),
                 FromSummary = fromSummary,
             });

--- a/src/DfE.CheckPerformanceData.Web/Controllers/SearchController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/SearchController.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using DfE.CheckPerformanceData.Application.Analytics;
 using DfE.CheckPerformanceData.Application.Search;
 using DfE.CheckPerformanceData.Application.Settings;
 using DfE.CheckPerformanceData.Web.Controllers.ViewModels;
@@ -19,7 +20,8 @@ namespace DfE.CheckPerformanceData.Web.Controllers;
 [AllowAnonymous]
 public sealed class SearchController(
     ISiteSearchService searchService,
-    ISettingService settings) : Controller
+    ISettingService settings,
+    IAnalyticsService analytics) : Controller
 {
     [HttpGet("/search")]
     public Task<IActionResult> Index(
@@ -103,6 +105,20 @@ public sealed class SearchController(
                 PageSize = effectivePageSize,
                 TotalCount = 0,
             });
+        }
+
+        // Mirrors the view's feedback-inset gate (Index.cshtml): only emit when a query was
+        // actually run. DataStoreUnavailable cannot occur here — that branch already returned
+        // above — so the condition need only exclude the empty-query landing and the
+        // below-minimum-length invalid branch, same as the view.
+        if (!string.IsNullOrEmpty(result.CurrentQuery)
+            && result.InvalidReason != SearchInvalidReason.BelowMinimumLength)
+        {
+            await analytics.TrackSafeAsync(new SearchResultCountEvent
+            {
+                ResultCount = result.TotalCount,
+                Scope = scope,
+            }, HttpContext.RequestAborted);
         }
 
         // Page over-clamp is handled inside the search service, which pages an already-

--- a/src/DfE.CheckPerformanceData.Web/Controllers/WhatToChangeController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/WhatToChangeController.cs
@@ -31,7 +31,7 @@ public sealed class WhatToChangeController(
         if (vm.SelectedWhatToChange == null)
         {
             ModelState.AddModelError(nameof(WhatToChangeViewModel.SelectedWhatToChange), "Select what pupil data you would like to change");
-            await analytics.TrackSafeAsync(new ValidationErrorEvent { ErrorCount = 1, ErrorCodes = [ValidationErrorCoding.NoSelection] });
+            await analytics.TrackSafeAsync(new ValidationErrorEvent { ErrorCount = 1, ErrorCodes = [ValidationErrorCoding.NoSelection], ErrorFields = [nameof(WhatToChangeViewModel.SelectedWhatToChange)] });
             return View("Index", new WhatToChangeViewModel { WindowId = windowId, SelectedWhatToChange = null });
         }
 

--- a/src/DfE.CheckPerformanceData.Web/Data/QuestionFlows/Remove_KS4June.json
+++ b/src/DfE.CheckPerformanceData.Web/Data/QuestionFlows/Remove_KS4June.json
@@ -180,7 +180,7 @@
           "hint" : "For example, 123/4567 or 1234567",
           "validator": "DfeNumber",
           "questionHelpTitle" : "How can I find a DfE number?",
-          "questionHelpText" : "<p>To find the DfE number, search the school or college name on <a href=\"https://get-information-schools.service.gov.uk/\" target=\"_blank\">Get Information About Schools (opens in new window)</a></p>"
+          "questionHelpText" : "<p>To find the DfE number, search the school or college name on <a href=\"https://get-information-schools.service.gov.uk/?utm_source=cypmd&amp;utm_medium=referral&amp;utm_campaign=help_guidance\" target=\"_blank\">Get Information About Schools (opens in new window)</a></p>"
         }
       ]
     },
@@ -212,7 +212,7 @@
           "validator": "DfeNumber",
           "validationFailure": "Enter the DfE number of the school {pupilName}'s exam results should be transferred to",
           "questionHelpTitle" : "How can I find a DfE number?",
-          "questionHelpText" : "<p>To find the DfE number, search the school or college name on <a href=\"https://get-information-schools.service.gov.uk/\" target=\"_blank\">Get Information About Schools (opens in new window)</a></p>"
+          "questionHelpText" : "<p>To find the DfE number, search the school or college name on <a href=\"https://get-information-schools.service.gov.uk/?utm_source=cypmd&amp;utm_medium=referral&amp;utm_campaign=help_guidance\" target=\"_blank\">Get Information About Schools (opens in new window)</a></p>"
         }
       ]
     },
@@ -230,7 +230,7 @@
           "validator": "DfeNumber",
           "validationFailure": "Enter the DfE number of the school or college where {pupilName} completed KS4",
           "questionHelpTitle" : "How can I find a DfE number?",
-          "questionHelpText" : "<p>To find the DfE number, search the school or college name on <a href=\"https://get-information-schools.service.gov.uk/\" target=\"_blank\">Get Information About Schools (opens in new window)</a></p>"
+          "questionHelpText" : "<p>To find the DfE number, search the school or college name on <a href=\"https://get-information-schools.service.gov.uk/?utm_source=cypmd&amp;utm_medium=referral&amp;utm_campaign=help_guidance\" target=\"_blank\">Get Information About Schools (opens in new window)</a></p>"
         }
       ]
     },
@@ -377,7 +377,7 @@
           "validator": "DfeNumber",
           "validationFailure": "Enter the DfE number of the school which excluded {pupilName}",
           "questionHelpTitle" : "How can I find a DfE number?",
-          "questionHelpText" : "<p>To find the DfE number, search the school or college name on <a href=\"https://get-information-schools.service.gov.uk/\" target=\"_blank\">Get Information About Schools (opens in new window)</a></p>"
+          "questionHelpText" : "<p>To find the DfE number, search the school or college name on <a href=\"https://get-information-schools.service.gov.uk/?utm_source=cypmd&amp;utm_medium=referral&amp;utm_campaign=help_guidance\" target=\"_blank\">Get Information About Schools (opens in new window)</a></p>"
         },
         {
           "id": "date-pupil-excluded",

--- a/src/DfE.CheckPerformanceData.Web/Startup/AnalyticsExtensions.cs
+++ b/src/DfE.CheckPerformanceData.Web/Startup/AnalyticsExtensions.cs
@@ -31,6 +31,10 @@ public static class AnalyticsExtensions
                     options.RequestFilter = AnalyticsRequestFilter.ShouldTrack);
 
             services.AddSingleton<IWebRequestEventEnricher, OrganisationEventEnricher>();
+            // AspNetCoreEventSender resolves IEnumerable<IWebRequestEventEnricher> and runs
+            // every registered enricher, so this masks pupil-name query params (AB#286387 R3)
+            // alongside the organisation enricher above rather than replacing it.
+            services.AddSingleton<IWebRequestEventEnricher, QueryRedactionEventEnricher>();
             // Custom events go through the same IEventSender (AspNetCoreEventSender), so each
             // is sent as its own row, auto-enriched with request + organisation context.
             services.AddTransient<IAnalyticsService, DfeAnalyticsService>();

--- a/src/DfE.CheckPerformanceData.Web/Views/Shared/_Layout.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Shared/_Layout.cshtml
@@ -145,7 +145,7 @@
                 Beta
             </strong>
             <span class="govuk-phase-banner__text">
-                This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+                This is a new service – your <a class="govuk-link" href="/feedback-link">feedback</a> will help us to improve it.
             </span>
         </p>
     </div>

--- a/src/DfE.CheckPerformanceData.Web/Views/Shared/_Layout.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Shared/_Layout.cshtml
@@ -5,6 +5,7 @@
 @using DfE.CheckPerformanceData.Web.Controllers
 @inject Microsoft.Extensions.Hosting.IHostEnvironment HostEnvironment
 @inject Microsoft.Extensions.Configuration.IConfiguration Configuration
+@inject Microsoft.AspNetCore.Antiforgery.IAntiforgery Antiforgery
 @{
     Layout = "_GovUkPageTemplate";
     // "Real DfE auth" = any authenticated identity that isn't the synthetic dev
@@ -59,6 +60,10 @@
         !ViewData.ModelState.IsValid || ViewData["HasError"] is true);
 }
 <head>
+    @* Form-less pages (CMS/guidance) have no __RequestVerificationToken hidden input, so
+       expose the antiforgery token here for wwwroot/js/analytics-events.js (and
+       test-data-seed.js's existing fallback probe) to read via fetch. *@
+    <meta name="request-verification-token" content="@Antiforgery.GetAndStoreTokens(Context).RequestToken" />
     @await Html.PartialAsync("_GtmHead")
     @await Html.PartialAsync("_ClarityHead")
     @Html.GovUkFrontendStyleImports()
@@ -254,5 +259,8 @@
        flash of the yet-to-be-hidden link before the hide-until-init script runs.
        The script no-ops on pages that don't render the .app-back-to-top container. *@
     <script src="~/js/back-to-top.js" defer asp-append-version="true"></script>
+    @* Client-side analytics beacons (AB#286387 R18/R19/R23): help-details expand,
+       external-link clicks, evidence-file selection. Fire-and-forget; never throws. *@
+    <script src="~/js/analytics-events.js" defer asp-append-version="true"></script>
     @RenderSection("Scripts", required: false)
 }

--- a/src/DfE.CheckPerformanceData.Web/wwwroot/js/analytics-events.js
+++ b/src/DfE.CheckPerformanceData.Web/wwwroot/js/analytics-events.js
@@ -1,0 +1,61 @@
+// Client-side analytics beacons (AB#286387 R18/R19/R23).
+// Fire-and-forget: failures must never affect the page.
+(function () {
+    'use strict';
+
+    function getToken() {
+        var meta = document.querySelector('meta[name="request-verification-token"]');
+        if (meta && meta.content) { return meta.content; }
+        var input = document.querySelector('input[name="__RequestVerificationToken"]');
+        return input ? input.value : '';
+    }
+
+    function postEvent(eventName, props) {
+        var token = getToken();
+        if (!token) { return; }
+        var body = Object.assign({ eventName: eventName }, props || {});
+        try {
+            fetch('/client-events', {
+                method: 'POST',
+                keepalive: true,
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-XSRF-TOKEN': token
+                },
+                body: JSON.stringify(body)
+            }).catch(function () { /* swallow */ });
+        } catch (e) { /* swallow */ }
+    }
+
+    // R18: help/details expanders — fire on open only.
+    // 'toggle' does not bubble, so listen in the capture phase.
+    document.addEventListener('toggle', function (e) {
+        var details = e.target;
+        if (!details || details.tagName !== 'DETAILS' || !details.open) { return; }
+        if (!details.classList.contains('govuk-details')) { return; }
+        var summary = details.querySelector('.govuk-details__summary-text');
+        postEvent('help_details_expanded', {
+            expandText: summary ? summary.textContent.trim() : ''
+        });
+    }, true);
+
+    // R19: external link clicks — send hostname only; the server maps GIAS.
+    document.addEventListener('click', function (e) {
+        var anchor = e.target && e.target.closest ? e.target.closest('a[href]') : null;
+        if (!anchor) { return; }
+        var url;
+        try { url = new URL(anchor.href, window.location.href); } catch (err) { return; }
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') { return; }
+        if (url.origin === window.location.origin) { return; }
+        postEvent('external_link_clicked', { destination: url.hostname });
+    }, true);
+
+    // R23: evidence file selected (before Upload is clicked).
+    document.addEventListener('change', function (e) {
+        var input = e.target;
+        if (!input || input.type !== 'file' || input.name !== 'fileUpload') { return; }
+        if (!input.files || input.files.length === 0) { return; }
+        postEvent('evidence_file_selected', {});
+    }, true);
+})();

--- a/tests/DfE.CheckPerformanceData.UnitTests/Analytics/AnalyticsRequestFilterTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Analytics/AnalyticsRequestFilterTests.cs
@@ -31,6 +31,13 @@ public sealed class AnalyticsRequestFilterTests
     public void Excludes_the_feedback_link_tracking_redirect() =>
         Assert.False(AnalyticsRequestFilter.ShouldTrack(new PathString("/feedback-link")));
 
+    // /client-events (AB#286387 R18/R19/R23) is the client-side beacon endpoint; it emits
+    // its own typed event (help_details_expanded / external_link_clicked /
+    // evidence_file_selected), so tracking the POST itself as a web_request would be noise.
+    [Fact]
+    public void Excludes_the_client_events_beacon_endpoint() =>
+        Assert.False(AnalyticsRequestFilter.ShouldTrack(new PathString("/client-events")));
+
     // Prefix matches — tested with a trailing segment so the prefix rule is what fires.
     [Theory]
     [InlineData("/administrator/index.php")]

--- a/tests/DfE.CheckPerformanceData.UnitTests/Analytics/AnalyticsRequestFilterTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Analytics/AnalyticsRequestFilterTests.cs
@@ -24,6 +24,13 @@ public sealed class AnalyticsRequestFilterTests
     public void Excludes_exact_paths(string path) =>
         Assert.False(AnalyticsRequestFilter.ShouldTrack(new PathString(path)));
 
+    // /feedback-link (AB#286387 R20) emits its own feedback_clicked event and then
+    // redirects to /contact; without this exclusion the redirect hop would double-count
+    // the click as a web_request page view too.
+    [Fact]
+    public void Excludes_the_feedback_link_tracking_redirect() =>
+        Assert.False(AnalyticsRequestFilter.ShouldTrack(new PathString("/feedback-link")));
+
     // Prefix matches — tested with a trailing segment so the prefix rule is what fires.
     [Theory]
     [InlineData("/administrator/index.php")]

--- a/tests/DfE.CheckPerformanceData.UnitTests/Analytics/ClientEventsTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Analytics/ClientEventsTests.cs
@@ -1,0 +1,33 @@
+namespace DfE.CheckPerformanceData.Application.UnitTests.Analytics;
+
+using DfE.CheckPerformanceData.Application.Analytics;
+
+public sealed class ClientEventsTests
+{
+    [Fact]
+    public void HelpDetailsExpandedEvent_projects_text_and_path()
+    {
+        var e = new HelpDetailsExpandedEvent { ExpandText = "How can I find a DfE number?", PagePath = "/Journey/x/page/y" };
+        Assert.Equal("help_details_expanded", e.EventType);
+        var byName = e.Fields.ToDictionary(f => f.Name);
+        Assert.Equal("How can I find a DfE number?", byName["expand_text"].Value);
+        Assert.Equal("/Journey/x/page/y", byName["page_path"].Value);
+    }
+
+    [Fact]
+    public void ExternalLinkClickedEvent_projects_destination_and_path()
+    {
+        var e = new ExternalLinkClickedEvent { Destination = "gias", PagePath = "/Journey/x/page/y" };
+        Assert.Equal("external_link_clicked", e.EventType);
+        var byName = e.Fields.ToDictionary(f => f.Name);
+        Assert.Equal("gias", byName["destination"].Value);
+    }
+
+    [Fact]
+    public void EvidenceFileSelectedEvent_projects_path()
+    {
+        var e = new EvidenceFileSelectedEvent { PagePath = "/Journey/x/page/evidence" };
+        Assert.Equal("evidence_file_selected", e.EventType);
+        Assert.Equal("/Journey/x/page/evidence", e.Fields.Single(f => f.Name == "page_path").Value);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Analytics/ContactUsEventsTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Analytics/ContactUsEventsTests.cs
@@ -16,4 +16,14 @@ public sealed class ContactUsEventsTests
         Assert.False(byName["enquiry_type"].Hidden);
         Assert.False(byName["is_authenticated"].Hidden);
     }
+
+    [Fact]
+    public void FeedbackClickedEvent_projects_page_path()
+    {
+        var e = new FeedbackClickedEvent { PagePath = "/CheckYourPupilData/abc" };
+        Assert.Equal("feedback_clicked", e.EventType);
+        var byName = e.Fields.ToDictionary(f => f.Name);
+        Assert.Equal("/CheckYourPupilData/abc", byName["page_path"].Value);
+        Assert.False(byName["page_path"].Hidden);
+    }
 }

--- a/tests/DfE.CheckPerformanceData.UnitTests/Analytics/ValidationAndSearchEventsTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Analytics/ValidationAndSearchEventsTests.cs
@@ -34,6 +34,32 @@ public sealed class ValidationAndSearchEventsTests
     }
 
     [Fact]
+    public void ValidationErrorEvent_projects_error_fields_parallel_to_codes()
+    {
+        var e = new ValidationErrorEvent
+        {
+            ErrorCount = 2,
+            ErrorCodes = ["required", "bad_date"],
+            ErrorFields = ["howEvidenceSupports", "dateOfArrival"],
+            WhatToChange = "Remove",
+            FromSummary = false,
+        };
+
+        var byName = e.Fields.ToDictionary(f => f.Name);
+        Assert.Equal(["howEvidenceSupports", "dateOfArrival"],
+            (IEnumerable<string>)byName["error_fields"].Value!);
+        Assert.False(byName["error_fields"].Hidden);
+    }
+
+    [Fact]
+    public void ValidationErrorEvent_error_fields_defaults_to_null_and_is_omitted()
+    {
+        var e = new ValidationErrorEvent { ErrorCount = 1, ErrorCodes = ["no_selection"] };
+        var byName = e.Fields.ToDictionary(f => f.Name);
+        Assert.Null(byName["error_fields"].Value); // null values are omitted at send
+    }
+
+    [Fact]
     public void PupilDataSearchResultsEvent_projects_count_and_tab()
     {
         var e = new PupilDataSearchResultsEvent { ResultCount = 7, ActiveTab = "included" };

--- a/tests/DfE.CheckPerformanceData.UnitTests/Analytics/ValidationAndSearchEventsTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Analytics/ValidationAndSearchEventsTests.cs
@@ -69,4 +69,15 @@ public sealed class ValidationAndSearchEventsTests
         Assert.Equal(7, byName["result_count"].Value);
         Assert.Equal("included", byName["active_tab"].Value);
     }
+
+    [Fact]
+    public void SearchResultCountEvent_projects_count_and_scope()
+    {
+        var e = new SearchResultCountEvent { ResultCount = 0, Scope = "guidance" };
+        Assert.Equal("search_result_count", e.EventType);
+        var byName = e.Fields.ToDictionary(f => f.Name);
+        Assert.Equal(0, byName["result_count"].Value);
+        Assert.Equal("guidance", byName["scope"].Value);
+        Assert.All(e.Fields, f => Assert.False(f.Hidden));
+    }
 }

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/QuestionFlowExternalLinkTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/QuestionFlowExternalLinkTests.cs
@@ -1,0 +1,42 @@
+using System.Text.RegularExpressions;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#286387 QA fix: "could you also add this at the end of the gias link & any other
+// external links: ?utm_source=cypmd&utm_medium=referral&utm_campaign=help_guidance".
+// The only external links in authored content are the 4 GIAS links in the seeded
+// question-flow JSON (Remove_KS4June.json). This guard test pins that every GIAS link
+// occurrence carries the UTM query string, using &amp; because questionHelpText is raw
+// HTML rendered via @Html.Raw (Views/Journey/_Question.cshtml:29) — a bare & would be
+// invalid in an HTML attribute.
+public sealed class QuestionFlowExternalLinkTests
+{
+    private static string RepoRoot
+    {
+        get
+        {
+            var thisFile = ThisFilePath();
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+        }
+    }
+
+    private static string ThisFilePath([System.Runtime.CompilerServices.CallerFilePath] string path = "")
+        => path;
+
+    private static string PathToRepoFile(string relativePath) =>
+        Path.Combine(RepoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+    [Fact]
+    public void Gias_links_carry_utm_parameters()
+    {
+        var json = File.ReadAllText(PathToRepoFile(
+            "src/DfE.CheckPerformanceData.Web/Data/QuestionFlows/Remove_KS4June.json"));
+
+        var giasCount = Regex.Matches(json, "get-information-schools\\.service\\.gov\\.uk").Count;
+        var utmCount = Regex.Matches(json,
+            "get-information-schools\\.service\\.gov\\.uk/\\?utm_source=cypmd&amp;utm_medium=referral&amp;utm_campaign=help_guidance").Count;
+
+        Assert.True(giasCount > 0, "expected GIAS links in the question flow");
+        Assert.Equal(giasCount, utmCount); // every GIAS link carries the UTM params
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Analytics/QueryRedactionEventEnricherTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Analytics/QueryRedactionEventEnricherTests.cs
@@ -1,0 +1,75 @@
+using Dfe.Analytics.AspNetCore;
+using Dfe.Analytics.Events;
+using DfE.CheckPerformanceData.Web.Analytics;
+using Microsoft.AspNetCore.Http;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Web.Analytics;
+
+public sealed class QueryRedactionEventEnricherTests
+{
+    private static async Task<Event> EnrichAsync(IDictionary<string, string[]> requestQuery)
+    {
+        var httpContext = new DefaultHttpContext();
+        var @event = new Event
+        {
+            EventType = "web_request",
+            Environment = "test",
+            RequestQuery = requestQuery,
+        };
+
+        await new QueryRedactionEventEnricher()
+            .EnrichEventAsync(new EnrichWebRequestEventContext(@event, httpContext));
+
+        return @event;
+    }
+
+    [Fact]
+    public async Task Masks_denylisted_param_values_in_request_query_dictionary()
+    {
+        // Event.RequestQuery is populated by the library as IDictionary<string, string[]>
+        // (see AspNetCoreEventSender.PopulateEventFromRequest), not a raw query string.
+        var ev = await EnrichAsync(new Dictionary<string, string[]>
+        {
+            ["includedSearch"] = ["John Smith"],
+            ["activeTab"] = ["included"],
+        });
+
+        Assert.Equal([QueryRedaction.Mask], ev.RequestQuery["includedSearch"]);
+        Assert.Equal(["included"], ev.RequestQuery["activeTab"]);
+    }
+
+    [Fact]
+    public async Task Leaves_help_search_query_param_untouched()
+    {
+        // R21: the site/help search term ("q") must NOT be redacted.
+        var ev = await EnrichAsync(new Dictionary<string, string[]>
+        {
+            ["q"] = ["pupil premium"],
+        });
+
+        Assert.Equal(["pupil premium"], ev.RequestQuery["q"]);
+    }
+
+    [Fact]
+    public async Task Keeps_empty_denylisted_values_empty()
+    {
+        var ev = await EnrichAsync(new Dictionary<string, string[]>
+        {
+            ["includedSearch"] = [""],
+        });
+
+        Assert.Equal([""], ev.RequestQuery["includedSearch"]);
+    }
+
+    [Fact]
+    public async Task Does_not_throw_when_request_query_is_null()
+    {
+        var httpContext = new DefaultHttpContext();
+        var @event = new Event { EventType = "web_request", Environment = "test" };
+
+        await new QueryRedactionEventEnricher()
+            .EnrichEventAsync(new EnrichWebRequestEventContext(@event, httpContext));
+
+        Assert.Null(@event.RequestQuery);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Analytics/QueryRedactionEventEnricherTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Analytics/QueryRedactionEventEnricherTests.cs
@@ -72,4 +72,68 @@ public sealed class QueryRedactionEventEnricherTests
 
         Assert.Null(@event.RequestQuery);
     }
+
+    private static async Task<Event> EnrichRefererAsync(string? referer)
+    {
+        var httpContext = new DefaultHttpContext();
+        var @event = new Event
+        {
+            EventType = "web_request",
+            Environment = "test",
+            RequestReferer = referer,
+        };
+
+        await new QueryRedactionEventEnricher()
+            .EnrichEventAsync(new EnrichWebRequestEventContext(@event, httpContext));
+
+        return @event;
+    }
+
+    [Fact]
+    public async Task Masks_denylisted_param_values_in_request_referer()
+    {
+        // AB#286387 whole-branch review Finding 1: Event.RequestReferer is a separate
+        // raw-string field (the Referer header verbatim) that must be scrubbed
+        // independently of RequestQuery.
+        var ev = await EnrichRefererAsync(
+            "https://host/CheckYourPupilData/abc?includedSearch=John+Smith&activeTab=included");
+
+        Assert.Equal(
+            "https://host/CheckYourPupilData/abc?includedSearch=%5Bredacted%5D&activeTab=included",
+            ev.RequestReferer);
+    }
+
+    [Fact]
+    public async Task Leaves_request_referer_without_denylisted_params_unchanged()
+    {
+        var ev = await EnrichRefererAsync("https://host/CheckYourPupilData/abc?activeTab=included");
+
+        Assert.Equal("https://host/CheckYourPupilData/abc?activeTab=included", ev.RequestReferer);
+    }
+
+    [Fact]
+    public async Task Leaves_request_referer_without_query_string_unchanged()
+    {
+        var ev = await EnrichRefererAsync("https://host/CheckYourPupilData/abc");
+
+        Assert.Equal("https://host/CheckYourPupilData/abc", ev.RequestReferer);
+    }
+
+    [Fact]
+    public async Task Leaves_null_request_referer_unchanged()
+    {
+        var ev = await EnrichRefererAsync(null);
+
+        Assert.Null(ev.RequestReferer);
+    }
+
+    [Theory]
+    [InlineData("not a url")]
+    [InlineData("/relative/only?includedSearch=John")]
+    public async Task Leaves_malformed_or_non_absolute_request_referer_unchanged_without_throwing(string referer)
+    {
+        var ev = await EnrichRefererAsync(referer);
+
+        Assert.Equal(referer, ev.RequestReferer);
+    }
 }

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Analytics/QueryRedactionTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Analytics/QueryRedactionTests.cs
@@ -1,0 +1,31 @@
+namespace DfE.CheckPerformanceData.Application.UnitTests.Web.Analytics;
+
+using DfE.CheckPerformanceData.Web.Analytics;
+
+public sealed class QueryRedactionTests
+{
+    [Theory]
+    [InlineData("includedSearch=John+Smith", "includedSearch=%5Bredacted%5D")]
+    [InlineData("nonIncludedSearch=Jane&activeTab=included", "nonIncludedSearch=%5Bredacted%5D&activeTab=included")]
+    [InlineData("query=smi", "query=%5Bredacted%5D")]
+    [InlineData("INCLUDEDSEARCH=x", "INCLUDEDSEARCH=%5Bredacted%5D")]
+    public void Redact_masks_denylisted_param_values(string input, string expected)
+        => Assert.Equal(expected, QueryRedaction.Redact(input));
+
+    [Theory]
+    [InlineData("q=pupil+premium")]                 // site search term is intentionally kept (R21)
+    [InlineData("includedPage=2&activeTab=included")]
+    public void Redact_leaves_other_params_untouched(string input)
+        => Assert.Equal(input, QueryRedaction.Redact(input));
+
+    [Fact]
+    public void Redact_keeps_empty_values_empty()
+        => Assert.Equal("includedSearch=&activeTab=included",
+            QueryRedaction.Redact("includedSearch=&activeTab=included"));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Redact_passes_through_null_and_empty(string? input)
+        => Assert.Equal(input, QueryRedaction.Redact(input));
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/ContactControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/ContactControllerTests.cs
@@ -160,13 +160,43 @@ public sealed class ContactControllerTests
     public async Task FeedbackLink_tracks_referer_path_only_and_redirects_to_index()
     {
         var sut = CreateSut(authenticated: false, out var ctx);
-        ctx.Request.Headers.Referer = "https://host/CheckYourPupilData/x?includedSearch=Smith";
+        ctx.Request.Headers.Referer = "https://localhost/CheckYourPupilData/x?includedSearch=Smith";
 
         var result = await sut.FeedbackLink();
 
         Assert.Equal(nameof(ContactController.Index), Assert.IsType<RedirectToActionResult>(result).ActionName);
         await _analytics.Received(1).TrackAsync(
             Arg.Is<FeedbackClickedEvent>(e => e.PagePath == "/CheckYourPupilData/x"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FeedbackLink_cross_origin_referer_yields_null_page_path()
+    {
+        // AB#286387 whole-branch review Finding 2: only same-origin referers are trusted
+        // as a page_path source.
+        var sut = CreateSut(authenticated: false, out var ctx);
+        ctx.Request.Headers.Referer = "https://evil.example/CheckYourPupilData/x";
+
+        await sut.FeedbackLink();
+
+        await _analytics.Received(1).TrackAsync(
+            Arg.Is<FeedbackClickedEvent>(e => e.PagePath == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task FeedbackLink_long_same_origin_referer_path_is_truncated()
+    {
+        var longPath = "/" + new string('a', 250);
+        var expectedTruncated = longPath[..100];
+        var sut = CreateSut(authenticated: false, out var ctx);
+        ctx.Request.Headers.Referer = $"https://localhost{longPath}";
+
+        await sut.FeedbackLink();
+
+        await _analytics.Received(1).TrackAsync(
+            Arg.Is<FeedbackClickedEvent>(e => e.PagePath == expectedTruncated),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/ContactControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/ContactControllerTests.cs
@@ -156,6 +156,20 @@ public sealed class ContactControllerTests
         Assert.Equal("/guidance", Assert.IsType<RedirectResult>(result).Url);
     }
 
+    [Fact]
+    public async Task FeedbackLink_tracks_referer_path_only_and_redirects_to_index()
+    {
+        var sut = CreateSut(authenticated: false, out var ctx);
+        ctx.Request.Headers.Referer = "https://host/CheckYourPupilData/x?includedSearch=Smith";
+
+        var result = await sut.FeedbackLink();
+
+        Assert.Equal(nameof(ContactController.Index), Assert.IsType<RedirectToActionResult>(result).ActionName);
+        await _analytics.Received(1).TrackAsync(
+            Arg.Is<FeedbackClickedEvent>(e => e.PagePath == "/CheckYourPupilData/x"),
+            Arg.Any<CancellationToken>());
+    }
+
     private static ContactViewModel Model(IActionResult result) =>
         Assert.IsType<ContactViewModel>(Assert.IsType<ViewResult>(result).Model);
 }

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/ClientEventsControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/ClientEventsControllerTests.cs
@@ -13,6 +13,7 @@ public sealed class ClientEventsControllerTests
     private ClientEventsController NewSut(string? referer = null)
     {
         var httpContext = new DefaultHttpContext();
+        httpContext.Request.Host = new HostString("host");
         if (referer is not null)
         {
             httpContext.Request.Headers.Referer = referer;
@@ -131,5 +132,31 @@ public sealed class ClientEventsControllerTests
 
         var e = Assert.IsType<EvidenceFileSelectedEvent>(Captured());
         Assert.Null(e.PagePath);
+    }
+
+    [Fact]
+    public async Task Cross_origin_referer_yields_null_page_path()
+    {
+        // AB#286387 whole-branch review Finding 2: only same-origin referers are trusted
+        // as a page_path source.
+        var sut = NewSut("https://evil.example/Journey/x");
+
+        await sut.Post(new ClientEventsController.ClientEventRequest { EventName = "evidence_file_selected" });
+
+        var e = Assert.IsType<EvidenceFileSelectedEvent>(Captured());
+        Assert.Null(e.PagePath);
+    }
+
+    [Fact]
+    public async Task Long_same_origin_referer_path_is_truncated()
+    {
+        var longPath = "/" + new string('a', 250);
+        var sut = NewSut($"https://host{longPath}");
+
+        await sut.Post(new ClientEventsController.ClientEventRequest { EventName = "evidence_file_selected" });
+
+        var e = Assert.IsType<EvidenceFileSelectedEvent>(Captured());
+        Assert.Equal(100, e.PagePath!.Length);
+        Assert.Equal(longPath[..100], e.PagePath);
     }
 }

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/ClientEventsControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/ClientEventsControllerTests.cs
@@ -1,0 +1,135 @@
+namespace DfE.CheckPerformanceData.Application.UnitTests.Web.Controllers;
+
+using DfE.CheckPerformanceData.Application.Analytics;
+using DfE.CheckPerformanceData.Web.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+
+public sealed class ClientEventsControllerTests
+{
+    private readonly IAnalyticsService _analytics = Substitute.For<IAnalyticsService>();
+
+    private ClientEventsController NewSut(string? referer = null)
+    {
+        var httpContext = new DefaultHttpContext();
+        if (referer is not null)
+        {
+            httpContext.Request.Headers.Referer = referer;
+        }
+
+        return new ClientEventsController(_analytics)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext },
+        };
+    }
+
+    private AnalyticsEvent? Captured()
+    {
+        var calls = _analytics.ReceivedCalls().ToList();
+        return calls.Count == 0 ? null : (AnalyticsEvent?)calls[0].GetArguments()[0];
+    }
+
+    [Fact]
+    public async Task Help_details_expanded_returns_204_and_emits_event_with_referer_path_only()
+    {
+        var sut = NewSut("https://host/Journey/x?fromSummary=true");
+
+        var result = await sut.Post(new ClientEventsController.ClientEventRequest
+        {
+            EventName = "help_details_expanded",
+            ExpandText = "How can I find a DfE number?",
+        });
+
+        Assert.IsType<NoContentResult>(result);
+        var e = Assert.IsType<HelpDetailsExpandedEvent>(Captured());
+        Assert.Equal("How can I find a DfE number?", e.ExpandText);
+        Assert.Equal("/Journey/x", e.PagePath); // query stripped
+    }
+
+    [Fact]
+    public async Task Expand_text_is_truncated_to_100_chars()
+    {
+        var sut = NewSut();
+
+        await sut.Post(new ClientEventsController.ClientEventRequest
+        {
+            EventName = "help_details_expanded",
+            ExpandText = new string('a', 250),
+        });
+
+        var e = Assert.IsType<HelpDetailsExpandedEvent>(Captured());
+        Assert.Equal(100, e.ExpandText!.Length);
+    }
+
+    [Fact]
+    public async Task Gias_hostname_maps_to_gias_destination()
+    {
+        var sut = NewSut();
+
+        var result = await sut.Post(new ClientEventsController.ClientEventRequest
+        {
+            EventName = "external_link_clicked",
+            Destination = "get-information-schools.service.gov.uk",
+        });
+
+        Assert.IsType<NoContentResult>(result);
+        var e = Assert.IsType<ExternalLinkClickedEvent>(Captured());
+        Assert.Equal("gias", e.Destination);
+    }
+
+    [Fact]
+    public async Task Other_hostnames_pass_through_lowercased()
+    {
+        var sut = NewSut();
+
+        await sut.Post(new ClientEventsController.ClientEventRequest
+        {
+            EventName = "external_link_clicked",
+            Destination = "Example.ORG",
+        });
+
+        var e = Assert.IsType<ExternalLinkClickedEvent>(Captured());
+        Assert.Equal("example.org", e.Destination);
+    }
+
+    [Fact]
+    public async Task Evidence_file_selected_returns_204_and_emits_event()
+    {
+        var sut = NewSut("https://host/Journey/x/page/evidence");
+
+        var result = await sut.Post(new ClientEventsController.ClientEventRequest
+        {
+            EventName = "evidence_file_selected",
+        });
+
+        Assert.IsType<NoContentResult>(result);
+        var e = Assert.IsType<EvidenceFileSelectedEvent>(Captured());
+        Assert.Equal("/Journey/x/page/evidence", e.PagePath);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("not_an_allowed_event")]
+    [InlineData("request_submitted")] // server-only events must not be client-triggerable
+    public async Task Unknown_or_disallowed_event_names_return_400_and_emit_nothing(string? eventName)
+    {
+        var sut = NewSut();
+
+        var result = await sut.Post(new ClientEventsController.ClientEventRequest { EventName = eventName });
+
+        Assert.IsType<BadRequestResult>(result);
+        Assert.Null(Captured());
+    }
+
+    [Fact]
+    public async Task Missing_referer_yields_null_page_path()
+    {
+        var sut = NewSut(referer: null);
+
+        await sut.Post(new ClientEventsController.ClientEventRequest { EventName = "evidence_file_selected" });
+
+        var e = Assert.IsType<EvidenceFileSelectedEvent>(Captured());
+        Assert.Null(e.PagePath);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/SearchControllerAnalyticsTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/SearchControllerAnalyticsTests.cs
@@ -1,0 +1,72 @@
+using DfE.CheckPerformanceData.Application.Analytics;
+using DfE.CheckPerformanceData.Application.Search;
+using DfE.CheckPerformanceData.Application.Settings;
+using DfE.CheckPerformanceData.Web.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Web.Controllers;
+
+// AB#286387 R22: the /search endpoint must emit search_result_count so zero-result
+// searches are visible in BigQuery. Mirrors the view's feedback-inset gate — the event
+// fires only when a query was actually run (a non-empty CurrentQuery came back from the
+// service), never on the empty-landing request and never on the DataStoreUnavailable
+// (503) branch, which SearchControllerPaginationTests already pins as a non-emitting path.
+public sealed class SearchControllerAnalyticsTests
+{
+    private readonly ISiteSearchService _searchService = Substitute.For<ISiteSearchService>();
+    private readonly ISettingService _settings = Substitute.For<ISettingService>();
+    private readonly IAnalyticsService _analytics = Substitute.For<IAnalyticsService>();
+
+    private SearchController CreateSut(int totalCount = 0, SearchInvalidReason? invalidReason = null)
+    {
+        _settings.GetIntAsync(SettingKeys.CmsPageLength).Returns(20);
+        _searchService
+            .SearchAsync(Arg.Any<SiteSearchQuery>())
+            .Returns(callInfo =>
+            {
+                var q = callInfo.Arg<SiteSearchQuery>();
+                return Task.FromResult(new SiteSearchPagedResult
+                {
+                    CurrentQuery = q.Query ?? string.Empty,
+                    ScopePath = q.ScopePath,
+                    InvalidReason = invalidReason,
+                    Hits = Array.Empty<CanonicalSearchHit>(),
+                    TotalCount = totalCount,
+                    Page = 0,
+                    PageSize = q.PageSize,
+                });
+            });
+
+        return new SearchController(_searchService, _settings, _analytics)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext(),
+            },
+        };
+    }
+
+    [Fact]
+    public async Task Index_QueryWithZeroHits_EmitsSearchResultCountEvent()
+    {
+        var sut = CreateSut(totalCount: 0);
+
+        _ = await sut.Index("anything", scope: "guidance", includePages: null, includeContentBlocks: null);
+
+        await _analytics.Received(1).TrackAsync(
+            Arg.Is<SearchResultCountEvent>(e => e.ResultCount == 0 && e.Scope == "guidance"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Index_EmptyQuery_DoesNotEmitSearchResultCountEvent()
+    {
+        var sut = CreateSut(totalCount: 0, invalidReason: SearchInvalidReason.EmptyQuery);
+
+        _ = await sut.Index(q: null, scope: null, includePages: null, includeContentBlocks: null);
+
+        await _analytics.DidNotReceive().TrackAsync(Arg.Any<SearchResultCountEvent>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/SearchControllerPaginationTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/SearchControllerPaginationTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using DfE.CheckPerformanceData.Application.Analytics;
 using DfE.CheckPerformanceData.Application.Search;
 using DfE.CheckPerformanceData.Application.Settings;
 using DfE.CheckPerformanceData.Web.Controllers;
@@ -37,6 +38,7 @@ public sealed class SearchControllerPaginationTests
 {
     private readonly ISiteSearchService _searchService = Substitute.For<ISiteSearchService>();
     private readonly ISettingService _settings = Substitute.For<ISettingService>();
+    private readonly IAnalyticsService _analytics = Substitute.For<IAnalyticsService>();
 
     // Compose a controller with a mocked service that echoes the requested paging window back
     // to the caller. The optional invalidReason lets a single helper drive both the happy path
@@ -78,7 +80,7 @@ public sealed class SearchControllerPaginationTests
                 });
             });
 
-        var controller = new SearchController(_searchService, _settings)
+        var controller = new SearchController(_searchService, _settings, _analytics)
         {
             ControllerContext = new ControllerContext
             {

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/SearchControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/SearchControllerTests.cs
@@ -1,3 +1,4 @@
+using DfE.CheckPerformanceData.Application.Analytics;
 using DfE.CheckPerformanceData.Application.Search;
 using DfE.CheckPerformanceData.Application.Settings;
 using DfE.CheckPerformanceData.Web.Controllers;
@@ -22,6 +23,7 @@ public sealed class SearchControllerTests
 {
     private readonly ISiteSearchService _searchService = Substitute.For<ISiteSearchService>();
     private readonly ISettingService _settings = Substitute.For<ISettingService>();
+    private readonly IAnalyticsService _analytics = Substitute.For<IAnalyticsService>();
 
     private SearchController CreateSut()
     {
@@ -29,7 +31,7 @@ public sealed class SearchControllerTests
             .SearchAsync(Arg.Any<SiteSearchQuery>())
             .Returns(callInfo => Task.FromResult(EmptyResultFor(callInfo.Arg<SiteSearchQuery>())));
         _settings.GetIntAsync(SettingKeys.CmsPageLength).Returns(20);
-        return new SearchController(_searchService, _settings)
+        return new SearchController(_searchService, _settings, _analytics)
         {
             // The 503 branch writes Response.StatusCode; even the happy-path tests keep the
             // context wired so a future assertion that reaches Response cannot NRE on a null

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Views/LayoutViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Views/LayoutViewSourceTests.cs
@@ -1,0 +1,33 @@
+namespace DfE.CheckPerformanceData.Application.UnitTests.Web.Views;
+
+// Source-file assertion pattern (mirrors SearchIndexViewTests / AutocompleteRestoreViewSourceTests):
+// reads Views/Shared/_Layout.cshtml from disk and asserts static Razor-source facts for
+// AB#286387 R18/R19/R23 client-side analytics wiring.
+//
+// Form-less pages (CMS/guidance) have no __RequestVerificationToken hidden input, so
+// _Layout must expose the antiforgery token via a <meta name="request-verification-token">
+// tag, which wwwroot/js/test-data-seed.js:42 already probes for as a fallback and which
+// the new wwwroot/js/analytics-events.js also relies on. _Layout must also load the new
+// script. The href="#" assertion is a regression guard for the dead feedback link removed
+// in Task 4.
+public sealed class LayoutViewSourceTests
+{
+    private static string ReadViewSource(string relativePath)
+    {
+        var viewsDir = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "src", "DfE.CheckPerformanceData.Web"));
+        return File.ReadAllText(Path.Combine(viewsDir, relativePath));
+    }
+
+    [Fact]
+    public void Layout_exposes_antiforgery_meta_and_loads_analytics_events_js()
+    {
+        var source = ReadViewSource("Views/Shared/_Layout.cshtml");
+
+        Assert.Contains("request-verification-token", source);
+        Assert.Contains("analytics-events.js", source);
+        Assert.DoesNotContain("href=\"#\"", source); // the dead feedback link is gone (Task 4)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes every row of the "Custom Events" tab of the CYPMD Success Measures QA spreadsheet that failed QA, across 8 tasks (9 commits, including one fix round from a whole-branch review).

## What changed, by QA row

- **R6 / R9** — `validation_error` now carries an `error_fields` list alongside `error_codes`, so QA can see which question/field each error code belongs to (e.g. "required" no longer needs guessing which field it's for).
- **R3** — Pupil search terms no longer reach BigQuery. This turned out to need two fixes: the `web_request.request_query` field was redacted first, then a whole-branch review caught that the same names were still leaking through a second field, `web_request.request_referer`, on the very next click after a search (because no `Referrer-Policy` was set). Both are now redacted.
- **R22** — New `search_result_count` event, so zero-result guidance/help searches are visible in BigQuery (not just the search term).
- **R20** — The dead "give feedback" link in the phase banner now works: it fires a `feedback_clicked` event and takes the user to the contact form.
- **R18 / R19 / R23** — Three new client-side events (`help_details_expanded`, `external_link_clicked`, `evidence_file_selected`) via a new `/client-events` endpoint. The server only ever accepts three named event types from the client — it can't be sent arbitrary data.
- **R19 (content)** — The GIAS help links now carry the requested UTM tracking parameters (`utm_source=cypmd&utm_medium=referral&utm_campaign=help_guidance`).
- Docs: `docs/bigquery-analytics.md` updated with the new events and the redaction behaviour.

## ⚠️ Operational notes — action needed after merge

**1. The GIAS link update (R19) will not reach QA/Preprod/Production automatically.**
The UTM parameters live in a content file (`Remove_KS4June.json`) that gets loaded from Azure Blob Storage in those environments. Only the Development and Review environments auto-refresh that content on startup — QA, Preproduction and Production do not. **Someone needs to manually re-upload the updated `Remove_KS4June.json` to the blob storage container for each of those three environments**, or the GIAS links there will keep showing the old URLs without the tracking parameters.

**2. QA needs `DfeAnalytics:DatasetId` configured to see any of this.**
None of the events in this PR (new or fixed) will show up in BigQuery for QA to check off unless the `DfeAnalytics:DatasetId` setting is configured in the environment being tested. This isn't new — it's an existing requirement — but it's easy to miss and would otherwise look like the fixes didn't work.

## Test plan

- [x] Full unit test suite passing: 3591/3591
- [x] Full solution build: 0 errors, no new warnings
- [x] Every task implemented test-first (failing test confirmed before the fix), reviewed individually for spec compliance and code quality
- [x] Whole-branch review (independent pass across all 8 tasks) run after completion; its two Important findings (the `request_referer` leak and unvalidated `page_path` on referer-derived fields) were fixed and re-reviewed clean
- [ ] Manual smoke test in a running environment (not done locally — Docker wasn't available in this session)
- [ ] QA re-check against the original spreadsheet once deployed with `DfeAnalytics:DatasetId` configured