### PR TITLE
Fix import parent ordering - Fix deep page trees needing repeated imports

### DIFF
--- a/src/DfE.CheckPerformanceData.Application/ContentStaging/ContentStagingService.cs
+++ b/src/DfE.CheckPerformanceData.Application/ContentStaging/ContentStagingService.cs
@@ -21,7 +21,27 @@ public sealed class ContentStagingService(
     IHtmlRenderingService htmlRenderer,
     ILogger<ContentStagingService>? logger = null) : IContentStagingService
 {
-    private const int MaxDepth = 10;
+    // Ancestor walks used to be bounded by a fixed depth ceiling. The ceiling was only ever there
+    // to stop a malformed bundle spinning forever, but it silently truncated legitimately deep
+    // trees as well — and each truncation was its own defect: a saturated depth made every page
+    // past the ceiling sort equal (so the import could attempt a child before its parent, record
+    // it as "parent not found", and only create it on a later run), a truncated path made the
+    // preview compare the wrong path for collisions, and a truncated ancestor set let a selective
+    // export omit the top of a deep page's chain, producing a bundle that could never fully land.
+    //
+    // Walking until the chain repeats a node stops a cycle just as firmly, without putting a
+    // ceiling on how deep a real page tree is allowed to be.
+    private static IEnumerable<T> SelfAndAncestors<T>(T start, Func<T, Guid> idOf, Func<T, T?> parentOf)
+        where T : class
+    {
+        var seen = new HashSet<Guid>();
+        var cursor = start;
+        while (cursor is not null && seen.Add(idOf(cursor)))
+        {
+            yield return cursor;
+            cursor = parentOf(cursor);
+        }
+    }
 
     private readonly ILogger<ContentStagingService> _log =
         logger ?? NullLogger<ContentStagingService>.Instance;
@@ -484,17 +504,8 @@ public sealed class ContentStagingService(
     {
         var byId = BundleById(pages);
 
-        int DepthOfPage(PageNodeBundleItem page)
-        {
-            var depth = 0;
-            var cursor = page;
-            while (cursor.ParentId is { } pid && byId.TryGetValue(pid, out var parent) && depth < MaxDepth)
-            {
-                depth++;
-                cursor = parent;
-            }
-            return depth;
-        }
+        int DepthOfPage(PageNodeBundleItem page) =>
+            SelfAndAncestors(page, p => p.Id, p => BundleParent(p, byId)).Count() - 1;
 
         return pages
             .OrderBy(DepthOfPage)
@@ -506,17 +517,19 @@ public sealed class ContentStagingService(
     // The materialised path a bundle item would land at, rebuilt from parent segments.
     private static string VirtualPath(PageNodeBundleItem page, IReadOnlyDictionary<Guid, PageNodeBundleItem> byId)
     {
-        var segments = new List<string>();
-        PageNodeBundleItem? cursor = page;
-        var depth = 0;
-        while (cursor is not null && depth < MaxDepth)
-        {
-            segments.Insert(0, cursor.Segment);
-            cursor = cursor.ParentId is { } pid && byId.TryGetValue(pid, out var parent) ? parent : null;
-            depth++;
-        }
+        var segments = SelfAndAncestors(page, p => p.Id, p => BundleParent(p, byId))
+            .Select(p => p.Segment)
+            .Reverse();
         return string.Join("/", segments);
     }
+
+    private static PageNodeBundleItem? BundleParent(
+        PageNodeBundleItem page, IReadOnlyDictionary<Guid, PageNodeBundleItem> byId) =>
+        page.ParentId is { } pid && byId.TryGetValue(pid, out var parent) ? parent : null;
+
+    private static PageNodeTreeItemDto? TreeParent(
+        PageNodeTreeItemDto node, IReadOnlyDictionary<Guid, PageNodeTreeItemDto> byId) =>
+        node.ParentId is { } pid && byId.TryGetValue(pid, out var parent) ? parent : null;
 
     // ---- export-side helpers ----------------------------------------------------------------
 
@@ -547,17 +560,8 @@ public sealed class ContentStagingService(
         return ordered;
     }
 
-    private static int DepthOf(PageNodeTreeItemDto node, Dictionary<Guid, PageNodeTreeItemDto> byId)
-    {
-        var depth = 0;
-        var cursor = node;
-        while (cursor.ParentId is { } pid && byId.TryGetValue(pid, out var parent) && depth < MaxDepth)
-        {
-            depth++;
-            cursor = parent;
-        }
-        return depth;
-    }
+    private static int DepthOf(PageNodeTreeItemDto node, Dictionary<Guid, PageNodeTreeItemDto> byId) =>
+        SelfAndAncestors(node, n => n.Id, n => TreeParent(n, byId)).Count() - 1;
 
     private static HashSet<Guid> ExpandWithAncestors(
         IReadOnlySet<Guid> selected, Dictionary<Guid, PageNodeTreeItemDto> byId)
@@ -567,13 +571,8 @@ public sealed class ContentStagingService(
         foreach (var guid in selected)
         {
             if (!byId.TryGetValue(guid, out var cursor)) continue;
-            var depth = 0;
-            while (cursor is not null && depth < MaxDepth)
-            {
-                included.Add(cursor.Id);
-                cursor = cursor.ParentId is { } pid && byId.TryGetValue(pid, out var parent) ? parent : null;
-                depth++;
-            }
+            foreach (var node in SelfAndAncestors(cursor, n => n.Id, n => TreeParent(n, byId)))
+                included.Add(node.Id);
         }
 
         return included;

--- a/tests/DfE.CheckPerformanceData.UnitTests/ContentStaging/ContentStagingServiceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/ContentStaging/ContentStagingServiceTests.cs
@@ -300,6 +300,82 @@ public class ContentStagingServiceTests
 
     // ── Import ─────────────────────────────────────────────────────────────
 
+    // Exporting a selection pulls in the chosen pages' ancestors, because a bundle whose pages
+    // have no parent cannot be imported. Bounding that walk by a fixed depth silently dropped the
+    // top of a deep page's chain, producing a bundle that could never fully land however many
+    // times it was imported.
+    [Fact]
+    public async Task ExportAsync_SelectingADeepPage_CarriesEveryAncestor()
+    {
+        const int depth = 14;
+        var ids = Enumerable.Range(1, depth).Select(i => new Guid($"22222222-0000-0000-0000-{i:D12}")).ToList();
+
+        var tree = new List<PageNodeTreeItemDto>();
+        for (var i = 0; i < depth; i++)
+            tree.Add(Node(ids[i], i == 0 ? null : ids[i - 1], $"level-{i:D2}", $"Level {i:D2}"));
+        _pages.GetTreeAsync().Returns(tree);
+
+        // Select only the deepest page; every ancestor has to come with it.
+        var selection = new ContentExportSelection(
+            new HashSet<Guid> { ids[^1] }, new HashSet<Guid>());
+
+        var bundle = await _sut.ExportAsync(selection);
+
+        Assert.Equal(depth, bundle.PageNodes.Count);
+        Assert.All(ids, id => Assert.Contains(bundle.PageNodes, p => p.Id == id));
+    }
+
+    // A bundle is applied in one pass, so every page has to be created after its parent. Ordering
+    // by a depth that saturates at a ceiling does not achieve that: past the ceiling every page
+    // compares equal and the SortOrder/Title tie-break decides, which can put a child first. The
+    // child then hits the "parent not found" branch and only appears on a LATER import — the
+    // symptom being an operator having to run the same import two or three times to land the
+    // whole tree, one level deeper each time.
+    //
+    // Emitted deepest-first with titles that sort children ahead of parents, so a correct
+    // implementation has to derive the order rather than inherit it from the file.
+    [Fact]
+    public async Task ImportAsync_DeeplyNestedTree_LandsEntirelyInASinglePass()
+    {
+        const int depth = 14;
+        // Offset by one so level 00 never lands on Guid.Empty, which the importer treats as
+        // "no stable identity" and would confuse this test with a different code path.
+        var ids = Enumerable.Range(1, depth).Select(i => new Guid($"11111111-0000-0000-0000-{i:D12}")).ToList();
+
+        var nodes = new List<PageNodeBundleItem>();
+        for (var i = 0; i < depth; i++)
+        {
+            nodes.Add(new PageNodeBundleItem
+            {
+                Id = ids[i],
+                ParentId = i == 0 ? null : ids[i - 1],
+                Segment = $"level-{i:D2}",
+                // Deeper pages sort alphabetically earlier, defeating the tie-break.
+                Title = $"{(char)('z' - i)} level {i:D2}",
+                PageType = "content",
+                Versions = [new() { VersionId = 1, Content = "{}" }]
+            });
+        }
+        nodes.Reverse();
+
+        _pages.GetByIdAsync(Arg.Any<Guid>()).ReturnsNull();
+        _pages.GetByPathAsync(Arg.Any<string>()).ReturnsNull();
+        _pages.CreateNodeForStagingAsync(
+                Arg.Any<Guid>(), Arg.Any<Guid?>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+                Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<bool>(),
+                Arg.Any<string?>(), Arg.Any<string?>())
+            .Returns(ci => new PageNodeDto
+            {
+                Id = (Guid)ci[0]!, ParentId = (Guid?)ci[1], Segment = (string)ci[2]!,
+                Path = (string)ci[3]!, Title = (string)ci[4]!, PageType = (string)ci[7]!
+            });
+
+        var result = await _sut.ImportAsync(new ContentBundle { PageNodes = nodes }, ContentImportMode.Skip);
+
+        Assert.Empty(result.Errors);
+        Assert.Equal(depth, result.PageNodesCreated);
+    }
+
     [Fact]
     public async Task ImportAsync_NewNode_CallsCreateThenReplaceVersions()
     {


### PR DESCRIPTION
Importing a content-staging bundle on a clean database did not land the whole page tree.
  Running the same import again added another level, and again another, so an operator had to
  repeat it until the count stopped changing.

  ## Cause

  Four ancestor walks in content staging were bounded by a fixed depth ceiling of ten. The
  ceiling was there to stop a malformed bundle spinning forever, but it also truncated
  legitimately deep trees, and each truncation was its own defect.

  Import ordering was the visible one. Pages are ordered by depth so a parent is always created
  before its children, but past the ceiling every page reported the same depth, so the ordering
  fell through to sort order and title. Wherever that put a child ahead of its parent, the child
  failed parent resolution, was recorded as "parent was not found", and was only created on a
  later import once its parent existed — one level per run.

  The same ceiling truncated the path the preview reconstructs, so a deep page was compared
  against the wrong path when detecting collisions. And it truncated the ancestors pulled into a
  selective export, so exporting a deep page could produce a bundle whose top ancestors were
  missing, which could then never fully import however many times it was run.

  ## Fix

  Walk the ancestor chain until it revisits a node. That stops a cycle just as firmly as a
  ceiling did, without putting a limit on how deep a real page tree is allowed to be. The four
  walks now share one helper, so the same defect cannot come back in one of them alone.

  ## Reproducing

  The export taken from the test site does NOT show this — it is only three levels deep. It needs
  a tree deeper than ten, emitted deepest-first, with titles that sort children ahead of their
  parents; otherwise the tie-break happens to produce a workable order and the bug hides.

  Against a cleared database, a fourteen-level chain before this change:

    import 1   11 of 14 pages
    import 2   12 of 14
    import 3   13 of 14
    import 4   14 of 14

  After: 14 of 14 on the first import, and a second import correctly adds nothing.

  ## Tests

  Two, both confirmed to fail against the previous code:

  - a deeply nested bundle lands entirely in a single pass, with no errors
  - a selective export of the deepest page carries every ancestor (it previously carried ten of
    fourteen)

  ## Verification

    Release build   clean
    Unit            3594 passed
    Integration      610 passed
    E2E (non-VR)     127 passed, run twice

  Checked against main as it now stands, which routes sample-page seeding through this same
  import path: seeding a cleared database still lands every sample page on a single press.

  Closes #275