### PR TITLE
Fix pupil page display issues in responsive mode

### DIFF
--- a/src/DfE.CheckPerformanceData.Web/Views/CheckYourPupilData/_PupilSection.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/CheckYourPupilData/_PupilSection.cshtml
@@ -33,7 +33,14 @@ else
     })
     @if (Model.Section.HasData)
     {
-        @await Html.PartialAsync("_PupilTable", Model.Section.Table)
+        @* MOJ scrollable pane (CSS already shipped via moj-frontend-9.0.0.min.css): the KS4
+           column set is wider than small screens, so the table scrolls inside this region
+           instead of pushing the page off-screen (issue #271). tabindex="0" makes the region
+           keyboard-scrollable and role + aria-label give it an accessible name — the pane's
+           own :focus style comes from the MOJ stylesheet. *@
+        <div class="moj-scrollable-pane" role="region" tabindex="0" aria-label="@Model.Section.Heading">
+            @await Html.PartialAsync("_PupilTable", Model.Section.Table)
+        </div>
         @await Html.PartialAsync("_Pagination", new PaginationViewModel
         {
             WindowId = Model.WindowId,

--- a/src/DfE.CheckPerformanceData.Web/wwwroot/css/site.css
+++ b/src/DfE.CheckPerformanceData.Web/wwwroot/css/site.css
@@ -43,6 +43,14 @@
   }
 }
 
+/* The MOJ pane ships overflow-x: scroll, which on classic-scrollbar platforms (Windows
+   Chrome/Firefox) paints a permanent disabled scrollbar track under every pupil table even
+   when nothing overflows. auto keeps the pane's scroll, shadows and focus behaviour
+   identical when content does overflow, and removes the empty gutter when it doesn't. */
+.moj-scrollable-pane {
+  overflow-x: auto;
+}
+
 .dfe-card-container{
   .govuk-heading-m {
     color: #347CA9;

--- a/src/DfE.CheckPerformanceData.Web/wwwroot/css/site.css
+++ b/src/DfE.CheckPerformanceData.Web/wwwroot/css/site.css
@@ -28,6 +28,21 @@
   margin-bottom: 0;
 }
 
+/* On narrow viewports the Search (and optional Clear) buttons' intrinsic widths leave the
+   flex-shrunk input only a few characters wide, so it reads as a broken field — the same
+   failure the landing-page search box had (see .cypmd-search__row further down). Stack the
+   row instead: input full width on its own line, buttons on the lines below. The existing
+   10px flex gap keeps the stacked controls spaced. */
+@media (max-width: 40.0625em) {
+  .pupil-search__row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .pupil-search__row .govuk-button {
+    align-self: flex-start;
+  }
+}
+
 .dfe-card-container{
   .govuk-heading-m {
     color: #347CA9;

--- a/tests/DfE.CheckPerformanceData.UnitTests/CheckYourPupilData/CheckYourPupilDataResponsiveViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/CheckYourPupilData/CheckYourPupilDataResponsiveViewSourceTests.cs
@@ -1,0 +1,35 @@
+namespace DfE.CheckPerformanceData.Application.UnitTests.CheckYourPupilData;
+
+// Source-file assertion pattern (mirrors LayoutViewSourceTests / AutocompleteRestoreViewSourceTests):
+// reads Web-project source files from disk and asserts static facts for GitHub issue #271 —
+// pupil page responsive display fixes. On narrow viewports the pupil search box collapsed to a
+// few characters wide (flex row squeezed by the Search/Clear buttons) and the pupil tables
+// overflowed off-screen (no horizontal-scroll container).
+public sealed class CheckYourPupilDataResponsiveViewSourceTests
+{
+    private static string ReadWebSource(string relativePath)
+    {
+        var webDir = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..", "..",
+            "src", "DfE.CheckPerformanceData.Web"));
+        return File.ReadAllText(Path.Combine(webDir, relativePath));
+    }
+
+    [Fact]
+    public void Site_css_stacks_pupil_search_row_below_the_mobile_breakpoint()
+    {
+        // Normalise line endings so the assertion is identical on Windows and the Linux CI runner.
+        var css = ReadWebSource("wwwroot/css/site.css").Replace("\r\n", "\n");
+
+        // The stacked block must exist verbatim: the same mobile-breakpoint fix .cypmd-search__row
+        // already has. If someone reformats site.css this pins the selector to the breakpoint.
+        Assert.Contains("@media (max-width: 40.0625em) {\n  .pupil-search__row {", css);
+
+        // And the stack must be a column with full-width children, not just any media rule.
+        var mediaIndex = css.IndexOf("@media (max-width: 40.0625em) {\n  .pupil-search__row {", StringComparison.Ordinal);
+        var block = css[mediaIndex..(mediaIndex + 400)];
+        Assert.Contains("flex-direction: column", block);
+        Assert.Contains("align-items: stretch", block);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/CheckYourPupilData/CheckYourPupilDataResponsiveViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/CheckYourPupilData/CheckYourPupilDataResponsiveViewSourceTests.cs
@@ -32,4 +32,26 @@ public sealed class CheckYourPupilDataResponsiveViewSourceTests
         Assert.Contains("flex-direction: column", block);
         Assert.Contains("align-items: stretch", block);
     }
+
+    [Fact]
+    public void Pupil_section_wraps_the_table_in_an_accessible_scrollable_pane()
+    {
+        var view = ReadWebSource("Views/CheckYourPupilData/_PupilSection.cshtml");
+
+        // MOJ scrollable pane (CSS ships in moj-frontend-9.0.0.min.css, already linked by
+        // _Layout) gives wide KS4 tables horizontal scroll instead of off-screen overflow.
+        Assert.Contains("moj-scrollable-pane", view);
+
+        // The scroll region must be keyboard-reachable and announceable: tabindex lets
+        // keyboard users scroll it (WCAG 2.1.1), role+label give it an accessible name.
+        Assert.Contains("tabindex=\"0\"", view);
+        Assert.Contains("role=\"region\"", view);
+        Assert.Contains("aria-label=\"@Model.Section.Heading\"", view);
+
+        // The pane must open before the table partial renders, i.e. it wraps the table.
+        var paneIndex = view.IndexOf("moj-scrollable-pane", StringComparison.Ordinal);
+        var tableIndex = view.IndexOf("_PupilTable", StringComparison.Ordinal);
+        Assert.True(paneIndex >= 0 && paneIndex < tableIndex,
+            "the moj-scrollable-pane container must wrap the _PupilTable partial");
+    }
 }

--- a/tests/DfE.CheckPerformanceData.UnitTests/CheckYourPupilData/CheckYourPupilDataResponsiveViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/CheckYourPupilData/CheckYourPupilDataResponsiveViewSourceTests.cs
@@ -28,7 +28,7 @@ public sealed class CheckYourPupilDataResponsiveViewSourceTests
 
         // And the stack must be a column with full-width children, not just any media rule.
         var mediaIndex = css.IndexOf("@media (max-width: 40.0625em) {\n  .pupil-search__row {", StringComparison.Ordinal);
-        var block = css[mediaIndex..(mediaIndex + 400)];
+        var block = css[mediaIndex..Math.Min(mediaIndex + 400, css.Length)];
         Assert.Contains("flex-direction: column", block);
         Assert.Contains("align-items: stretch", block);
     }
@@ -40,16 +40,17 @@ public sealed class CheckYourPupilDataResponsiveViewSourceTests
 
         // MOJ scrollable pane (CSS ships in moj-frontend-9.0.0.min.css, already linked by
         // _Layout) gives wide KS4 tables horizontal scroll instead of off-screen overflow.
-        Assert.Contains("moj-scrollable-pane", view);
-
+        // Assert the full opening tag as one literal — role="region" alone also matches the
+        // unrelated "no data" alert markup earlier in this view, and separate attribute
+        // assertions wouldn't prove tabindex/role/aria-label all sit on the same element.
         // The scroll region must be keyboard-reachable and announceable: tabindex lets
         // keyboard users scroll it (WCAG 2.1.1), role+label give it an accessible name.
-        Assert.Contains("tabindex=\"0\"", view);
-        Assert.Contains("role=\"region\"", view);
-        Assert.Contains("aria-label=\"@Model.Section.Heading\"", view);
+        const string paneOpenTag =
+            "<div class=\"moj-scrollable-pane\" role=\"region\" tabindex=\"0\" aria-label=\"@Model.Section.Heading\">";
+        Assert.Contains(paneOpenTag, view);
 
         // The pane must open before the table partial renders, i.e. it wraps the table.
-        var paneIndex = view.IndexOf("moj-scrollable-pane", StringComparison.Ordinal);
+        var paneIndex = view.IndexOf(paneOpenTag, StringComparison.Ordinal);
         var tableIndex = view.IndexOf("_PupilTable", StringComparison.Ordinal);
         Assert.True(paneIndex >= 0 && paneIndex < tableIndex,
             "the moj-scrollable-pane container must wrap the _PupilTable partial");


### PR DESCRIPTION
Closes #271

## What

Two mobile-viewport defects on the Check your pupil data page:

- **Search box collapsed to a few characters wide** — the `.pupil-search__row` flex row let the Search/Clear buttons crowd out the input. Below the GOV.UK mobile breakpoint (`40.0625em`) the row now stacks into a column (input full width, buttons below), mirroring the existing `.cypmd-search__row` fix for the landing-page search box.
- **Tables overflowed off-screen to the right** — the pupil table is now wrapped in the MOJ Design System `moj-scrollable-pane` (CSS already shipped in `moj-frontend-9.0.0.min.css`), so wide tables scroll horizontally inside their own pane. The region carries `role="region"`, `tabindex="0"` and an `aria-label` from the section heading so it is keyboard-scrollable and announceable (WCAG 2.1.1/4.1.2). A `overflow-x: auto` override prevents a permanent empty scrollbar gutter on classic-scrollbar desktops.

CSS + Razor only — no JavaScript, no C# production changes; desktop rendering is unchanged.

## Testing

- New `CheckYourPupilDataResponsiveViewSourceTests` (2 tests) pin the media query and the accessible pane markup, developed TDD (red → green).
- Full suite green locally: 3671/3671 unit, 610/610 integration.
- Visually verified in the dockerised app at 375×812 (including the stacked Search + Clear state via an active search) and 1280×900.