### PR TITLE
Put the clear-all button behind a setting and an environment boundary

### DIFF
--- a/src/DfE.CheckPerformanceData.Application/Settings/SettingDefinitions.cs
+++ b/src/DfE.CheckPerformanceData.Application/Settings/SettingDefinitions.cs
@@ -6,6 +6,7 @@ public static class SettingKeys
 {
     public const string CmsPageLength = "CMS:PageLength";
     public const string SearchDebugOn = "CMS:SearchDebugOn";
+    public const string ShowDeleteAllButton = "CMS:ShowDeleteAllButton";
 
     public const string DlqFullPayloadEnabled = "Dlq:FullPayloadEnabled";
     public const string DlqAlertThreshold = "Dlq:AlertThreshold";
@@ -62,6 +63,12 @@ public static class SettingDefinitions
             "Number of rows shown per page on paged lists.",
             "20",
             SettingKind.Int),
+        new(SettingKeys.ShowDeleteAllButton,
+            "Whether the content-staging page offers the Clear all CMS content button, which deletes " +
+            "every page and content block in this environment. Off by default, and unavailable in " +
+            "production and on QA and preproduction whatever this is set to.",
+            "false",
+            SettingKind.Bool),
         new(SettingKeys.DlqFullPayloadEnabled,
             "Whether operators may view the full original payload of a dead-lettered message. Off by default.",
             "false",

--- a/src/DfE.CheckPerformanceData.Web/Controllers/ContentStagingController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/ContentStagingController.cs
@@ -1,12 +1,14 @@
 using System.Text;
 using System.Text.Json;
 using DfE.CheckPerformanceData.Application.ContentStaging;
+using DfE.CheckPerformanceData.Application.Settings;
 using DfE.CheckPerformanceData.Application.CurrentUser;
 using DfE.CheckPerformanceData.Application.PageTree;
 using DfE.CheckPerformanceData.Web.Admin;
 using DfE.CheckPerformanceData.Web.Admin.Nav;
 using DfE.CheckPerformanceData.Web.Controllers.ViewModels;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Hosting;
 
 namespace DfE.CheckPerformanceData.Web.Controllers;
 
@@ -18,10 +20,46 @@ public sealed class ContentStagingController(
     IContentStagingService staging,
     ICurrentUserService currentUser,
     IPageNodeRepository pageNodeRepository,
-    ILogger<ContentStagingController> logger) : Controller
+    ILogger<ContentStagingController> logger,
+    IConfiguration configuration,
+    IHostEnvironment hostEnvironment,
+    ISettingService settingService) : Controller
 {
+    // Clear-all wipes every page and content block in the environment: fine on a development or
+    // throwaway environment, and it has no business being reachable on one holding content anyone
+    // depends on.
+    //
+    // Available where the environment IS Development (local, and the deployed DEV app, which runs
+    // under that environment name) or where dev tools are switched on (the ephemeral review apps
+    // set Dev:ToolsEnabled) — and never in Production, whatever the configuration says.
+    //
+    // Deliberately NOT the plain Dev:ToolsEnabled test the /dev/* surfaces use. That flag is not
+    // set on deployed DEV, so reusing it alone would take clear-all away from the very environment
+    // it is wanted on; and setting the flag there to compensate would switch on dev impersonation
+    // as a side effect, which DevImpersonationController states must never reach deployed DEV.
+    private bool EnvironmentAllowsClearAll =>
+        (hostEnvironment.IsDevelopment() || configuration.GetValue<bool>(SettingKeys.DevToolsEnabled))
+        && !hostEnvironment.IsProduction();
+
+    // Two gates, and both have to say yes.
+    //
+    // The environment one above is the boundary and is not editable: whatever an operator does on
+    // the settings page, clear-all cannot appear on QA, preproduction or production. The setting
+    // is the switch within the environments that may have it, defaulted off, so an environment
+    // only offers it once somebody deliberately asks for it — and so the hidden state can be
+    // exercised without redeploying with different configuration.
+    private async Task<bool> ClearAllAvailableAsync() =>
+        EnvironmentAllowsClearAll
+        && await settingService.GetBoolAsync(SettingKeys.ShowDeleteAllButton);
+
     [HttpGet("")]
-    public IActionResult Index() => View();
+    public async Task<IActionResult> Index()
+    {
+        // The view hides the whole reset section on this, so the button never appears where
+        // the route would refuse it anyway.
+        ViewData["ClearAllAvailable"] = await ClearAllAvailableAsync();
+        return View();
+    }
 
     // Whole-environment export (the "export everything" convenience button).
     [HttpGet("export")]
@@ -136,6 +174,16 @@ public sealed class ContentStagingController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> ClearAll()
     {
+        // Refuse on the route, not just in the view. Hiding the button would still leave a
+        // destructive POST reachable by anyone with the content-staging grant who knows the URL.
+        if (!await ClearAllAvailableAsync())
+        {
+            logger.LogWarning(
+                "ContentStaging: clear-all refused (environment={Environment}, environmentAllows={EnvironmentAllows})",
+                hostEnvironment.EnvironmentName, EnvironmentAllowsClearAll);
+            return NotFound();
+        }
+
         await pageNodeRepository.TruncateAllContentAsync();
         TempData["ContentStagingResult"] =
             "All CMS pages and content blocks were cleared. Default root nodes will regenerate on the next request.";

--- a/src/DfE.CheckPerformanceData.Web/Views/ContentStaging/Index.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/ContentStaging/Index.cshtml
@@ -103,23 +103,29 @@
     </button>
 </form>
 
-<h2 class="govuk-heading-l">Reset content</h2>
-<p class="govuk-body">
-    Deletes every CMS page and content block in this environment. Use it to get a clean slate
-    before replaying a bundle from another environment.
-</p>
-<button type="button" class="govuk-button govuk-button--warning"
-        data-module="govuk-button" data-confirm-trigger="clear-all-modal">
-    Clear all CMS content
-</button>
+@* Reset content is a throwaway-environment tool: it deletes every page and content block.
+   Rendered only where the controller says the route will accept it (Dev:ToolsEnabled and not
+   production), so the button is never shown somewhere the POST would 404. *@
+@if (ViewData["ClearAllAvailable"] is true)
+{
+    <h2 class="govuk-heading-l">Reset content</h2>
+    <p class="govuk-body">
+        Deletes every CMS page and content block in this environment. Use it to get a clean slate
+        before replaying a bundle from another environment.
+    </p>
+    <button type="button" class="govuk-button govuk-button--warning"
+            data-module="govuk-button" data-confirm-trigger="clear-all-modal">
+        Clear all CMS content
+    </button>
 
-<govuk-confirm-modal id="clear-all-modal"
-                     title="Clear all CMS content?"
-                     warning-text="This deletes every page and content block from this environment. It cannot be undone."
-                     body="Default root nodes (support, help, guidance, wiki) and the /help/not-found page regenerate automatically on the next request. Any custom pages, saved versions, or content-block edits are gone."
-                     confirm-label="Yes, clear everything"
-                     destructive="true"
-                     form-action="/admin/content-staging/clear-all"
-                     form-method="post">
-    @Html.AntiForgeryToken()
-</govuk-confirm-modal>
+    <govuk-confirm-modal id="clear-all-modal"
+                         title="Clear all CMS content?"
+                         warning-text="This deletes every page and content block from this environment. It cannot be undone."
+                         body="Default root nodes (support, help, guidance, wiki) and the /help/not-found page regenerate automatically on the next request. Any custom pages, saved versions, or content-block edits are gone."
+                         confirm-label="Yes, clear everything"
+                         destructive="true"
+                         form-action="/admin/content-staging/clear-all"
+                         form-method="post">
+        @Html.AntiForgeryToken()
+    </govuk-confirm-modal>
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/ContentStagingControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/ContentStagingControllerTests.cs
@@ -26,10 +26,127 @@ public sealed class ContentStagingControllerTests
     public ContentStagingControllerTests()
     {
         _currentUser.Email.Returns("editor@education.gov.uk");
-        _sut = new ContentStagingController(_staging, _currentUser, _pageNodeRepository, _logger)
+        _sut = Build(devToolsEnabled: true, environment: "Development");
+    }
+
+
+    // Clear-all is gated the way the other destructive dev surfaces are: the Dev:ToolsEnabled
+    // flag AND not-production. Build a controller for a given environment so each case is explicit.
+    private ContentStagingController Build(bool devToolsEnabled, string environment, bool showButton = true)
+    {
+        var configuration = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Dev:ToolsEnabled"] = devToolsEnabled ? "true" : "false"
+            })
+            .Build();
+
+        var host = Substitute.For<Microsoft.Extensions.Hosting.IHostEnvironment>();
+        host.EnvironmentName.Returns(environment);
+
+        var settings = Substitute.For<DfE.CheckPerformanceData.Application.Settings.ISettingService>();
+        settings.GetBoolAsync(DfE.CheckPerformanceData.Application.Settings.SettingKeys.ShowDeleteAllButton)
+            .Returns(showButton);
+
+        return new ContentStagingController(_staging, _currentUser, _pageNodeRepository, _logger, configuration, host, settings)
         {
             TempData = new TempDataDictionary(new DefaultHttpContext(), Substitute.For<ITempDataProvider>())
         };
+    }
+
+    // --- Clear-all environment gate (issue: hide/remove Clear All from non-dev environments) ---
+
+    // The destructive endpoint must not merely be hidden in the UI. A hidden button still leaves a
+    // POST route reachable by anyone holding the content-staging grant who knows the URL, and the
+    // action truncates every page and content block in the environment.
+    [Theory]
+    [InlineData(false, "QA")]            // deployed QA: neither Development nor the flag
+    [InlineData(false, "Preproduction")]
+    [InlineData(true,  "Production")]    // even if a prod deploy leaves the flag on
+    [InlineData(false, "Production")]
+    public async Task ClearAll_WhenNotADevSurface_Returns404_AndTouchesNothing(bool devTools, string environment)
+    {
+        var sut = Build(devTools, environment);
+
+        var result = await sut.ClearAll();
+
+        Assert.IsType<NotFoundResult>(result);
+        await _pageNodeRepository.DidNotReceiveWithAnyArgs().TruncateAllContentAsync();
+    }
+
+    [Theory]
+    [InlineData(true,  "Development")]   // local dev
+    [InlineData(false, "Development")]   // deployed DEV: environment name only, no flag
+    [InlineData(true,  "Review")]        // ephemeral review app: flag only
+    public async Task ClearAll_OnADevSurface_StillClearsTheEnvironment(bool devTools, string environment)
+    {
+        var sut = Build(devToolsEnabled: devTools, environment: environment);
+
+        var result = await sut.ClearAll();
+
+        Assert.IsType<RedirectResult>(result);
+        await _pageNodeRepository.Received(1).TruncateAllContentAsync();
+    }
+
+    // The view renders the reset section from this flag, so the button disappears with the route.
+    [Theory]
+    [InlineData(true,  "Development", true)]    // local dev
+    [InlineData(false, "Development", true)]    // deployed DEV: no flag, still a dev environment
+    [InlineData(true,  "Review",      true)]    // review app: flag set
+    [InlineData(false, "QA",          false)]
+    [InlineData(false, "Preproduction", false)]
+    [InlineData(true,  "Production",  false)]
+    public async Task Index_TellsTheView_WhetherClearAllIsAvailable(bool devTools, string environment, bool expected)
+    {
+        var sut = Build(devTools, environment);
+
+        var result = Assert.IsType<ViewResult>(await sut.Index());
+
+        Assert.Equal(expected, result.ViewData["ClearAllAvailable"]);
+    }
+
+
+    // The setting is the operator-facing switch, defaulted off, so an environment that MAY offer
+    // clear-all still does not until somebody asks for it — and the hidden state can be exercised
+    // without redeploying under different configuration.
+    [Fact]
+    public async Task ClearAll_WhenTheSettingIsOff_Returns404_EvenOnADevSurface()
+    {
+        var sut = Build(devToolsEnabled: true, environment: "Development", showButton: false);
+
+        var result = await sut.ClearAll();
+
+        Assert.IsType<NotFoundResult>(result);
+        await _pageNodeRepository.DidNotReceiveWithAnyArgs().TruncateAllContentAsync();
+    }
+
+    [Fact]
+    public async Task Index_WhenTheSettingIsOff_HidesTheButton_EvenOnADevSurface()
+    {
+        var sut = Build(devToolsEnabled: true, environment: "Development", showButton: false);
+
+        var result = Assert.IsType<ViewResult>(await sut.Index());
+
+        Assert.Equal(false, result.ViewData["ClearAllAvailable"]);
+    }
+
+    // The environment boundary is not editable: turning the setting on where the environment does
+    // not allow it changes nothing. QA and preproduction are listed with dev tools off because
+    // that is how they are configured — Dev:ToolsEnabled is the marker that declares an
+    // environment a dev surface, so setting it on QA would be a statement that QA is one (and
+    // would switch on dev impersonation besides). Production is refused with the flag ON, because
+    // there the environment name alone has to be enough.
+    [Theory]
+    [InlineData("QA", false)]
+    [InlineData("Preproduction", false)]
+    [InlineData("Production", true)]
+    public async Task ClearAll_SettingOn_StillRefusedWhereTheEnvironmentForbidsIt(string environment, bool devTools)
+    {
+        var sut = Build(devToolsEnabled: devTools, environment: environment, showButton: true);
+
+        Assert.IsType<NotFoundResult>(await sut.ClearAll());
+        Assert.Equal(false, Assert.IsType<ViewResult>(await sut.Index()).ViewData["ClearAllAvailable"]);
+        await _pageNodeRepository.DidNotReceiveWithAnyArgs().TruncateAllContentAsync();
     }
 
     private static IFormFile FileFrom(string content)

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Views/ContentStagingViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Views/ContentStagingViewSourceTests.cs
@@ -1,0 +1,69 @@
+namespace DfE.CheckPerformanceData.Application.UnitTests.Web.Views;
+
+// Source-file assertion pattern (mirrors LayoutViewSourceTests): reads the content-staging view
+// from disk and asserts where the reset-content markup sits relative to its guard.
+//
+// The controller refuses the clear-all route outside a dev surface, and a companion test covers
+// that. This one covers the other half: that the button, the confirm modal and the form action
+// are all INSIDE the guard. Rendering an actionable destructive control that the route will 404
+// is not a security hole, but it is a support call — an administrator on QA clicking a button
+// that appears to work and silently does nothing. Nothing in the compiler or in a controller
+// test notices if someone later moves that markup out of the conditional, which is exactly the
+// edit this guards.
+public sealed class ContentStagingViewSourceTests
+{
+    private const string ViewPath = "Views/ContentStaging/Index.cshtml";
+
+    private static string ReadViewSource(string relativePath)
+    {
+        var viewsDir = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "src", "DfE.CheckPerformanceData.Web"));
+        return File.ReadAllText(Path.Combine(viewsDir, relativePath));
+    }
+
+    [Fact]
+    public void ResetContentSection_IsRenderedOnlyBehindTheClearAllGuard()
+    {
+        var source = ReadViewSource(ViewPath);
+
+        var guard = source.IndexOf("@if (ViewData[\"ClearAllAvailable\"] is true)", StringComparison.Ordinal);
+        Assert.True(guard >= 0, "the reset-content section must be guarded by the ClearAllAvailable flag");
+
+        // Everything that makes the control actionable has to come after the guard opens.
+        foreach (var marker in new[]
+                 {
+                     // The heading markup, not the words: the guard's own comment mentions
+                     // "reset content" and would otherwise match here.
+                     "<h2 class=\"govuk-heading-l\">Reset content</h2>",
+                     "clear-all-modal",
+                     "/admin/content-staging/clear-all",
+                     "Clear all CMS content"
+                 })
+        {
+            var at = source.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(at > guard,
+                $"'{marker}' appears at {at}, before the guard at {guard} — it would render on every environment");
+        }
+    }
+
+    // The import and export halves of this page are ordinary admin functions and must not be
+    // caught by the guard: gating them would take content staging away from QA and preproduction,
+    // which is where bundles are actually replayed.
+    [Fact]
+    public void ImportAndExport_AreNotGated()
+    {
+        var source = ReadViewSource(ViewPath);
+
+        var guard = source.IndexOf("@if (ViewData[\"ClearAllAvailable\"] is true)", StringComparison.Ordinal);
+        Assert.True(guard >= 0);
+
+        foreach (var marker in new[] { "/admin/content-staging/preview", "Preview import" })
+        {
+            var at = source.IndexOf(marker, StringComparison.Ordinal);
+            Assert.True(at >= 0 && at < guard,
+                $"'{marker}' should sit outside the clear-all guard, but was found at {at} (guard at {guard})");
+        }
+    }
+}


### PR DESCRIPTION
Clear-all deletes every page and content block in the environment. It was available wherever the content-staging grant was, with nothing to turn it off and nothing stopping it appearing somewhere real.

Two gates now, and both have to agree.

The environment boundary is not editable. Clear-all can only appear where the environment IS Development — local, and the deployed DEV app, which runs under that name — or where dev tools are switched on, which the ephemeral review apps set. Never in production, whatever the configuration says. QA and preproduction have it neither way.

Within those, CMS:ShowDeleteAllButton is the switch, defaulted off, so an environment only offers it once somebody deliberately asks for it. It takes its default from code, so a fresh environment starts hidden, and it renders on the settings page like any other boolean, which is what makes the hidden state testable without redeploying under different configuration.

The route refuses as well as the view hiding the button. Hiding it alone would leave a destructive POST reachable by anyone holding the grant who knows the URL, which is the part that actually matters. The view guard is still worth having so nobody is offered a control that silently 404s.

Deliberately not the plain Dev:ToolsEnabled test the /dev/ surfaces use for the environment half. That flag is not set on deployed DEV, so reusing it alone would take clear-all away from an environment it is wanted on; setting the flag there to compensate would switch on dev impersonation as a side effect, which must never reach deployed DEV.

Import and export stay ungated: those are ordinary admin functions and QA and preproduction are where bundles are replayed.

[AB#292207](https://dfe-gov-uk.visualstudio.com/b947688b-53a4-4c90-9c43-5a5db31e313d/_workitems/edit/292207)
Refs #243