### PR TITLE
16-19 report an incorrect grade results enquiry AB#296648

### DIFF
--- a/docs/bigquery-analytics.md
+++ b/docs/bigquery-analytics.md
@@ -96,6 +96,8 @@ All custom events carry **no PII as plain fields**; a hidden field is noted belo
 | `draft_resumed` | `reference_number`, `what_to_change`, `checking_window_type` | `AmendmentRequestsController.Edit` | `reference_number` |
 | `request_submitted` | `what_to_change`, `checking_window_type`, `reference_number` | `JourneyController.SummaryConfirm` (success) | `reference_number` |
 | `request_submission_failed` | `failure_reason`, `what_to_change`, `checking_window_type` | `JourneyController.SummaryConfirm` (duplicate) | — |
+| `results_enquiry_started` | `enquiry_type`, `checking_window_type`, `late_results_guidance_shown` | `ResultIssueController.Confirm` (valid POST) | — |
+| `results_enquiry_submitted` | `enquiry_type`, `cohort_wide`, `checking_window_type`, `reference_number` | `JourneyController.SummaryConfirm` (results-enquiry branch) | `reference_number` |
 | `validation_error` | `error_count`, `error_codes`, `error_fields`, `what_to_change`, `from_summary` | `JourneyController` (pupil search, page POST), `WhatToChangeController`, `CheckYourPupilDataController` | — |
 | `evidence_upload_attempted` | `outcome`, `failure_reason`, `page_count`, `file_size_bytes` | `JourneyController.UploadFile` | — |
 | `evidence_continue` | `file_count`, `page_count`, `evidence_text_length` | `JourneyController.PagePost` (evidence page) | — |
@@ -127,6 +129,21 @@ flowchart LR
     C --> D
     A --> E[request_submission_failed]
 ```
+
+### The results-enquiry funnel
+
+The 16-19 "report an incorrect grade" journey (AB#296648) has its own two-step funnel, linked by the
+hidden, hashed `reference_number`. `late_results_guidance_shown` on the start event is the measure that
+answers the question behind the guidance interstitial: is it stopping enquiries that the November late
+results file would have corrected anyway?
+
+```mermaid
+flowchart LR
+    A[results_enquiry_started] --> B[results_enquiry_submitted]
+    A -.abandoned.-> C[no submitted event]
+```
+
+See `docs/results-enquiry.md` for the journey these events describe.
 
 ---
 

--- a/docs/results-enquiry.md
+++ b/docs/results-enquiry.md
@@ -1,0 +1,266 @@
+# 16-19 results enquiry — report an incorrect grade
+
+AB#296648. A school reports that one of its 16-19 students has been given the wrong exam grade, from
+choosing the enquiry type through to a reference number on screen and by email.
+
+Related tickets: AB#296999 (results data), AB#297004 (student selection), AB#297130 (grade reference
+data), AB#297013.
+
+## The journey
+
+| Page id | Type | What it asks |
+|---|---|---|
+| `check-late-results` | `Content` | Guidance: check your second late results file first. Entered by the controller, not the flow's `firstPageId` — see [Late results guidance](#late-results-guidance). |
+| `cohort-scope` | `Question` / Radio | Does the incorrect grade affect the whole cohort? Branches the journey. |
+| `cohort-count` | `Question` / FreeText | How many students (cohort branch only). Validated by the `WholeNumber` format validator. |
+| `select-student-cohort` | `PupilSearch` | One student as an example (cohort branch). |
+| `select-student-single` | `PupilSearch` | The affected student (single branch). |
+| `select-result` | `ResultSearch` | Which of the student's results is wrong. |
+| `grade-details` | `ResultDetails` | Shows the chosen result; asks for the revised grade. |
+| `additional-info` | `Question` / TextArea | Optional comments, 250 characters. |
+
+Then the shared journey summary (`Journey/Summary.cshtml`, enquiry branch) and
+`Journey/EnquiryConfirmation.cshtml`.
+
+Flow config: `src/DfE.CheckPerformanceData.Web/Data/QuestionFlows/IncorrectGrade_Post16.json`, resolved
+by the usual `{WhatToChange}_{CheckingWindowType}` key. **Page and question ids are a serialization
+contract** — they are written into session state and into the persisted journey blob, so renaming one
+after merge orphans stored enquiries. `IncorrectGradeFlowTests` pins them.
+
+### Getting in
+
+The check-your-student-data page's "What would you like to do?" radios gain a third option for 16-19
+windows: **Report an issue with an exam result**, routed to `ResultIssueController`. The issue page
+renders only the *Incorrect grade* option; the two others on the Figma screen belong to sibling
+tickets, and posting their values is rejected as unanswered rather than starting a journey with no flow
+behind it.
+
+## Late results guidance
+
+Exam results arrive in batches: main + non-included + late results 1 in October, **late results 2 in
+November**, revised in February, retention in March. Nearly all incorrect grades correct themselves in
+the November batch, so a school reporting one in October may be doing work that batch was about to do
+for them.
+
+**Decision (BA, 2026-08-17): the guidance informs, it never blocks.** When the school holds no
+`16to19_LR2` row, `ResultIssueController` routes into `check-late-results`; when it does, straight to
+`cohort-scope`. The option itself is always selectable. A Figma frame showing the option greyed out
+with *"Incorrect grade option will be available after releasing second late results"* was considered
+and not chosen — it contradicts the ticket's own acceptance criteria.
+
+Because the flow's `firstPageId` is `cohort-scope`, the controller **seeds `QuestionHistory` with
+`check-late-results`** when that is the entry point. Without it the journey engine's out-of-sequence
+guard bounces the user straight past the guidance and the AC silently never happens.
+
+Availability is derived, never configured: `ILateResultsAvailability` asks
+`IStudentResultsClient.AnyForSourceAsync(..., "16to19_LR2")`. That is the only place the service
+decides what "the second late results file has landed" means.
+
+## Data seams
+
+### Student results — `IStudentResultsClient`
+
+Container `{windowId}`, blob `results-enquiry/data/{laestab}_results.json`. One merged array per
+school across all six supplier files, each row stamped with its source tag.
+
+The `results-enquiry/` prefix is deliberate: per consequence #2 of `docs/16-19-window-model.md` each
+window activity owns its own blob prefix, so when ingress becomes per-activity no migration is needed
+and one activity's sweep cannot destroy another's output. Pupil-data checking keeps its bare `data/`
+prefix. Every path segment lives in `ResultsEnquiryBlobPaths`.
+
+Source tags (`ResultsFileTags`, verbatim from AB#296999 — a data contract with ingestion):
+
+| Constant | Value |
+|---|---|
+| `Post16Main` | `16to19_MAIN` |
+| `Post16LateResults1` | `16to19_LR1` |
+| `Post16LateResults2` | `16to19_LR2` |
+| `Post16Revised` | `16to19_Revised` |
+| `Post16Retention` | `16to19_Retention` |
+| `Ks4Main` | `KS4_MAIN` |
+| `Ks4LateResults1` | `KS4_LR1` |
+| `Ks4LateResults2` | `KS4_LR2` |
+| `Ks4Revised` | `KS4_Revised` |
+
+Reads are cached 30 minutes per `results:{windowId}:{laestab}`, matching the pupil cache so a school's
+results and pupils go stale together. A missing blob reads as empty; malformed JSON throws so a corrupt
+file surfaces. Numeric-looking values are tolerated unquoted, because CSV-to-JSON converters routinely
+emit them that way (`TolerantStringJsonConverter`).
+
+A result is identified by a **composite key** `QAN|SESSION|SOURCE`, not by QAN — a student can hold the
+same qualification across sessions and across source files.
+
+### Grade reference — `IGradeReferenceClient`
+
+Container `rules-config`, blob `grade-reference.json`, beside `rules.json` because it is the same kind
+of thing: slow-moving reference data from another team, shared by every window, self-seeded from a
+bundled copy. Cached 5 minutes; a missing blob reads as an empty lookup rather than throwing.
+
+Seeded from `src/DfE.CheckPerformanceData.Web/Data/GradeReference/grade-reference.json`,
+**seed-if-missing** (`If-None-Match: *`) so an environment that has had the real AODC export loaded is
+never clobbered by a redeploy of an older bundled copy.
+
+The checked-in seed holds the three AB#297130 examples plus the dev QANs. The IB Diploma's 93-grade
+scale is derived from the ticket (44 pass: `24B`/`24D` … `45B`/`45D`; 49 fail: `00F`–`45F`, `R`, `U`,
+`X`) and is what gives the tests their `24F`-vs-`24D` case.
+
+## Revised-grade rules
+
+Server-authoritative, in this order (`JourneyValidationService.ValidateGradeSelect`):
+
+1. Unanswered → `Select the revised grade`
+2. Equal to the result's current grade → `The revised grade must be different from the current grade`
+3. Not a grade the QAN offers → treated as unanswered (fail closed against a forged post)
+4. QAN absent from the reference data → the picker is empty, the page says
+   `We cannot list grades for this qualification yet`, a warning is logged, and validation can never
+   pass
+
+Comparison is **ordinal and case-sensitive**. The IB Diploma is why: `24F` is a fail and `24D` a pass,
+so `24F` → `24D` is a real enquiry, and any normalising comparison risks either rejecting it or
+accepting a no-op.
+
+## Progressive enhancement
+
+Both pickers are server-rendered GOV.UK `<select>`s that accessible-autocomplete upgrades in place via
+`enhanceSelectElement`, so **both pages work with JavaScript off**. The result options are rendered
+server-side rather than fetched: a student holds a handful of results, so there is nothing to gain from
+a round-trip, and a fetch-only control would be unusable without script. The grade picker is enhanced
+because some qualifications award 93 grades.
+
+`/results/suggestions` (`ResultSuggestionsController`) exists and is tested but is **not used by the
+result page** as a consequence. It is scoped to the session's selected student — no pupil id is ever
+taken from the query string. Decide whether to keep it for the sibling "Review exam results" tickets or
+remove it.
+
+## Submission
+
+`RequestService.SubmitResultsEnquiryAsync` makes the same two writes a pupil change request does:
+
+1. a `ChangeRequests` row — `RequestType.ResultsEnquiry`, `AmendmentType = IncorrectGrade`,
+   `Status = SubmittedUnCommitted`, description `Results enquiry - Incorrect grade`
+2. the journey JSON via `IRequestStateBlobClient`
+
+Both enum columns are `HasConversion<string>()` capped at 20 characters; `ResultsEnquiry` (14) and
+`IncorrectGrade` (14) fit, which is why **no migration was needed**.
+
+Reference format: `CYPMD_16to19_RE_{7 hex}` (`GenerateEnquiryReference`). The `RE` segment lets support
+staff tell an enquiry from an amendment when a school reads one out. The confirmation mockup's
+`3014023_RE10005` was confirmed illustrative.
+
+No duplicate check — the spec allows several enquiries for the same student and result.
+
+### Two places the duplicate rule had to be taught about enquiries
+
+`RequestRepository` enforces one submitted request per pupil per window, to stop two competing
+*amendments* to the same record. An enquiry changes no pupil data, so it neither raises that conflict
+nor counts as one. `ResultsEnquiry` rows are therefore excluded from both:
+
+- `UpsertAsync`'s hard block (and the check is skipped entirely for an incoming enquiry)
+- `CheckForConflictAsync`, which drives the pupil-search duplicate warning
+
+The two must stay in step, or a user is warned about something that then submits fine — or worse, the
+reverse. Without these exclusions, reporting a wrong grade for a student blocked every later amendment
+for them, with an error naming an unrelated request.
+
+### Choosing a student discards only what came after
+
+`PupilSearchPost` used to clear *every* answer when a primary pupil was selected — correct for the
+amendment journeys, where the pupil page is first. The enquiry journey asks about the cohort **before**
+the student, so it now keeps answers from pages earlier in the history and discards only those after,
+along with `SelectedResult` (a result belongs to one student). Wiping them lost the cohort scope and
+count, and the summary silently presented a cohort-wide enquiry as a single-student one.
+
+## Downstream processing — a separate story
+
+**Decision (BA, 2026-08-17):** an enquiry drops into `ChangeRequests` and saves its journey JSON, and
+is **not enqueued**. It *is* ultimately bound for Zendesk, but how it gets there is a separate ticket.
+
+Two consequences, both deliberate and both commented in code:
+
+- `SubmitResultsEnquiryAsync` does not enqueue. When the dispatch story lands, the enqueue belongs
+  **there and nowhere else**.
+- `AdminRequestsService.ProcessCloseWindowEvent` skips `IncorrectGrade` journeys. That replay builds a
+  *pupil-amendment* ticket, and an enquiry's QAN, session, current and revised grade have no place in
+  that shape. Replaying one would create a malformed ticket **and** flip the row to
+  `SubmittedCommitted`, so the real dispatch could never find it again.
+- `QuestionFlowOutcomeKeyAlignmentTests` lists `IncorrectGrade` in
+  `FlowPrefixesThatDoNotRouteToTheRulesEngine` and asserts it has **no** outcome key, so nobody can
+  quietly bind it to rules-engine routing. That list going empty is the signal every flow routes.
+
+## Confirmation email
+
+`NotificationType.ResultsEnquirySubmitted`, dispatched by
+`RequestNotificationService.NotifyResultsEnquirySubmittedAsync` through the existing
+`INotificationDispatcher` → `NotificationSender` pipeline. Personalisation is `ref number` and
+`email address`. It carries **no deadline** (an enquiry is not something the school must come back and
+finish) and goes to the **submitter only** (nothing is being asked of the rest of the school).
+
+**The template does not exist yet.** `Notify:ResultsEnquirySubmittedTemplateId` is empty in every
+environment config. `NotifyService` now logs a warning and sends nothing when a template id is blank,
+rather than throwing out of its template-id switch — so the journey completes without it, but **no
+enquiry email is sent until the template is created and the id configured.**
+
+## Analytics
+
+Event catalogue additions — see also `docs/bigquery-analytics.md`.
+
+| Event | Fields | Notes |
+|---|---|---|
+| `results_enquiry_started` | `enquiry_type`, `checking_window_type`, `late_results_guidance_shown` | Emitted by `ResultIssueController`. The guidance flag answers the question behind the interstitial: are we stopping enquiries that did not need raising? |
+| `results_enquiry_submitted` | `enquiry_type`, `cohort_wide`, `checking_window_type`, `reference_number` **(hidden)** | Emitted by `JourneyController` on submission. |
+
+PII rules: the reference number is always `Hidden`. No grade, QAN, student name, session or free text
+ever leaves as a plain field — a grade paired with a school and a date is identifying, and the comments
+box is free text by definition. `cohort_wide` is a boolean rather than the count for the same reason.
+
+Validation failures flow through the existing `validation_error` event; `GradeSelect` codes as
+`selection_invalid` alongside Radio and Autocomplete.
+
+## Local development
+
+`SeedStudentResults` writes results for Kingsmead (`860/4070`) in the seeded Post16 window. Three
+students, mixed `16to19_MAIN` / `16to19_LR1` tags, one qualification held twice in different sessions,
+and **no `16to19_LR2` rows** so the interstitial is on the happy path.
+
+The qualification fixtures come from the Figma screens, but the CYPMD ids are the ones
+`SeedPupilData` actually generates (`500001`–`500003`) — a result keyed to Figma's own id would belong
+to no selectable student and dead-end the journey.
+
+```
+docker compose --profile web --profile database --profile storage up -d --build
+# then, as an impersonated editor:
+#   /CheckYourPupilData/6c2e1f4a-9b7d-4e38-8a15-3d9c2b4e7f01
+```
+
+## Alignment with the 16-19 window model
+
+Per `docs/16-19-window-model.md`, without building any of the activity model:
+
+- **Naming** is `ResultsEnquiry` (plural) throughout, matching `CheckingWindowActivityType`.
+- **Journey identity** uses Option A: `WhatToChangeActivityMap.ActivityFor` is the one lookup from a
+  `WhatToChange` to its activity. The future `IsSessionReady` gating consumes it; nothing else may
+  hardcode the mapping.
+- **Blob layout** is born activity-scoped (`results-enquiry/data/`).
+- **The entry radio** shows for any open 16-19 window. `// PARKED` comments mark where visibility moves
+  to `IWindowActivityService.OpenActivities`.
+
+Not built here: `CheckingWindowActivity` entity and migrations, `IWindowActivityService`, read-only page
+states, dataset reparenting, per-activity ingress, draft-across-boundary rules.
+
+## Deliberately out of scope
+
+The "Review exam results" / Results / Late-results tab pages and CSV/ZIP downloads (entry-point
+ticket); the six-file ingestion pipeline (FACT tickets — this feature seeds the blobs it reads);
+missing-qualification and result-does-not-belong-to-student flows (sibling tickets); drafts (decided
+against); duplicate-enquiry blocking (the spec allows multiples).
+
+## Still open
+
+| Item | Owner |
+|---|---|
+| Full AODC export (`Dynamic form QAN list 2026 v1.xlsx`, SharePoint) → replace the seeded `grade-reference.json` | AODC team |
+| GOV.UK Notify template + `Notify:ResultsEnquirySubmittedTemplateId` — **no email sends without it** | Ops / content |
+| Copy sign-off: the must-differ message; "We cannot list grades for this qualification yet"; the issue page's expander body (never captured in Figma); the result label's appended session | Content designer |
+| Whether to keep or delete `/results/suggestions` | Dev team |
+| Breadcrumb: the designs show `Check your student data - 16 to 19 and result enquiry`, but no journey view in the service renders a breadcrumb. Worth doing across the whole 16-19 journey at once rather than on one page | Design / dev |
+| `PupilSearch.cshtml` is still JavaScript-dependent (pre-existing). The same `enhanceSelectElement` approach used here would fix it | Dev team |

--- a/src/DfE.CheckPerformanceData.Application/Analytics/Events/ResultsEnquiryEvents.cs
+++ b/src/DfE.CheckPerformanceData.Application/Analytics/Events/ResultsEnquiryEvents.cs
@@ -1,0 +1,59 @@
+namespace DfE.CheckPerformanceData.Application.Analytics;
+
+/// <summary>
+/// A school began a 16-19 results enquiry (AB#296648) — chose an issue type on the ResultIssue page.
+/// Paired with <see cref="ResultsEnquirySubmittedEvent"/> to give the start-to-submit funnel, which is
+/// how we will find out whether the late-results guidance is stopping enquiries that did not need
+/// raising.
+/// </summary>
+public sealed record ResultsEnquiryStartedEvent : AnalyticsEvent
+{
+    /// <summary>The issue type chosen, e.g. <c>incorrect-grade</c>. An option value, never free text.</summary>
+    public required string EnquiryType { get; init; }
+
+    public required string CheckingWindowType { get; init; }
+
+    /// <summary>
+    /// Whether the school had to be shown the "check your second late results file" guidance. This is
+    /// the measure that tells us whether the guidance is doing its job.
+    /// </summary>
+    public required bool LateResultsGuidanceShown { get; init; }
+
+    public override string EventType => "results_enquiry_started";
+
+    public override IReadOnlyList<AnalyticsField> Fields =>
+    [
+        new("enquiry_type", EnquiryType),
+        new("checking_window_type", CheckingWindowType),
+        new("late_results_guidance_shown", LateResultsGuidanceShown.ToString().ToLowerInvariant()),
+    ];
+}
+
+/// <summary>
+/// A 16-19 results enquiry was submitted (AB#296648).
+///
+/// House law on PII: the reference number is always hidden, and no grade, QAN, student name or free
+/// text ever appears — a grade paired with a school and a date is identifying, and the comments box is
+/// free text by definition.
+/// </summary>
+public sealed record ResultsEnquirySubmittedEvent : AnalyticsEvent
+{
+    public required string EnquiryType { get; init; }
+
+    /// <summary>Whether the enquiry covers a whole cohort. A count would be safe too, but the
+    /// boolean is what tells us how often the cohort branch is used.</summary>
+    public required bool CohortWide { get; init; }
+
+    public required string CheckingWindowType { get; init; }
+    public required string ReferenceNumber { get; init; }
+
+    public override string EventType => "results_enquiry_submitted";
+
+    public override IReadOnlyList<AnalyticsField> Fields =>
+    [
+        new("enquiry_type", EnquiryType),
+        new("cohort_wide", CohortWide.ToString().ToLowerInvariant()),
+        new("checking_window_type", CheckingWindowType),
+        new("reference_number", ReferenceNumber, Hidden: true),
+    ];
+}

--- a/src/DfE.CheckPerformanceData.Application/CheckYourPupilData/NextSteps.cs
+++ b/src/DfE.CheckPerformanceData.Application/CheckYourPupilData/NextSteps.cs
@@ -3,5 +3,8 @@ namespace DfE.CheckPerformanceData.Application.CheckYourPupilData;
 public enum NextSteps
 {
     RequestChange,
-    Confirm
+    Confirm,
+    // AB#296648: the 16-19 way in to the results-enquiry journey from the check-your-pupil-data
+    // page. Appended last so existing values are unmoved.
+    ResultsEnquiry
 }

--- a/src/DfE.CheckPerformanceData.Application/CheckYourPupilData/PupilSuggestionFormat.cs
+++ b/src/DfE.CheckPerformanceData.Application/CheckYourPupilData/PupilSuggestionFormat.cs
@@ -1,0 +1,51 @@
+using DfE.CheckPerformanceData.Domain.Enums;
+
+namespace DfE.CheckPerformanceData.Application.CheckYourPupilData;
+
+/// <summary>
+/// How a pupil is matched against a search query and rendered as an autocomplete suggestion.
+///
+/// Extracted from <c>CheckYourPupilDataRepository.SearchPupilsAsync</c> so the format — which is
+/// user-visible text pinned by tests — can be exercised without blob storage or a database.
+///
+/// 16-19 (AB#297004) needs more than KS4: a school identifies a student by ULN, CYPMD ID or date of
+/// birth as readily as by name, and the suggestion has to show those identifiers plus the inclusion
+/// tag so two students with similar names can be told apart. KS4 behaviour is deliberately left
+/// exactly as it was — those journeys are live and are not in this ticket's scope.
+/// </summary>
+public static class PupilSuggestionFormat
+{
+    public static string Label(IPupilRecord pupil, CheckingWindowType windowType)
+    {
+        var dob = PupilDateFormatter.ToDisplayDate(pupil.DateOfBirth);
+
+        if (windowType != CheckingWindowType.Post16)
+            return $"{pupil.Surname}, {pupil.Firstname}, {dob}";
+
+        // AB#297004 specifies "UPN" here, but 16-19 students have a ULN and no UPN — Identifier is
+        // the ULN for Post16. FLAGGED to the BA: the label says ULN because that is what the value is.
+        var inclusion = pupil.IsIncluded ? "INCLUDED" : "NOT INCLUDED";
+        return $"{pupil.Firstname}, {pupil.Surname}, " +
+               $"(CYPMD ID:{pupil.Cypmd_Id}, ULN:{pupil.Identifier}, DOB:{dob}, {inclusion})";
+    }
+
+    public static bool Matches(IPupilRecord pupil, string query, CheckingWindowType windowType)
+    {
+        if (pupil.Identifier.StartsWith(query, StringComparison.OrdinalIgnoreCase) ||
+            pupil.Cypmd_Id.StartsWith(query, StringComparison.OrdinalIgnoreCase) ||
+            pupil.Surname.Contains(query, StringComparison.OrdinalIgnoreCase) ||
+            pupil.Firstname.Contains(query, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Date-of-birth search is 16-19 only for now. Matched against the DISPLAYED date, because
+        // that is the form the user reads off the screen and types back — the raw supplier value is
+        // an ISO timestamp nobody would enter.
+        return windowType == CheckingWindowType.Post16 && MatchesDateOfBirth(pupil, query);
+    }
+
+    private static bool MatchesDateOfBirth(IPupilRecord pupil, string query)
+    {
+        var dob = PupilDateFormatter.ToDisplayDate(pupil.DateOfBirth);
+        return dob.Length > 0 && dob.StartsWith(query, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/DfE.CheckPerformanceData.Application/CheckYourPupilData/WhatToChange.cs
+++ b/src/DfE.CheckPerformanceData.Application/CheckYourPupilData/WhatToChange.cs
@@ -7,5 +7,9 @@ public enum WhatToChange
     Remove,
     // No Add journey exists yet (there is no Add_*.json flow config) — the member exists so
     // ChangeRequest.AmendmentType can already model it. Appended last so existing values are unmoved.
-    Add
+    Add,
+    // AB#296648: the 16-19 "report an incorrect grade" results-enquiry journey. Belongs to the
+    // ResultsEnquiry window activity rather than pupil-data checking — see WhatToChangeActivityMap.
+    // Appended last so existing values are unmoved.
+    IncorrectGrade
 }

--- a/src/DfE.CheckPerformanceData.Application/DependencyManager.cs
+++ b/src/DfE.CheckPerformanceData.Application/DependencyManager.cs
@@ -53,11 +53,17 @@ public static class DependencyManager
         services.AddScoped<IJourneyCondition, EalWouldBeAutoRejectedCondition>();
         services.AddScoped<IOriginCountryLanguageCapture, OriginCountryLanguageCapture>();
         services.AddScoped<IFormatValidator, DfeNumberFormatValidator>();
+        // AB#296648: the cohort-count question. Registration is load-bearing — the journey engine
+        // fails OPEN on an unregistered validator name, so a missing line here silently skips the
+        // format check rather than throwing anywhere.
+        services.AddScoped<IFormatValidator, WholeNumberFormatValidator>();
         services.AddScoped<IAmendmentRequestsService, AmendmentRequestsService>();
         services.AddScoped<IBulkSubmissionService, BulkSubmissionService>();
         services.AddScoped<ISubmittedRequestService, SubmittedRequestService>();
         services.AddScoped<IEditAdviceService, EditAdviceService>();
         services.AddScoped<UncommittedRequests.IAdminRequestsService, UncommittedRequests.AdminRequestsService>();
+        // AB#296648: the single derivation of "the second late results file has landed".
+        services.AddScoped<ResultsEnquiry.ILateResultsAvailability, ResultsEnquiry.LateResultsAvailability>();
 
         services.AddSingleton<Observability.IHealthEvaluator, Observability.HealthEvaluator>();
         services.AddSingleton<Observability.StatusSentenceBuilder>();

--- a/src/DfE.CheckPerformanceData.Application/Journey/IJourneyValidationService.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/IJourneyValidationService.cs
@@ -17,6 +17,24 @@ public interface IJourneyValidationService
     IReadOnlyList<DateFieldViolation> ValidatePageDates(JourneyPage page, IReadOnlyDictionary<string, QuestionAnswer> answers, string pupilName);
 
     string? ValidateAnswer(Question question, QuestionAnswer answer, string resolvedTitle, string? resolvedValidationFailure = null);
+
+    /// <summary>
+    /// The revised-grade rules for a <see cref="QuestionType.GradeSelect"/> question (AB#296648).
+    ///
+    /// A separate method rather than a parameter on <see cref="ValidateAnswer"/>: the rules need
+    /// inputs no other question type has (the qualification's grade scale, and the grade the result
+    /// currently holds), and the caller must resolve the scale asynchronously before validating —
+    /// which <see cref="ValidateAnswer"/> deliberately stays clear of.
+    /// </summary>
+    /// <param name="reference">The QAN's grade scale, or null when the qualification is absent from
+    /// the AODC reference data — in which case nothing can be submitted.</param>
+    /// <param name="currentGrade">The grade the selected result holds, or null when unknown.</param>
+    string? ValidateGradeSelect(
+        Question question,
+        QuestionAnswer? answer,
+        ResultsEnquiry.GradeReference? reference,
+        string? currentGrade,
+        string? resolvedValidationFailure = null);
     string? ValidateFileUpload(string fileName, int newPageCount, IReadOnlyList<FileAnswer> existingFiles);
 
     /// <summary>
@@ -27,6 +45,9 @@ public interface IJourneyValidationService
     string? ValidateDuplicateFileName(string fileName, IReadOnlyList<FileAnswer> existingFiles);
 
     string GenerateReference(CheckingWindowType? windowType);
+
+    /// <summary>AB#296648: the reference for a 16-19 results enquiry, <c>CYPMD_16to19_RE_{7 hex}</c>.</summary>
+    string GenerateEnquiryReference();
     EvidenceValidationResult? ValidateEvidencePage(JourneyPage page, RequestState journey, string pupilName,
         IReadOnlySet<string>? conditionallyOptionalQuestionIds = null);
 }

--- a/src/DfE.CheckPerformanceData.Application/Journey/JourneyValidationService.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/JourneyValidationService.cs
@@ -1,5 +1,6 @@
 using DfE.CheckPerformanceData.Application.Journey.DateRules;
 using DfE.CheckPerformanceData.Application.Journey.Validators;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
 using DfE.CheckPerformanceData.Domain.Enums;
 
 namespace DfE.CheckPerformanceData.Application.Journey;
@@ -77,6 +78,42 @@ public sealed class JourneyValidationService(
 
     private DateOnly UkToday() => DateOnly.FromDateTime(
         TimeZoneInfo.ConvertTimeFromUtc(_timeProvider.GetUtcNow().UtcDateTime, UkZone));
+
+    /// <summary>
+    /// AB#296648: copy flagged for content review. Pinned by tests, so a change here is deliberate.
+    /// </summary>
+    public const string RevisedGradeMustDifferMessage =
+        "The revised grade must be different from the current grade";
+
+    public string? ValidateGradeSelect(
+        Question question,
+        QuestionAnswer? answer,
+        GradeReference? reference,
+        string? currentGrade,
+        string? resolvedValidationFailure = null)
+    {
+        var required = resolvedValidationFailure ?? "Select the revised grade";
+        var chosen = answer?.TextValue?.Trim();
+
+        if (string.IsNullOrEmpty(chosen))
+            return required;
+
+        // Ordinal and case-sensitive throughout. Grades are opaque codes, and the IB Diploma proves
+        // why precision matters: 24F is a fail and 24D a pass, so 24F -> 24D is a real change. Any
+        // normalising comparison risks either rejecting a genuine enquiry or accepting a no-op one.
+        if (currentGrade is { Length: > 0 } current
+            && !string.IsNullOrWhiteSpace(current)
+            && string.Equals(chosen, current.Trim(), StringComparison.Ordinal))
+            return RevisedGradeMustDifferMessage;
+
+        // Fail closed. A null reference (the QAN is missing from the AODC data) or an empty scale
+        // both land here, so a reference-data gap holds the enquiry back without a special case —
+        // the page explains the gap to the user.
+        if (reference is null || !reference.Offers(chosen))
+            return required;
+
+        return null;
+    }
 
     public string? ValidateAnswer(Question question, QuestionAnswer answer, string resolvedTitle, string? resolvedValidationFailure = null)
     {
@@ -157,6 +194,19 @@ public sealed class JourneyValidationService(
         var uniqueId = Guid.NewGuid().ToString("N")[..7].ToUpper();
         return $"CYPMD_{type}_{uniqueId}";
     }
+
+    /// <summary>
+    /// The reference for a 16-19 results enquiry: <c>CYPMD_16to19_RE_{7 hex}</c>. AB#296648.
+    ///
+    /// A separate format from <see cref="GenerateReference"/> because support staff read these aloud
+    /// and need to tell an enquiry from an amendment at a glance — hence the <c>RE</c> segment, and
+    /// <c>16to19</c> rather than the enum's <c>Post16</c>, which is what the service calls the key
+    /// stage everywhere a school can see it.
+    ///
+    /// Decided: the confirmation mockup's <c>3014023_RE10005</c> was confirmed illustrative.
+    /// </summary>
+    public string GenerateEnquiryReference()
+        => $"CYPMD_16to19_RE_{Guid.NewGuid().ToString("N")[..7].ToUpper()}";
 
     public EvidenceValidationResult? ValidateEvidencePage(JourneyPage page, RequestState journey, string pupilName,
         IReadOnlySet<string>? conditionallyOptionalQuestionIds = null)

--- a/src/DfE.CheckPerformanceData.Application/Journey/PageType.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/PageType.cs
@@ -1,3 +1,6 @@
 namespace DfE.CheckPerformanceData.Application.Journey;
 
-public enum PageType { Question, Content, EvidenceUpload, PupilSearch }
+// AB#296648 appends ResultSearch (pick one of a student's exam results) and ResultDetails
+// (confirm the result and choose the revised grade). Appended last so existing flow JSON
+// deserialises to unmoved values.
+public enum PageType { Question, Content, EvidenceUpload, PupilSearch, ResultSearch, ResultDetails }

--- a/src/DfE.CheckPerformanceData.Application/Journey/QuestionType.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/QuestionType.cs
@@ -7,5 +7,8 @@ public enum QuestionType
     Date,
     FileUpload,
     TextArea,
-    Autocomplete
+    Autocomplete,
+    // AB#296648: a grade picker whose options come from the AODC reference data for the
+    // selected result's QAN. Appended last so existing flow JSON values are unmoved.
+    GradeSelect
 }

--- a/src/DfE.CheckPerformanceData.Application/Journey/RequestState.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/RequestState.cs
@@ -1,5 +1,6 @@
 using DfE.CheckPerformanceData.Application.CheckYourPupilData;
 using DfE.CheckPerformanceData.Application.LandingPage;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
 
 namespace DfE.CheckPerformanceData.Application.Journey;
 
@@ -13,6 +14,16 @@ public sealed class RequestState
     public string? MatchedPupilId { get; set; }
     public string? MatchedPupilLabel { get; set; }
     public PupilDto? MatchedPupil { get; set; }
+    /// <summary>AB#296648: the exam result chosen on a ResultSearch page, re-resolved server-side
+    /// from the results blob so a forged posted key cannot put an unheld result into the journey.
+    /// Null until one is chosen.</summary>
+    public StudentResultRecord? SelectedResult { get; set; }
+
+    /// <summary>AB#296648: the display label of the exam result chosen on a ResultSearch page,
+    /// re-rendered into the autocomplete on validation redisplay. Null until one is chosen.
+    /// The typed record itself is <c>SelectedResult</c>.</summary>
+    public string? SelectedResultLabel { get; set; }
+
     public CheckingWindowDto? CheckingWindow { get; set; }
     public string? ReferenceNumber { get; set; }
     public Dictionary<string, QuestionAnswer> QuestionAnswers { get; set; } = new();

--- a/src/DfE.CheckPerformanceData.Application/Journey/Validators/WholeNumberFormatValidator.cs
+++ b/src/DfE.CheckPerformanceData.Application/Journey/Validators/WholeNumberFormatValidator.cs
@@ -1,0 +1,48 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace DfE.CheckPerformanceData.Application.Journey.Validators;
+
+/// <summary>
+/// Validates that a value is a plain whole number from 1 to 9999 — the cohort-count question on the
+/// incorrect-grade enquiry journey (AB#296648).
+///
+/// Digits only: a sign, a decimal point or a thousands separator in a headcount is a typo rather than
+/// a quantity, and accepting them would put a value the downstream document cannot represent as an
+/// <c>int</c> into a submitted enquiry. The upper bound is a sanity cap — no single qualification
+/// cohort at one school reaches four figures, so a larger number is a slipped keystroke.
+///
+/// Surrounding whitespace is trimmed (unlike <see cref="DfeNumberFormatValidator"/>, where the
+/// pattern is an exact identifier): here the whitespace is a typing artefact and the answer it
+/// denotes is unambiguous.
+/// </summary>
+public sealed partial class WholeNumberFormatValidator : IFormatValidator
+{
+    private const int Minimum = 1;
+    private const int Maximum = 9999;
+
+    public string Name => "WholeNumber";
+
+    /// <summary>
+    /// Must read identically to the question's <c>validationFailure</c> in the flow config: the
+    /// engine reports the required-rule message for an empty answer and THIS message for a malformed
+    /// one, so different copy would make the same field appear to have two different rules.
+    /// </summary>
+    public string FailureMessage => "Enter how many students have an incorrect grade for this qualification";
+
+    public bool IsValid(string value)
+    {
+        var trimmed = value?.Trim() ?? string.Empty;
+
+        if (!DigitsOnlyPattern().IsMatch(trimmed))
+            return false;
+
+        // A leading-zero form such as "0010" denotes 10, so parse rather than measure the string.
+        // TryParse also rejects a digit run too long for an int instead of overflowing.
+        return int.TryParse(trimmed, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed)
+               && parsed is >= Minimum and <= Maximum;
+    }
+
+    [GeneratedRegex(@"^\d+$")]
+    private static partial Regex DigitsOnlyPattern();
+}

--- a/src/DfE.CheckPerformanceData.Application/Notify/INotifyService.cs
+++ b/src/DfE.CheckPerformanceData.Application/Notify/INotifyService.cs
@@ -9,7 +9,10 @@ public enum NotificationType
     BulkSubmissionConfirmed,
     DataCheckConfirmed,
     AmendmentWithdrawn,
-    DataCheckWithdrawn
+    DataCheckWithdrawn,
+    // AB#296648: confirmation that a 16-19 results enquiry was submitted. Appended last so existing
+    // stored/serialised values are unmoved.
+    ResultsEnquirySubmitted
 }
 
 /// <summary>

--- a/src/DfE.CheckPerformanceData.Application/Notify/IRequestNotificationService.cs
+++ b/src/DfE.CheckPerformanceData.Application/Notify/IRequestNotificationService.cs
@@ -10,6 +10,15 @@ public interface IRequestNotificationService
     Task NotifyBulkSubmissionConfirmedAsync(Guid windowId, DateTime deadlineDate, IReadOnlyList<string> referenceNumbers);
     Task NotifyDataCheckConfirmedAsync(DateTime deadlineDate, string referenceNumber);
 
+    /// <summary>
+    /// Confirms a submitted 16-19 results enquiry to the person who submitted it (AB#296648).
+    ///
+    /// Unlike an amendment confirmation this carries no deadline: an enquiry is not something the
+    /// school must come back and finish before the window closes. It goes to the submitter only, not
+    /// the whole organisation — the school has not been asked to do anything further.
+    /// </summary>
+    Task NotifyResultsEnquirySubmittedAsync(string referenceNumber);
+
     Task NotifyAmendmentWithdrawnAsync(string referenceNumber, DateTime deadlineDate);
 
     Task NotifyDataCheckWithdrawnAsync(string referenceNumber, DateTime deadlineDate);

--- a/src/DfE.CheckPerformanceData.Application/Notify/NotifySettings.cs
+++ b/src/DfE.CheckPerformanceData.Application/Notify/NotifySettings.cs
@@ -24,6 +24,13 @@ public class NotifySettings
     public string BulkSubmissionNotificationTemplateId { get; set; } = null!;
 
     /// <summary>
+    /// AB#296648: confirms a submitted 16-19 results enquiry. Not <c>[Required]</c> — the team has yet
+    /// to create this template, and an unset value must degrade to "no email sent, warning logged"
+    /// rather than stopping the app from starting.
+    /// </summary>
+    public string ResultsEnquirySubmittedTemplateId { get; set; } = null!;
+
+    /// <summary>
     /// Batch size at or above which a single consolidated submission email is sent instead of one
     /// email per request. Below it, individual emails are sent (parity with single submissions).
     /// </summary>

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/IRequestService.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/IRequestService.cs
@@ -16,6 +16,19 @@ public interface IRequestService
     /// </summary>
     Task SubmitRequestAsync(Guid windowId, RequestState journey);
 
+    /// <summary>
+    /// Submits a 16-19 results enquiry (AB#296648) and returns its reference number.
+    ///
+    /// Persists a <see cref="Domain.Enums.RequestType.ResultsEnquiry"/> row and the journey JSON —
+    /// the same two writes a pupil change request makes — and deliberately does NOT enqueue.
+    /// Enquiries are bound for Zendesk, but how they get there is a separate story; when it lands,
+    /// the enqueue belongs here and nowhere else.
+    ///
+    /// No duplicate check: the spec allows several enquiries about the same pupil and result. The
+    /// confirmation email is the caller's responsibility, matching <see cref="SubmitRequestAsync"/>.
+    /// </summary>
+    Task<string> SubmitResultsEnquiryAsync(Guid windowId, RequestState journey, CancellationToken ct = default);
+
     Task ConfirmRequestAsync(Guid windowId, RequestState journey);
     Task SaveDraftAsync(Guid windowId, RequestState journey, RequestStatus status);
     Task<RequestState?> ResumeDraftAsync(Guid windowId, string referenceNumber);

--- a/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestService.cs
+++ b/src/DfE.CheckPerformanceData.Application/RequestSubmission/RequestService.cs
@@ -94,6 +94,53 @@ public sealed class RequestService(
         await requestStateBlobClient.SaveAsync(windowId, journey.ReferenceNumber ?? string.Empty, journey);
     }
 
+    public async Task<string> SubmitResultsEnquiryAsync(
+        Guid windowId, RequestState journey, CancellationToken ct = default)
+    {
+        if (journey.SelectedWhatToChange != WhatToChange.IncorrectGrade)
+            throw new InvalidOperationException(
+                $"SubmitResultsEnquiryAsync is the results-enquiry path; got {journey.SelectedWhatToChange}. " +
+                "Routing an amendment through here would store the wrong RequestType and skip the rules engine.");
+
+        if (journey.CheckingWindow is null || journey.SelectedPupil is null || journey.SelectedResult is null
+            || string.IsNullOrWhiteSpace(journey.ReferenceNumber))
+            throw new InvalidOperationException("Session state is incomplete for results-enquiry submission.");
+
+        // The row first: it is the record of truth, and a journey blob with no row would be invisible
+        // to every admin view.
+        await requestRepository.UpsertAsync(new ChangeRequestData
+        {
+            WindowId = windowId,
+            ReferenceNumber = journey.ReferenceNumber,
+            OrganisationUrn = OrganisationUrnLong,
+            PupilId = journey.SelectedPupil.Id,
+            PupilUpn = journey.SelectedPupil.Identifier,
+            PupilFirstname = journey.SelectedPupil.Firstname,
+            PupilSurname = journey.SelectedPupil.Surname,
+            // Stored as UTC and converted to London time at display. The column is
+            // `timestamp without time zone`, so the value carries an Unspecified kind
+            // (Npgsql rejects a Utc kind here); the instant it holds is UTC.
+            Timestamp = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
+            SubmittedById = Guid.Parse(currentUserService.UserId),
+            SubmittedByName = currentUserService.DisplayName,
+            SubmittedByEmail = currentUserService.Email,
+            Status = RequestStatus.SubmittedUnCommitted,
+            RequestType = RequestType.ResultsEnquiry,
+            RequestTypeDescription = "Results enquiry - Incorrect grade",
+            AmendmentType = WhatToChange.IncorrectGrade
+        });
+
+        // The journey JSON is the enquiry's full record — it carries the selected result and every
+        // answer — so the separate Zendesk story can build its ticket from this without a new schema.
+        await requestStateBlobClient.SaveAsync(windowId, journey.ReferenceNumber, journey);
+
+        // PARKED AB#296648: no enqueue. Enquiries are destined for Zendesk, but the dispatch is a
+        // separate ticket. When it lands, the enqueue goes HERE and nowhere else — and the exclusion
+        // in AdminRequestsService.ProcessCloseWindowEvent comes out at the same time.
+
+        return journey.ReferenceNumber;
+    }
+
     public async Task ConfirmRequestAsync(Guid windowId, RequestState journey)
     {
         await SubmitRequestAsync(windowId, journey);

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/GradeReference.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/GradeReference.cs
@@ -1,0 +1,27 @@
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// AB#297130: the valid grades for one qualification, from the AODC reference data.
+/// <see cref="PassGrades"/> render before <see cref="FailGrades"/>; ordering within each list is
+/// preserved from the source, because a grade scale has a meaningful order (highest first) that
+/// alphabetical sorting would destroy.
+/// </summary>
+public sealed class GradeReference
+{
+    public required string Qan { get; init; }
+    public required string QualificationTitle { get; init; }
+    public string AwardingOrganisation { get; init; } = string.Empty;
+    public required IReadOnlyList<string> PassGrades { get; init; }
+    public required IReadOnlyList<string> FailGrades { get; init; }
+
+    /// <summary>The full picker option order: every pass grade, then every fail grade.</summary>
+    public IReadOnlyList<string> AllGrades => [.. PassGrades, .. FailGrades];
+
+    /// <summary>
+    /// Whether a posted grade is one this qualification actually offers. Ordinal and
+    /// case-sensitive: grades such as <c>24F</c> and <c>24D</c> differ only by suffix, and a
+    /// case-insensitive match could accept a value the picker never rendered.
+    /// </summary>
+    public bool Offers(string? grade)
+        => grade is not null && AllGrades.Contains(grade, StringComparer.Ordinal);
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/GradeReferenceLookup.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/GradeReferenceLookup.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// The parsed AODC grade reference document: a QAN-keyed map of <see cref="GradeReference"/>.
+///
+/// Parsing lives here rather than in the blob client so the shipped seed file can be validated by
+/// unit tests without blob storage, and so the client is left with only the fetch-and-cache job.
+/// Lookups are case-insensitive and trimmed because a QAN can end in a letter (<c>6037116X</c>) and
+/// arrives from a supplier CSV whose casing and padding are not guaranteed.
+/// </summary>
+public sealed class GradeReferenceLookup
+{
+    private readonly Dictionary<string, GradeReference> _byQan;
+
+    private GradeReferenceLookup(Dictionary<string, GradeReference> byQan) => _byQan = byQan;
+
+    public static GradeReferenceLookup Empty { get; } = new([]);
+
+    /// <summary>All entries, keyed by the QAN key from the document.</summary>
+    public IReadOnlyDictionary<string, GradeReference> Entries => _byQan;
+
+    /// <summary>The grades for a QAN, or <c>null</c> when the qualification is not in the reference
+    /// data. A reference-data gap is a normal (if loggable) state, not an exception.</summary>
+    public GradeReference? Find(string? qan)
+        => string.IsNullOrWhiteSpace(qan) ? null : _byQan.GetValueOrDefault(qan.Trim());
+
+    /// <summary>Parses the reference document. Malformed JSON throws so a broken file surfaces
+    /// rather than reading as "no qualification has any grades".</summary>
+    public static GradeReferenceLookup Parse(string json)
+    {
+        var parsed = JsonSerializer.Deserialize<Dictionary<string, GradeReference>>(
+            json, ResultsEnquiryJson.Options);
+
+        if (parsed is null or { Count: 0 })
+            return Empty;
+
+        return new GradeReferenceLookup(
+            new Dictionary<string, GradeReference>(parsed, StringComparer.OrdinalIgnoreCase));
+    }
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/IGradeReferenceClient.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/IGradeReferenceClient.cs
@@ -1,0 +1,17 @@
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// Reads the AODC grade reference data (AB#297130) — the valid grades per qualification — from the
+/// <c>rules-config</c> container, blob <c>grade-reference.json</c>. It sits alongside
+/// <c>rules.json</c> because it is the same kind of thing: slow-moving reference data supplied by
+/// another team, shared by every window, and self-seeded from a bundled copy.
+/// </summary>
+public interface IGradeReferenceClient
+{
+    /// <summary>
+    /// The grades a qualification can award, or <c>null</c> when the QAN is absent from the
+    /// reference data. Absent is a real state — the results CSVs and the AODC export come from
+    /// different teams and can disagree — so callers must handle it rather than assume coverage.
+    /// </summary>
+    Task<GradeReference?> GetByQanAsync(string qan, CancellationToken ct = default);
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/ILateResultsAvailability.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/ILateResultsAvailability.cs
@@ -1,0 +1,13 @@
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// Whether a school's second late results file has landed for a window. AB#296648.
+///
+/// Nearly all incorrect grades are corrected by that file, so the enquiry journey tells the user to
+/// check it first. The service is never told separately whether it exists — it derives the answer
+/// from the results data it already holds.
+/// </summary>
+public interface ILateResultsAvailability
+{
+    Task<bool> IsSecondLateResultsAvailableAsync(Guid windowId, string laestab, CancellationToken ct = default);
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/IStudentResultsClient.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/IStudentResultsClient.cs
@@ -1,0 +1,26 @@
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// Reads (and, for dev seeding, writes) the per-school 16-19 exam results held in blob storage at
+/// container <c>{windowId}</c>, blob <c>results-enquiry/data/{laestab}_results.json</c> — see
+/// <see cref="ResultsEnquiryBlobPaths"/>. The file is one merged array across all six supplier
+/// input files, each row stamped with its <see cref="ResultsFileTags"/> source tag by ingestion.
+/// </summary>
+public interface IStudentResultsClient
+{
+    /// <summary>
+    /// The results held for one student. Empty when the container, the blob or the student is
+    /// absent — a school with no results is a normal state, not an error. Malformed JSON throws so
+    /// a corrupt file surfaces rather than reading as "this student has no results".
+    /// </summary>
+    Task<IReadOnlyList<StudentResultRecord>> GetResultsAsync(Guid windowId, string laestab, string cypmdId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Whether the school holds any result from a given source file. This is how the service works
+    /// out for itself whether a supplier file has landed, rather than being told separately.
+    /// </summary>
+    Task<bool> AnyForSourceAsync(Guid windowId, string laestab, string sourceTag, CancellationToken ct = default);
+
+    /// <summary>Writes a school's results file. Used only by development data seeding.</summary>
+    Task UploadResultsAsync(Guid windowId, string laestab, IReadOnlyList<StudentResultRecord> results, CancellationToken ct = default);
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/LateResultsAvailability.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/LateResultsAvailability.cs
@@ -1,0 +1,20 @@
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// Derives second-late-results availability from the presence of any result tagged
+/// <see cref="ResultsFileTags.Post16LateResults2"/> in the school's results file.
+///
+/// This is the ONLY place in the service that decides what "the second late results file is
+/// available" means. Anything that needs the answer asks here, so the interstitial and every future
+/// consumer cannot drift apart.
+///
+/// PARKED AB#296648: the October-gating decision (whether "Incorrect grade" is even selectable
+/// before the second late results file exists) may add a second consumer of this. That is why it is
+/// a seam rather than an inline check in the controller.
+/// </summary>
+public sealed class LateResultsAvailability(IStudentResultsClient results) : ILateResultsAvailability
+{
+    public Task<bool> IsSecondLateResultsAvailableAsync(
+        Guid windowId, string laestab, CancellationToken ct = default)
+        => results.AnyForSourceAsync(windowId, laestab, ResultsFileTags.Post16LateResults2, ct);
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/ResultLabel.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/ResultLabel.cs
@@ -1,0 +1,19 @@
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// How one exam result is described to a school when they pick which one is wrong.
+///
+/// One definition, because the text appears in two places — the server-rendered options on the
+/// ResultSearch page and the <c>/results/suggestions</c> endpoint — and they must agree or the
+/// enhanced and unenhanced versions of the same page would read differently.
+///
+/// The Figma frame shows "{qualification}, QAN: {qan}". The session is appended because
+/// AB#296648 requires that "each result shows enough detail for me to identify the right one", and
+/// its stated rationale is that a pupil can hold several results in one subject area — a resit would
+/// otherwise be indistinguishable from the original sitting. FLAGGED for content sign-off.
+/// </summary>
+public static class ResultLabel
+{
+    public static string For(StudentResultRecord result)
+        => $"{result.QualificationName}, QAN: {result.Qan}, Session: {result.Session}";
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/ResultsEnquiryBlobPaths.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/ResultsEnquiryBlobPaths.cs
@@ -1,0 +1,27 @@
+using DfE.CheckPerformanceData.Application.Dashboard;
+
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// Every blob path segment the results-enquiry feature uses, in one place. The lead developer's
+/// 16-19 window-model note warns the activity naming may change, so a rename must be mechanical.
+///
+/// Layout: container <c>{windowId}</c> (the existing per-window container), blob
+/// <c>results-enquiry/data/{laestab}_results.json</c> — one merged array per school across all six
+/// source files. The <c>results-enquiry/</c> prefix is deliberate: per consequence #2 of
+/// docs/16-19-window-model.md each window activity owns its own blob prefix, so when ingress
+/// becomes per-activity no blob migration is needed and one activity's sweep cannot destroy
+/// another's output. Pupil-data checking keeps its existing bare <c>data/</c> prefix.
+/// </summary>
+public static class ResultsEnquiryBlobPaths
+{
+    public const string ResultsPrefix = "results-enquiry/data/";
+    public const string ResultsSuffix = "_results.json";
+
+    /// <summary>The grade-reference blob, seeded alongside <c>rules.json</c> in the rules-config container.</summary>
+    public const string GradeReferenceBlobName = "grade-reference.json";
+
+    /// <summary>e.g. "933/4070" -> "results-enquiry/data/9334070_results.json".</summary>
+    public static string ResultsBlobName(string laestab)
+        => $"{ResultsPrefix}{LaestabNormaliser.Normalise(laestab)}{ResultsSuffix}";
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/ResultsEnquiryJson.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/ResultsEnquiryJson.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// The single <see cref="JsonSerializerOptions"/> instance the results-enquiry blob readers use.
+/// Held in Application (rather than on the Infrastructure client, as the pupil schema does) so the
+/// serialization contract for the read model lives beside the read model, and so the unit tests can
+/// bind fixtures through the exact instance production uses without depending on the blob client.
+/// <c>StudentResultsBlobClient.JsonOptions</c> and <c>GradeReferenceBlobClient.JsonOptions</c> both
+/// forward here.
+/// </summary>
+public static class ResultsEnquiryJson
+{
+    public static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(), new TolerantStringJsonConverter() }
+    };
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/ResultsFileTags.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/ResultsFileTags.cs
@@ -1,0 +1,19 @@
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// The provenance tag stamped on each result row by ingestion, one per input CSV. Values are
+/// verbatim from AB#296999 — they are a data contract with the ingestion pipeline, so a rename
+/// here is a breaking change to already-written blobs.
+/// </summary>
+public static class ResultsFileTags
+{
+    public const string Post16Main = "16to19_MAIN";
+    public const string Post16LateResults1 = "16to19_LR1";
+    public const string Post16LateResults2 = "16to19_LR2";
+    public const string Post16Revised = "16to19_Revised";
+    public const string Post16Retention = "16to19_Retention";
+    public const string Ks4Main = "KS4_MAIN";
+    public const string Ks4LateResults1 = "KS4_LR1";
+    public const string Ks4LateResults2 = "KS4_LR2";
+    public const string Ks4Revised = "KS4_Revised";
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/StudentResultRecord.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/StudentResultRecord.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// The 16-19 per-student result read model (AB#296999). One record per result row across the six
+/// input CSVs; <see cref="SourceFile"/> carries the provenance tag so the school can trace which
+/// file a result came from. Unknown JSON fields are ignored so ingestion can add columns without
+/// breaking readers.
+/// </summary>
+public sealed class StudentResultRecord
+{
+    [JsonPropertyName("CYPMD_ID")] public string CypmdId { get; init; } = string.Empty;
+    [JsonPropertyName("QAN")] public string Qan { get; init; } = string.Empty;
+
+    /// <summary>e.g. "GCSE (9-1) Bus. Studs:Single".</summary>
+    [JsonPropertyName("QUAL_NAME")] public string QualificationName { get; init; } = string.Empty;
+
+    [JsonPropertyName("SYLLABUS")] public string SyllabusCode { get; init; } = string.Empty;
+
+    /// <summary>e.g. "S2024".</summary>
+    [JsonPropertyName("SESSION")] public string Session { get; init; } = string.Empty;
+
+    [JsonPropertyName("GRADE")] public string Grade { get; init; } = string.Empty;
+
+    /// <summary>A <see cref="ResultsFileTags"/> value.</summary>
+    [JsonPropertyName("SOURCE")] public string SourceFile { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The composite key that uniquely identifies this result for the pupil, used as the posted
+    /// value of a ResultSearch selection. A pupil can hold the same QAN across sessions and across
+    /// source files, so QAN alone is not enough.
+    /// </summary>
+    [JsonIgnore]
+    public string CompositeKey => $"{Qan}|{Session}|{SourceFile}";
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/TolerantStringJsonConverter.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/TolerantStringJsonConverter.cs
@@ -1,0 +1,43 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// Reads a JSON string, <c>null</c>, number or boolean into a <see cref="string"/>, mapping
+/// <c>null</c> to <see cref="string.Empty"/>.
+///
+/// Every field on <see cref="StudentResultRecord"/> is a string because the values are opaque
+/// codes (grades such as <c>*2</c> and <c>24F</c>, QANs such as <c>6037116X</c>) that must never be
+/// coerced to a number. But the ingestion step converts supplier CSVs, and CSV-to-JSON converters
+/// routinely emit numeric-looking columns unquoted — <c>"GRADE": 5</c> rather than <c>"GRADE": "5"</c>.
+/// The default string converter throws on a number token, so a single unquoted column would fail
+/// the whole file. <c>JsonNumberHandling.AllowReadingFromString</c> does not help: it relaxes the
+/// opposite direction (string token into a numeric property).
+///
+/// <see cref="HandleNull"/> is <c>true</c> because System.Text.Json otherwise short-circuits a null
+/// token for reference types and never calls the converter — the same reason
+/// <c>NullToEmptyStringJsonConverter</c> overrides it for the pupil schema.
+/// </summary>
+public sealed class TolerantStringJsonConverter : JsonConverter<string>
+{
+    public override bool HandleNull => true;
+
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.TokenType switch
+        {
+            JsonTokenType.Null => string.Empty,
+            JsonTokenType.String => reader.GetString() ?? string.Empty,
+            // The raw token text, so 5 reads as "5" and not "5.0" via a round-trip through double.
+            JsonTokenType.Number => Encoding.UTF8.GetString(
+                reader.HasValueSequence ? BuffersExtensions.ToArray(reader.ValueSequence) : reader.ValueSpan),
+            JsonTokenType.True => bool.TrueString,
+            JsonTokenType.False => bool.FalseString,
+            _ => throw new JsonException($"Cannot read a {reader.TokenType} token as a string.")
+        };
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        => writer.WriteStringValue(value);
+}

--- a/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/WhatToChangeActivityMap.cs
+++ b/src/DfE.CheckPerformanceData.Application/ResultsEnquiry/WhatToChangeActivityMap.cs
@@ -1,0 +1,21 @@
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+
+namespace DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+/// <summary>
+/// Option A of docs/16-19-window-model.md: each <see cref="WhatToChange"/> member belongs to
+/// one window activity. The future IWindowActivityService gating consumes this; nothing else
+/// may hardcode the mapping. String values (not the not-yet-built CheckingWindowActivityType
+/// enum) so this ticket does not depend on the activity model landing first.
+/// </summary>
+public static class WhatToChangeActivityMap
+{
+    public const string PupilData = "PupilData";
+    public const string ResultsEnquiry = "ResultsEnquiry";
+
+    public static string ActivityFor(WhatToChange change) => change switch
+    {
+        WhatToChange.IncorrectGrade => ResultsEnquiry,
+        _ => PupilData
+    };
+}

--- a/src/DfE.CheckPerformanceData.Application/UncommittedRequests/AdminRequestsService.cs
+++ b/src/DfE.CheckPerformanceData.Application/UncommittedRequests/AdminRequestsService.cs
@@ -27,6 +27,15 @@ public sealed class AdminRequestsService(
             if (journey?.SelectedWhatToChange is null || journey.CheckingWindow is null || journey.SelectedPupil is null)
                 continue;
 
+            // PARKED AB#296648: a 16-19 results enquiry is excluded from this replay. It IS bound for
+            // Zendesk, but this path builds a pupil-amendment ticket — BuildDocument maps journey
+            // answers onto the amendment ticket fields, and an enquiry's QAN, session, current and
+            // revised grade have no place in that shape. Replaying one would create a malformed
+            // ticket AND flip the row to SubmittedCommitted, so the real dispatch could never pick it
+            // up. Remove this once the enquiry-to-Zendesk story defines its own ticket shape.
+            if (journey.SelectedWhatToChange == CheckYourPupilData.WhatToChange.IncorrectGrade)
+                continue;
+
             var config = await flowService.GetConfigAsync(
                 journey.SelectedWhatToChange.Value, journey.CheckingWindow.CheckingWindowType);
             if (config is null)

--- a/src/DfE.CheckPerformanceData.Domain/Enums/RequestType.cs
+++ b/src/DfE.CheckPerformanceData.Domain/Enums/RequestType.cs
@@ -3,5 +3,9 @@ namespace DfE.CheckPerformanceData.Domain.Enums;
 public enum RequestType
 {
     Amendment,
-    ConfirmCorrect
+    ConfirmCorrect,
+    // AB#296648: a 16-19 results enquiry (e.g. an incorrect grade report). Stored in the
+    // ChangeRequest.RequestType string column (max 20) — "ResultsEnquiry" fits, no migration.
+    // Appended last so existing stored values are unmoved.
+    ResultsEnquiry
 }

--- a/src/DfE.CheckPerformanceData.Infrastructure/BlobStorage/GradeReferenceBlobClient.cs
+++ b/src/DfE.CheckPerformanceData.Infrastructure/BlobStorage/GradeReferenceBlobClient.cs
@@ -1,0 +1,131 @@
+using System.Text;
+using System.Text.Json;
+using Azure;
+using Azure.Storage.Blobs;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Infrastructure.RulesEngine;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace DfE.CheckPerformanceData.Infrastructure.BlobStorage;
+
+/// <summary>
+/// Reads the AODC grade reference document from the rules-config container, and self-seeds it from
+/// the bundled copy when absent — the same arrangement <see cref="RulesConfigSeeder"/> uses, and for
+/// the same reason: Terraform provisions an empty container and the storage account has no public
+/// network access, so nothing outside the cluster can upload the blob.
+///
+/// The document is shared by every school and every window and changes at most once a year, so it is
+/// cached for five minutes. A missing blob caches as an empty lookup rather than throwing: the
+/// details page degrades to "we cannot list grades for this qualification yet" instead of erroring,
+/// and a five-minute retry picks the blob up once it lands.
+/// </summary>
+public sealed class GradeReferenceBlobClient : IGradeReferenceClient
+{
+    private const string CacheKey = "grade-reference";
+    private static readonly TimeSpan CacheExpiry = TimeSpan.FromMinutes(5);
+
+    private readonly BlobServiceClient _blobServiceClient;
+    private readonly IMemoryCache _cache;
+    private readonly BlobRulesProviderOptions _options;
+    private readonly ILogger<GradeReferenceBlobClient> _logger;
+
+    public GradeReferenceBlobClient(
+        BlobServiceClient blobServiceClient,
+        IMemoryCache cache,
+        IOptions<BlobRulesProviderOptions> options,
+        ILogger<GradeReferenceBlobClient> logger)
+    {
+        _blobServiceClient = blobServiceClient;
+        _cache = cache;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <summary>Public so tests bind fixture JSON exactly as production does.</summary>
+    public static JsonSerializerOptions JsonOptions => ResultsEnquiryJson.Options;
+
+    public async Task<GradeReference?> GetByQanAsync(string qan, CancellationToken ct = default)
+        => (await GetLookupAsync(ct)).Find(qan);
+
+    /// <summary>
+    /// Uploads the bundled document only if the blob is absent (If-None-Match=*), so a hand-edited
+    /// or newer-than-bundled blob in a deployed environment is never clobbered. Best-effort: a
+    /// storage failure is logged, not thrown, because the grade picker degrading is far better than
+    /// the whole app failing to start.
+    /// </summary>
+    public async Task SeedIfMissingAsync(string json, CancellationToken ct = default)
+    {
+        try
+        {
+            var container = _blobServiceClient.GetBlobContainerClient(_options.RulesBlobContainer);
+            await container.CreateIfNotExistsAsync(cancellationToken: ct);
+
+            var blob = container.GetBlobClient(ResultsEnquiryBlobPaths.GradeReferenceBlobName);
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+            await blob.UploadAsync(
+                stream,
+                new Azure.Storage.Blobs.Models.BlobUploadOptions
+                {
+                    Conditions = new Azure.Storage.Blobs.Models.BlobRequestConditions { IfNoneMatch = ETag.All }
+                },
+                ct);
+
+            _cache.Remove(CacheKey);
+            _logger.LogInformation(
+                "Seeded grade reference '{Blob}' into container '{Container}'.",
+                ResultsEnquiryBlobPaths.GradeReferenceBlobName, _options.RulesBlobContainer);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 409)
+        {
+            // Already present (or another instance won the race) — the whole point of the guard.
+            _logger.LogInformation(
+                "Grade reference '{Blob}' already present; skipping seed.",
+                ResultsEnquiryBlobPaths.GradeReferenceBlobName);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to seed grade reference '{Blob}'; the revised-grade picker will have no options " +
+                "until the blob is provisioned.", ResultsEnquiryBlobPaths.GradeReferenceBlobName);
+        }
+    }
+
+    private async Task<GradeReferenceLookup> GetLookupAsync(CancellationToken ct)
+    {
+        if (_cache.TryGetValue(CacheKey, out GradeReferenceLookup? cached) && cached is not null)
+            return cached;
+
+        var lookup = await DownloadAsync(ct);
+        _cache.Set(CacheKey, lookup, new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = CacheExpiry });
+        return lookup;
+    }
+
+    private async Task<GradeReferenceLookup> DownloadAsync(CancellationToken ct)
+    {
+        var blob = _blobServiceClient
+            .GetBlobContainerClient(_options.RulesBlobContainer)
+            .GetBlobClient(ResultsEnquiryBlobPaths.GradeReferenceBlobName);
+
+        try
+        {
+            var response = await blob.DownloadContentAsync(ct);
+            // Malformed JSON intentionally throws so a corrupt reference file surfaces rather than
+            // silently emptying every grade picker in the service.
+            return GradeReferenceLookup.Parse(response.Value.Content.ToString());
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            _logger.LogWarning(
+                "Grade reference '{Blob}' is not present in container '{Container}'; no qualification " +
+                "will offer grades until it is seeded.",
+                ResultsEnquiryBlobPaths.GradeReferenceBlobName, _options.RulesBlobContainer);
+            return GradeReferenceLookup.Empty;
+        }
+    }
+}

--- a/src/DfE.CheckPerformanceData.Infrastructure/BlobStorage/StudentResultsBlobClient.cs
+++ b/src/DfE.CheckPerformanceData.Infrastructure/BlobStorage/StudentResultsBlobClient.cs
@@ -1,0 +1,84 @@
+using System.Text;
+using System.Text.Json;
+using Azure.Storage.Blobs;
+using DfE.CheckPerformanceData.Application.Dashboard;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace DfE.CheckPerformanceData.Infrastructure.BlobStorage;
+
+/// <summary>
+/// Reads the per-school 16-19 results blob, mirroring <see cref="PupilDataBlobClient"/>. Caching
+/// lives here rather than in a repository (as it does for pupils) because there is no repository
+/// between this and its callers — the same 30-minute sliding window is used so a school's results
+/// and pupils go stale together.
+/// </summary>
+public sealed class StudentResultsBlobClient(BlobServiceClient blobServiceClient, IMemoryCache cache) : IStudentResultsClient
+{
+    private static readonly TimeSpan CacheSlidingExpiry = TimeSpan.FromMinutes(30);
+
+    /// <summary>Public so tests bind fixture JSON exactly as production does.</summary>
+    public static JsonSerializerOptions JsonOptions => ResultsEnquiryJson.Options;
+
+    public async Task<IReadOnlyList<StudentResultRecord>> GetResultsAsync(
+        Guid windowId, string laestab, string cypmdId, CancellationToken ct = default)
+    {
+        var all = await GetSchoolResultsAsync(windowId, laestab, ct);
+        return all.Where(r => string.Equals(r.CypmdId, cypmdId, StringComparison.OrdinalIgnoreCase)).ToList();
+    }
+
+    public async Task<bool> AnyForSourceAsync(
+        Guid windowId, string laestab, string sourceTag, CancellationToken ct = default)
+    {
+        var all = await GetSchoolResultsAsync(windowId, laestab, ct);
+        return all.Any(r => string.Equals(r.SourceFile, sourceTag, StringComparison.Ordinal));
+    }
+
+    public async Task UploadResultsAsync(
+        Guid windowId, string laestab, IReadOnlyList<StudentResultRecord> results, CancellationToken ct = default)
+    {
+        var container = blobServiceClient.GetBlobContainerClient(windowId.ToString());
+        await container.CreateIfNotExistsAsync(cancellationToken: ct);
+
+        var blob = container.GetBlobClient(ResultsEnquiryBlobPaths.ResultsBlobName(laestab));
+        var json = JsonSerializer.Serialize(results, JsonOptions);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
+        await blob.UploadAsync(stream, overwrite: true, cancellationToken: ct);
+
+        // A seeding write must not leave the reader serving the pre-seed value for 30 minutes.
+        cache.Remove(CacheKey(windowId, laestab));
+    }
+
+    private async Task<IReadOnlyList<StudentResultRecord>> GetSchoolResultsAsync(
+        Guid windowId, string laestab, CancellationToken ct)
+    {
+        var key = CacheKey(windowId, laestab);
+        if (cache.TryGetValue(key, out IReadOnlyList<StudentResultRecord>? cached) && cached is not null)
+            return cached;
+
+        var results = await DownloadAsync(windowId, laestab, ct);
+        cache.Set(key, results, new MemoryCacheEntryOptions { SlidingExpiration = CacheSlidingExpiry });
+        return results;
+    }
+
+    private async Task<IReadOnlyList<StudentResultRecord>> DownloadAsync(
+        Guid windowId, string laestab, CancellationToken ct)
+    {
+        var container = blobServiceClient.GetBlobContainerClient(windowId.ToString());
+        if (!await container.ExistsAsync(ct))
+            return [];
+
+        var blob = container.GetBlobClient(ResultsEnquiryBlobPaths.ResultsBlobName(laestab));
+        if (!await blob.ExistsAsync(ct))
+            return [];
+
+        var response = await blob.DownloadContentAsync(ct);
+        // Malformed JSON intentionally throws so corrupt files surface rather than read as empty.
+        return JsonSerializer.Deserialize<List<StudentResultRecord>>(
+            response.Value.Content.ToMemory().Span, JsonOptions) ?? [];
+    }
+
+    // The laestab is normalised so a claim value of "933/4070" and a blob name of "9334070" agree.
+    private static string CacheKey(Guid windowId, string laestab)
+        => $"results:{windowId}:{LaestabNormaliser.Normalise(laestab)}";
+}

--- a/src/DfE.CheckPerformanceData.Infrastructure/DependencyManager.cs
+++ b/src/DfE.CheckPerformanceData.Infrastructure/DependencyManager.cs
@@ -12,6 +12,7 @@ using DfE.CheckPerformanceData.Infrastructure.Analytics;
 using DfE.CheckPerformanceData.Application.DfESignInApiClient;
 using DfE.CheckPerformanceData.Infrastructure.BlobStorage;
 using DfE.CheckPerformanceData.Application.Notify;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
 using DfE.CheckPerformanceData.Application.RulesConfig;
 using DfE.CheckPerformanceData.Application.RulesEngine;
 using DfE.CheckPerformanceData.Application.ZendeskClient;
@@ -58,6 +59,10 @@ public static class DependencyManager
         // the Web host) because the Persistence repositories that consume it are pulled in
         // by every host that calls AddPersistenceDependencies — including the worker.
         services.AddScoped<IPupilDataBlobClient, PupilDataBlobClient>();
+
+        // AB#296648: the 16-19 exam results a school can raise an enquiry against, held in the same
+        // per-window container under the results-enquiry activity prefix.
+        services.AddScoped<IStudentResultsClient, StudentResultsBlobClient>();
 
         // Analytics sink: the real dfe-analytics adapter when DfeAnalytics:DatasetId is
         // configured (deployed envs wire it via Terraform), else a no-op so dev/review/

--- a/src/DfE.CheckPerformanceData.Infrastructure/Notify/NotifyService.cs
+++ b/src/DfE.CheckPerformanceData.Infrastructure/Notify/NotifyService.cs
@@ -43,8 +43,22 @@ public class NotifyService : INotifyService
             NotificationType.DataCheckConfirmed => _settings.PupilDataCheckConfirmTemplateId,
             NotificationType.AmendmentWithdrawn => _settings.WithdrawNotificationTemplateId,
             NotificationType.DataCheckWithdrawn => _settings.PupilDataCheckWithdrawTemplateId,
+            NotificationType.ResultsEnquirySubmitted => _settings.ResultsEnquirySubmittedTemplateId,
             _ => throw new ArgumentOutOfRangeException(nameof(notificationType))
         };
+
+        // A template id that is not configured yet — the results-enquiry template is still to be
+        // created (AB#296648) — would otherwise be sent to Notify once per recipient and rejected
+        // once per recipient. One warning is the useful signal, and it keeps the caller's outcome
+        // independent of email delivery as this interface promises.
+        if (string.IsNullOrWhiteSpace(templateId))
+        {
+            _logger.LogWarning(
+                "No GOV.UK Notify template is configured for {NotificationType}; skipping {RecipientCount} " +
+                "email(s) for ref {ReferenceNumber}. Set the corresponding Notify:*TemplateId setting.",
+                notificationType, recipientEmails.Count, referenceNumber);
+            return;
+        }
 
         _logger.LogInformation(
             "Sending {NotificationType} notifications for ref {ReferenceNumber} to {RecipientCount} recipient(s)",

--- a/src/DfE.CheckPerformanceData.Infrastructure/Notify/RequestNotificationService.cs
+++ b/src/DfE.CheckPerformanceData.Infrastructure/Notify/RequestNotificationService.cs
@@ -35,6 +35,23 @@ public sealed class RequestNotificationService(
         });
     }
 
+    public async Task NotifyResultsEnquirySubmittedAsync(string referenceNumber)
+    {
+        await dispatcher.EnqueueAsync(new EmailNotification
+        {
+            Type = NotificationType.ResultsEnquirySubmitted,
+            ReferenceNumber = referenceNumber,
+            // No deadline: an enquiry is not something the school must come back and finish. The
+            // template is worded accordingly.
+            Deadline = string.Empty,
+            Ukprn = currentUserService.Ukprn,
+            OriginatorEmail = currentUserService.Email,
+            // The submitter only. Nothing is being asked of the rest of the school, so copying every
+            // user would be noise.
+            IncludeOrganisationUsers = false
+        });
+    }
+
     public async Task NotifyBulkSubmissionConfirmedAsync(
         Guid windowId, DateTime deadlineDate, IReadOnlyList<string> referenceNumbers)
     {

--- a/src/DfE.CheckPerformanceData.Persistence/Repositories/CheckYourPupilDataRepository.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Repositories/CheckYourPupilDataRepository.cs
@@ -55,6 +55,11 @@ public sealed class CheckYourPupilDataRepository(
     {
         // urn is retained on the signature for callers but is unused: the UPN-based exclusion
         // query it served was removed in 3f9efadf, which moved conflict detection onto pupil Id.
+        //
+        // AB#297004: matching and label text differ by window type (16-19 searches on date of birth
+        // too and shows its identifiers), so both live in PupilSuggestionFormat where they can be
+        // unit-tested against pinned copy.
+        var window = await GetCheckingWindowAsync(windowId);
         var pupils = (await GetSchoolPupilsAsync(windowId, laestab))
             .Where(p => filter switch
             {
@@ -62,10 +67,7 @@ public sealed class CheckYourPupilDataRepository(
                 PupilFilter.Included => p.IsIncluded,
                 _ => !p.IsIncluded
             })
-            .Where(p => p.Identifier.StartsWith(query, StringComparison.OrdinalIgnoreCase) ||
-                        p.Cypmd_Id.StartsWith(query, StringComparison.OrdinalIgnoreCase) ||
-                        p.Surname.Contains(query, StringComparison.OrdinalIgnoreCase) ||
-                        p.Firstname.Contains(query, StringComparison.OrdinalIgnoreCase));
+            .Where(p => PupilSuggestionFormat.Matches(p, query, window.CheckingWindowType));
 
         if (excludeId.HasValue)
             pupils = pupils.Where(p => p.Id != excludeId.Value);
@@ -73,7 +75,7 @@ public sealed class CheckYourPupilDataRepository(
         return pupils
             .OrderBy(p => p.Surname).ThenBy(p => p.Firstname)
             .Take(10)
-            .Select(p => new PupilSuggestionDto(p.Id, $"{p.Surname}, {p.Firstname}, {PupilDateFormatter.ToDisplayDate(p.DateOfBirth)}"))
+            .Select(p => new PupilSuggestionDto(p.Id, PupilSuggestionFormat.Label(p, window.CheckingWindowType)))
             .ToList();
     }
 

--- a/src/DfE.CheckPerformanceData.Persistence/Repositories/RequestRepository.cs
+++ b/src/DfE.CheckPerformanceData.Persistence/Repositories/RequestRepository.cs
@@ -33,7 +33,12 @@ public sealed class RequestRepository(IPortalDbContext db) : IRequestRepository
                 && r.PupilId == pupilId
                 && r.OrganisationUrn == organisationUrn
                 && r.ReferenceNumber != currentReferenceNumber
-                && r.Status == RequestStatus.SubmittedUnCommitted)
+                && r.Status == RequestStatus.SubmittedUnCommitted
+                // AB#296648: a results enquiry is not a competing amendment, so it must not raise the
+                // pupil-search duplicate warning. Kept in step with ConflictQuery below — the warning
+                // and the hard block have to agree, or the user is warned about something that then
+                // submits fine (or worse, the reverse).
+                && r.RequestType != RequestType.ResultsEnquiry)
             .OrderByDescending(r => r.Submitted)
             .Select(r => new { r.SubmittedById, r.ReferenceNumber, r.RequestTypeDescription, r.SubmittedByName })
             .FirstOrDefaultAsync();
@@ -70,6 +75,28 @@ public sealed class RequestRepository(IPortalDbContext db) : IRequestRepository
             .Distinct()
             .ToListAsync();
 
+    /// <summary>
+    /// Rows that would conflict with <paramref name="data"/>: another submitted-uncommitted amendment
+    /// for the same pupil, at the same school, in the same window.
+    ///
+    /// Results enquiries are excluded (AB#296648) — they change no pupil data, so they neither
+    /// compete with an amendment nor with each other.
+    /// </summary>
+    private static IQueryable<ChangeRequest> ConflictQuery(
+        IPortalDbContext db, ChangeRequestData data, Guid existingId)
+    {
+        var query = db.ChangeRequests
+            .Where(r => r.WindowId == data.WindowId
+                && r.PupilId == data.PupilId
+                && r.OrganisationUrn == data.OrganisationUrn
+                && r.Status == RequestStatus.SubmittedUnCommitted
+                && r.RequestType != RequestType.ResultsEnquiry);
+
+        // When updating an existing row, exclude the current row from conflict
+        // detection so a user can re-submit or update their own draft.
+        return existingId != Guid.Empty ? query.Where(r => r.Id != existingId) : query;
+    }
+
     public async Task<Guid> UpsertAsync(ChangeRequestData data)
     {
         var timestamp = DateTime.SpecifyKind(data.Timestamp, DateTimeKind.Local);
@@ -94,18 +121,16 @@ public sealed class RequestRepository(IPortalDbContext db) : IRequestRepository
                     .Select(r => r.Id)
                     .FirstOrDefaultAsync();
 
-                var conflictQuery = db.ChangeRequests
-                    .Where(r => r.WindowId == data.WindowId
-                        && r.PupilId == data.PupilId
-                        && r.OrganisationUrn == data.OrganisationUrn
-                        && r.Status == RequestStatus.SubmittedUnCommitted);
-
-                // When updating an existing row, exclude the current row from conflict
-                // detection so a user can re-submit or update their own draft.
-                if (existingId != Guid.Empty)
-                    conflictQuery = conflictQuery.Where(r => r.Id != existingId);
-
-                var conflict = await conflictQuery.FirstOrDefaultAsync();
+                // AB#296648: the duplicate rule guards against two competing AMENDMENTS to the same
+                // pupil's record — only one can be right, so the second is a conflict to resolve. A
+                // results enquiry is not an amendment: it changes no pupil data, and the spec
+                // explicitly allows several for the same pupil and result. So an enquiry neither
+                // raises a conflict nor counts as one. Without both exclusions, reporting a wrong
+                // grade for a pupil would block every later amendment for them (and vice versa), with
+                // an error message naming an unrelated request.
+                var conflict = data.RequestType == RequestType.ResultsEnquiry
+                    ? null
+                    : await ConflictQuery(db, data, existingId).FirstOrDefaultAsync();
 
                 if (conflict is not null)
                 {

--- a/src/DfE.CheckPerformanceData.Web/Analytics/ValidationErrorCoding.cs
+++ b/src/DfE.CheckPerformanceData.Web/Analytics/ValidationErrorCoding.cs
@@ -33,6 +33,11 @@ public static class ValidationErrorCoding
             QuestionType.TextArea => "too_long",
             QuestionType.Autocomplete => "selection_invalid",
             QuestionType.Radio => "selection_invalid",
+            // AB#296648: a grade picker is a selection control, so it belongs with the other two.
+            // Without this it fell through to the generic "invalid", which loses exactly the
+            // distinction this taxonomy exists to make — a rejected grade is a bad selection (the
+            // qualification does not offer it, or it matches the current grade), not a bad format.
+            QuestionType.GradeSelect => "selection_invalid",
             _ => "invalid",
         };
     }

--- a/src/DfE.CheckPerformanceData.Web/Controllers/CheckYourPupilData/CheckYourPupilDataController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/CheckYourPupilData/CheckYourPupilDataController.cs
@@ -95,7 +95,15 @@ public sealed class CheckYourPupilDataController(ICheckYourPupilDataService chec
     [Route("CheckYourPupilData/{windowId}/nextstep")]
     public async Task<IActionResult> NextStep(Guid windowId, CheckYourPupilDataViewModel viewModel)
     {
-        if (viewModel.SelectedNextStep is null)
+        // AB#296648: the results-enquiry option is 16-19 only, and the rule is re-derived from the
+        // window here rather than trusted from the post. Not rendering the radio is a UI courtesy; a
+        // hand-crafted post must not start a journey for a key stage with no results data and no flow
+        // config behind it, so it is rejected exactly as an unanswered question would be.
+        var window = await checkYourPupilDataService.GetCheckingWindowAsync(windowId);
+        var optionAllowed = viewModel.SelectedNextStep != NextSteps.ResultsEnquiry
+                            || OffersResultsEnquiry(window.CheckingWindowType);
+
+        if (viewModel.SelectedNextStep is null || !optionAllowed)
         {
             ModelState.AddModelError(nameof(CheckYourPupilDataViewModel.SelectedNextStep), "Select what you would like to do");
             await analytics.TrackSafeAsync(new ValidationErrorEvent { ErrorCount = 1, ErrorCodes = [ValidationErrorCoding.NoSelection], ErrorFields = [nameof(CheckYourPupilDataViewModel.SelectedNextStep)] });
@@ -109,6 +117,7 @@ public sealed class CheckYourPupilDataController(ICheckYourPupilDataService chec
         {
             NextSteps.RequestChange => RedirectToAction("Index", "WhatToChange", new { windowId }),
             NextSteps.Confirm => RedirectToAction("Index", "ConfirmCorrect", new { windowId }),
+            NextSteps.ResultsEnquiry => RedirectToAction("Index", "ResultIssue", new { windowId }),
             _ => RedirectToAction("Index", "CheckYourPupilData", new { windowId })
         };
     }
@@ -177,9 +186,20 @@ public sealed class CheckYourPupilDataController(ICheckYourPupilDataService chec
             // dataset (the other 16-19 import files become sibling tabs later), not inclusion.
             SectionsAsTabs = window.CheckingWindowType != CheckingWindowType.Post16,
             IsWindowOpen = window.StartDate <= now && now <= window.EndDate,
+            ShowResultsEnquiryOption = OffersResultsEnquiry(window.CheckingWindowType),
             OrganisationName = currentUserService.OrganisationName
         };
     }
+
+    /// <summary>
+    /// Whether a window type has a results-enquiry journey. AB#296648: 16-19 only — the other key
+    /// stages have neither results data nor an <c>IncorrectGrade_*</c> flow config.
+    ///
+    /// PARKED: becomes an <c>IWindowActivityService.OpenActivities</c> check when the activity model
+    /// lands (docs/16-19-window-model.md) and results enquiry gets its own dates.
+    /// </summary>
+    private static bool OffersResultsEnquiry(CheckingWindowType windowType) =>
+        windowType == CheckingWindowType.Post16;
 
     private static int TotalPages(int count) => (int)Math.Ceiling(count / (double)PageSize);
 }

--- a/src/DfE.CheckPerformanceData.Web/Controllers/CheckYourPupilData/CheckYourPupilDataViewModel.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/CheckYourPupilData/CheckYourPupilDataViewModel.cs
@@ -20,5 +20,16 @@ public sealed class CheckYourPupilDataViewModel
     public required string WindowTitle { get; init; }
     public NextSteps? SelectedNextStep { get; init; }
     public required bool IsWindowOpen { get; init; }
+
+    /// <summary>
+    /// AB#296648: whether to offer "Report an issue with an exam result" alongside the amend/confirm
+    /// options. 16-19 only for now — no other key stage has results data or a flow config behind it.
+    ///
+    /// PARKED: visibility moves to <c>IWindowActivityService.OpenActivities</c> when the activity model
+    /// lands (docs/16-19-window-model.md), at which point results enquiry gets its own dates and this
+    /// stops being a straight window-type test. Not defaulted from the request — the POST re-derives it
+    /// so a hand-crafted post cannot bypass the rule.
+    /// </summary>
+    public bool ShowResultsEnquiryOption { get; init; }
     public required string OrganisationName { get; init; }
 }

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/EnquiryConfirmationViewModel.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/EnquiryConfirmationViewModel.cs
@@ -1,0 +1,12 @@
+namespace DfE.CheckPerformanceData.Web.Controllers.Journey;
+
+/// <summary>
+/// The "Results enquiry submitted" page (AB#296648). Deliberately minimal: after submission the
+/// journey state is cleared, so the page has only the reference to show — everything the school
+/// entered has gone, which is what makes "Report another issue" start clean.
+/// </summary>
+public sealed class EnquiryConfirmationViewModel
+{
+    public required Guid WindowId { get; init; }
+    public required string ReferenceNumber { get; init; }
+}

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/IJourneyViewModelBuilder.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/IJourneyViewModelBuilder.cs
@@ -23,8 +23,20 @@ public interface IJourneyViewModelBuilder
         ModelStateDictionary modelState,
         QuestionFlowConfig? config = null,
         string? uploadError = null,
-        string? atLeastOneError = null);
+        string? atLeastOneError = null,
+        /// <summary>AB#296648: the selected result's grade scale, for a GradeSelect question. Resolved
+        /// by the caller because the lookup is async. Null when the page has no grade picker, or when
+        /// the QAN is absent from the reference data.</summary>
+        Application.ResultsEnquiry.GradeReference? gradeReference = null);
 
     PupilSearchViewModel BuildPupilSearchVm(
         Guid windowId, string pageId, JourneyPage page, RequestState journey, QuestionFlowConfig config);
+
+    /// <summary>
+    /// AB#296648: the "which of {pupil}'s results is incorrect?" page. The pupil's results are passed
+    /// in rather than fetched here because reading them is async and the builder is not.
+    /// </summary>
+    ResultSearchViewModel BuildResultSearchVm(
+        Guid windowId, string pageId, JourneyPage page, RequestState journey, QuestionFlowConfig config,
+        IReadOnlyList<Application.ResultsEnquiry.StudentResultRecord> availableResults);
 }

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyController.cs
@@ -5,7 +5,9 @@ using DfE.CheckPerformanceData.Web.Analytics;
 using DfE.CheckPerformanceData.Web.Common;
 using DfE.CheckPerformanceData.Application.FileStorage;
 using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.Notify;
 using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
 using DfE.CheckPerformanceData.Domain.Enums;
 using DfE.CheckPerformanceData.Web.FileStorage;
 using DfE.CheckPerformanceData.Web.Session;
@@ -24,9 +26,19 @@ public sealed class JourneyController(
     ICurrentUserService currentUserService,
     IOptionVisibilityService optionVisibilityService,
     IQuestionOptionalityService optionalityService,
-    IOriginCountryLanguageCapture originCountryLanguageCapture) : Controller
+    IOriginCountryLanguageCapture originCountryLanguageCapture,
+    IStudentResultsClient studentResultsClient,
+    IGradeReferenceClient gradeReferenceClient,
+    IRequestNotificationService requestNotificationService,
+    ILogger<JourneyController> logger) : Controller
 {
     internal static string FieldName(string questionId) => $"q_{questionId.Replace("-", "_")}";
+
+    /// <summary>
+    /// AB#296648: the revised-grade question id from <c>IncorrectGrade_Post16.json</c>. Named here
+    /// because changing the selected result has to clear this one answer specifically.
+    /// </summary>
+    internal const string RevisedGradeQuestionId = "q-revised-grade";
 
     private const long MaxUploadBytes = 10 * 1024 * 1024; // 10 MB
 
@@ -47,17 +59,30 @@ public sealed class JourneyController(
         if (page.Type == PageType.PupilSearch)
             return RedirectToAction(nameof(PupilSearchPage), new { windowId, pageId });
 
+        // AB#296648: the result search posts a composite result key rather than answers, so it has
+        // its own action — the same reason PupilSearch does.
+        if (page.Type == PageType.ResultSearch)
+            return RedirectToAction(nameof(ResultSearchPage), new { windowId, pageId });
+
         var nav = flowService.GetNavigationGuard(config, journey, pageId);
         if (nav is RedirectToJourneySummary) return RedirectToAction(nameof(Summary), new { windowId });
         if (nav is RedirectToJourneyPage { PageId: var navPageId })
             return RedirectToAction(nameof(Page), new { windowId, pageId = navPageId });
 
-        var viewName = page.Type == PageType.EvidenceUpload ? "EvidenceUpload" : "Page";
+        var viewName = page.Type switch
+        {
+            PageType.EvidenceUpload => "EvidenceUpload",
+            // A question page that also displays the selected result — served by this action so it
+            // inherits PagePost's answer handling, but rendered by its own view.
+            PageType.ResultDetails => "ResultDetails",
+            _ => "Page"
+        };
         // Surface an upload error stashed by UploadFile before its PRG redirect here — otherwise
         // a rejected upload (e.g. a non-PDF) would silently show no validation message.
         return View(viewName, viewModelBuilder.BuildPageVm(windowId, page, journey.QuestionAnswers,
             journey, fromSummary, ModelState, config,
-            uploadError: TempData["UploadError"] as string));
+            uploadError: TempData["UploadError"] as string,
+            gradeReference: await GetGradeReferenceAsync(page, journey)));
     }
 
     // ── PupilSearchPage (GET) ───────────────────────────────────────────────
@@ -204,15 +229,34 @@ public sealed class JourneyController(
         }
         else
         {
-            var reference = journeyService.GenerateReference(journey.CheckingWindow?.CheckingWindowType);
+            // AB#296648: an enquiry's reference carries an RE segment so support staff can tell it
+            // from an amendment when a school reads it out.
+            var reference = journey.SelectedWhatToChange == Application.CheckYourPupilData.WhatToChange.IncorrectGrade
+                ? journeyService.GenerateEnquiryReference()
+                : journeyService.GenerateReference(journey.CheckingWindow?.CheckingWindowType);
+
+            // Choosing the primary pupil discards everything that was answered ABOUT a pupil — but
+            // only what came after this page. On the amendment journeys the pupil page is first, so
+            // that is every answer, which is what this used to do unconditionally. The enquiry journey
+            // asks about the cohort BEFORE the pupil, and those answers are not about the pupil at
+            // all: wiping them lost the cohort scope and count, and the summary then silently showed
+            // a single-pupil enquiry (AB#296648).
+            var answersToKeep = AnswersAnsweredBefore(journey, config, pageId);
+            var historyBefore = journey.QuestionHistory.TakeWhile(id => id != pageId).ToList();
+
             HttpContext.Session.SaveRequestState(windowId, s =>
             {
                 s.SelectedPupilId = selectedPupilId;
                 s.SelectedPupilLabel = selectedPupilLabel;
                 s.SelectedPupil = pupil;
                 s.ReferenceNumber = reference;
-                s.QuestionAnswers = new Dictionary<string, QuestionAnswer>();
-                s.QuestionHistory = [pageId];
+                s.QuestionAnswers = answersToKeep;
+                // A result belongs to one pupil, so a pupil change invalidates it. Fail-closed
+                // re-resolution on the result page would catch a stale key, but the summary and the
+                // grade page read SelectedResult directly.
+                s.SelectedResult = null;
+                s.SelectedResultLabel = null;
+                s.QuestionHistory = [.. historyBefore, pageId];
                 s.MatchedPupil = null;
                 s.MatchedPupilId = null;
                 s.MatchedPupilLabel = null;
@@ -222,10 +266,177 @@ public sealed class JourneyController(
         if (page.NextPageId is null)
             return RedirectToAction(nameof(Summary), new { windowId });
 
-        var nextPage = flowService.GetPage(config, page.NextPageId);
-        return nextPage?.Type == PageType.PupilSearch
-            ? RedirectToAction(nameof(PupilSearchPage), new { windowId, pageId = page.NextPageId })
-            : RedirectToAction(nameof(Page), new { windowId, pageId = page.NextPageId });
+        // Routed through the shared helper: on the incorrect-grade journey the page after a pupil
+        // search is a ResultSearch, which has its own action too.
+        return RedirectToJourneyAction(config, windowId, page.NextPageId);
+    }
+
+    // ── ResultSearchPage (GET) ──────────────────────────────────────────────
+
+    [Route("/Journey/{windowId}/result-search/{pageId}")]
+    public async Task<IActionResult> ResultSearchPage(Guid windowId, string pageId)
+    {
+        var journey = HttpContext.Session.GetRequestState(windowId);
+        if (!IsSessionReady(journey)) return RedirectToCheckYourData(windowId);
+
+        var config = await GetConfigAsync(journey);
+        if (config is null) return RedirectToCheckYourData(windowId);
+
+        var page = flowService.GetPage(config, pageId);
+        if (page is null || page.Type != PageType.ResultSearch) return NotFound();
+
+        var nav = flowService.GetNavigationGuard(config, journey, pageId);
+        if (nav is RedirectToJourneySummary) return RedirectToAction(nameof(Summary), new { windowId });
+        if (nav is RedirectToJourneyPage { PageId: var navPageId })
+            return RedirectToJourneyAction(config, windowId, navPageId);
+
+        var available = await GetPupilResultsAsync(windowId, journey);
+        return View("ResultSearch",
+            viewModelBuilder.BuildResultSearchVm(windowId, pageId, page, journey, config, available));
+    }
+
+    // ── ResultSearchPage (POST) ─────────────────────────────────────────────
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [Route("/Journey/{windowId}/result-search/{pageId}")]
+    public async Task<IActionResult> ResultSearchPost(
+        Guid windowId, string pageId, string? selectedResultKey, string? selectedResultLabel, CancellationToken ct = default)
+    {
+        var journey = HttpContext.Session.GetRequestState(windowId);
+        if (!IsSessionReady(journey)) return RedirectToCheckYourData(windowId);
+
+        var config = await GetConfigAsync(journey);
+        if (config is null) return RedirectToCheckYourData(windowId);
+
+        var page = flowService.GetPage(config, pageId);
+        if (page is null || page.Type != PageType.ResultSearch) return NotFound();
+
+        // The posted key is a claim, not a fact: re-resolve it against the results this pupil
+        // actually holds. Anything that does not resolve — forged, stale, or belonging to another
+        // pupil — is treated exactly as if nothing was selected (fail closed, per PBI 292525).
+        var available = await GetPupilResultsAsync(windowId, journey, ct);
+        var resolved = string.IsNullOrWhiteSpace(selectedResultKey)
+            ? null
+            : available.FirstOrDefault(r =>
+                string.Equals(r.CompositeKey, selectedResultKey.Trim(), StringComparison.Ordinal));
+
+        if (resolved is null)
+        {
+            var validationMessage = page.ValidationFailure is not null
+                ? JourneyTemplate.Resolve(page.ValidationFailure, JourneyViewModelBuilder.GetPupilName(journey))
+                : "Enter which result is incorrect";
+            ModelState.AddModelError("selectedResultKey", validationMessage);
+            await analytics.TrackSafeAsync(new ValidationErrorEvent
+            {
+                ErrorCount = 1,
+                ErrorCodes = [ValidationErrorCoding.NoSelection],
+                ErrorFields = ["selectedResultKey"],
+                WhatToChange = journey.SelectedWhatToChange?.ToString(),
+            });
+            return View("ResultSearch",
+                viewModelBuilder.BuildResultSearchVm(windowId, pageId, page, journey, config, available));
+        }
+
+        // A revised grade belongs to one result. Changing the result must not carry a grade over to a
+        // qualification the user never chose it for — but re-confirming the same result is not a
+        // change, so the grade survives back-navigation.
+        var resultChanged = journey.SelectedResult?.CompositeKey != resolved.CompositeKey;
+
+        HttpContext.Session.SaveRequestState(windowId, s =>
+        {
+            s.SelectedResult = resolved;
+            s.SelectedResultLabel = selectedResultLabel;
+            if (resultChanged)
+                s.QuestionAnswers.Remove(RevisedGradeQuestionId);
+        });
+
+        journey = HttpContext.Session.GetRequestState(windowId);
+        TrimHistoryTo(journey, windowId, pageId);
+
+        if (page.NextPageId is null)
+            return RedirectToAction(nameof(Summary), new { windowId });
+
+        return RedirectToJourneyAction(config, windowId, page.NextPageId);
+    }
+
+    /// <summary>
+    /// The answers belonging to pages the user visited BEFORE <paramref name="pageId"/>. Used when a
+    /// pupil selection invalidates everything asked about that pupil, without discarding answers that
+    /// were never about them.
+    /// </summary>
+    private Dictionary<string, QuestionAnswer> AnswersAnsweredBefore(
+        RequestState journey, QuestionFlowConfig config, string pageId)
+    {
+        var keep = journey.QuestionHistory
+            .TakeWhile(id => id != pageId)
+            .Select(id => flowService.GetPage(config, id))
+            .Where(p => p is not null)
+            .SelectMany(p => p!.Questions.Select(q => q.Id))
+            .ToHashSet(StringComparer.Ordinal);
+
+        return journey.QuestionAnswers
+            .Where(kv => keep.Contains(kv.Key))
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+    }
+
+    /// <summary>
+    /// The page a results enquiry must go back to before it can be reviewed, or null when it is
+    /// complete. Returns the earliest gap so the user is sent to the first thing they still owe.
+    /// Always null for an amendment journey.
+    /// </summary>
+    private static string? FirstIncompleteEnquiryPage(RequestState journey, QuestionFlowConfig config)
+    {
+        if (journey.SelectedWhatToChange != Application.CheckYourPupilData.WhatToChange.IncorrectGrade)
+            return null;
+
+        var resultPage = config.Pages.FirstOrDefault(p => p.Type == PageType.ResultSearch);
+        if (journey.SelectedResult is null)
+            return resultPage?.Id;
+
+        var gradePage = config.Pages.FirstOrDefault(
+            p => p.Questions.Any(q => q.Id == RevisedGradeQuestionId));
+        var hasGrade = journey.QuestionAnswers.TryGetValue(RevisedGradeQuestionId, out var grade)
+                       && !string.IsNullOrWhiteSpace(grade.TextValue);
+
+        return hasGrade ? null : gradePage?.Id;
+    }
+
+    /// <summary>
+    /// The grade scale for the selected result's qualification, or null when the page has no grade
+    /// picker or the QAN is absent from the AODC reference data. A gap is logged rather than thrown:
+    /// the page tells the user grades cannot be listed yet, and validation holds the enquiry back.
+    /// </summary>
+    private async Task<GradeReference?> GetGradeReferenceAsync(
+        JourneyPage page, RequestState journey, CancellationToken ct = default)
+    {
+        if (page.Questions.All(q => q.Type != QuestionType.GradeSelect)) return null;
+
+        var qan = journey.SelectedResult?.Qan;
+        if (string.IsNullOrWhiteSpace(qan)) return null;
+
+        var reference = await gradeReferenceClient.GetByQanAsync(qan, ct);
+        if (reference is null)
+            logger.LogWarning(
+                "No AODC grade reference for QAN {Qan}; the revised-grade picker on page {PageId} will " +
+                "be empty and the enquiry cannot be submitted until the reference data covers it.",
+                qan, page.Id);
+
+        return reference;
+    }
+
+    /// <summary>
+    /// Every result the journey's selected pupil holds at the signed-in school. Empty when no pupil
+    /// has been chosen yet — which both renders an empty picker and makes any posted key unresolvable.
+    /// </summary>
+    private async Task<IReadOnlyList<StudentResultRecord>> GetPupilResultsAsync(
+        Guid windowId, RequestState journey, CancellationToken ct = default)
+    {
+        var cypmdId = journey.SelectedPupil?.Cypmd_Id;
+        if (string.IsNullOrWhiteSpace(cypmdId)) return [];
+
+        return await studentResultsClient.GetResultsAsync(
+            windowId, currentUserService.OrganisationLaestab, cypmdId, ct);
     }
 
     // ── Page (POST — Continue) ──────────────────────────────────────────────
@@ -247,6 +458,9 @@ public sealed class JourneyController(
 
         var newAnswers = new Dictionary<string, QuestionAnswer>();
         var pupilName = JourneyViewModelBuilder.GetPupilName(journey);
+        // Resolved once for the page rather than per question: the lookup is async and cached, and a
+        // page has at most one grade picker.
+        var gradeReference = await GetGradeReferenceAsync(page, journey);
         var isValid = true;
         var conditionContext = JourneyConditionContextFactory.Create(journey, currentUserService);
         var conditionallyOptional = optionalityService.GetConditionallyOptionalQuestionIds(page, conditionContext);
@@ -310,7 +524,16 @@ public sealed class JourneyController(
                 {
                     var resolvedValidationFailure = question.ValidationFailure is not null
                         ? JourneyTemplate.Resolve(question.ValidationFailure, pupilName) : null;
-                    var error = journeyService.ValidateAnswer(question, answer, JourneyTemplate.Resolve(question.Title, pupilName), resolvedValidationFailure);
+
+                    // A grade picker has its own rules and its own inputs (the qualification's scale
+                    // and the grade the result already holds), so it does not go through the generic
+                    // answer validator. AB#296648.
+                    var error = question.Type == QuestionType.GradeSelect
+                        ? journeyService.ValidateGradeSelect(
+                            question, answer, gradeReference, journey.SelectedResult?.Grade, resolvedValidationFailure)
+                        : journeyService.ValidateAnswer(
+                            question, answer, JourneyTemplate.Resolve(question.Title, pupilName), resolvedValidationFailure);
+
                     if (error is not null)
                     {
                         ModelState.AddModelError(question.Id, error);
@@ -374,11 +597,17 @@ public sealed class JourneyController(
                 .Concat(newAnswers)
                 .GroupBy(kv => kv.Key)
                 .ToDictionary(g => g.Key, g => g.Last().Value);
-            var invalidViewName = page.Type == PageType.EvidenceUpload ? "EvidenceUpload" : "Page";
+            var invalidViewName = page.Type switch
+            {
+                PageType.EvidenceUpload => "EvidenceUpload",
+                PageType.ResultDetails => "ResultDetails",
+                _ => "Page"
+            };
             return View(invalidViewName, viewModelBuilder.BuildPageVm(windowId, page, displayAnswers,
                 journey, fromSummary, ModelState, config,
                 uploadError: pendingUploadError ?? TempData["UploadError"] as string,
-                atLeastOneError: atLeastOne?.SummaryMessage));
+                atLeastOneError: atLeastOne?.SummaryMessage,
+                gradeReference: gradeReference));
         }
 
         if (page.Type == PageType.EvidenceUpload)
@@ -632,6 +861,14 @@ public sealed class JourneyController(
             && !IsEvidencePageValid(evidencePage, journey, JourneyViewModelBuilder.GetPupilName(journey)))
             return RedirectToAction(nameof(Page), new { windowId, pageId = evidencePage.Id });
 
+        // AB#296648: a results enquiry needs a chosen result and a revised grade, neither of which
+        // the flow engine's question-answer walk can see — the result lives outside QuestionAnswers,
+        // and its grade is cleared when the result changes. Without this, an enquiry with no result
+        // would reach the summary showing blank rows and could be submitted.
+        var incompleteEnquiryPage = FirstIncompleteEnquiryPage(journey, config);
+        if (incompleteEnquiryPage is not null)
+            return RedirectToJourneyAction(config, windowId, incompleteEnquiryPage);
+
         var fromBulk = HttpContext.Session.IsBulkEditMode(windowId);
         var fromEdit = HttpContext.Session.IsSingleEditMode(windowId);
         return View(viewModelBuilder.BuildSummaryVm(windowId, journey, config, fromBulk: fromBulk, fromEdit: fromEdit));
@@ -664,6 +901,11 @@ public sealed class JourneyController(
     {
         var journey = HttpContext.Session.GetRequestState(windowId);
         if (!IsSessionReady(journey)) return RedirectToCheckYourData(windowId);
+
+        // AB#296648: a results enquiry submits by a different route — no duplicate check (several
+        // enquiries about the same result are allowed) and no rules-engine enqueue.
+        if (journey.SelectedWhatToChange == Application.CheckYourPupilData.WhatToChange.IncorrectGrade)
+            return await ConfirmResultsEnquiryAsync(windowId, journey);
 
         try
         {
@@ -717,6 +959,59 @@ public sealed class JourneyController(
 
         return RedirectToAction(nameof(Confirmation), new { windowId });
     }
+
+    // ── Results enquiry submission ─────────────────────────────────────────
+
+    /// <summary>
+    /// Submits a results enquiry, then clears the journey while keeping what the confirmation page
+    /// needs. AB#296648.
+    /// </summary>
+    private async Task<IActionResult> ConfirmResultsEnquiryAsync(Guid windowId, RequestState journey)
+    {
+        var reference = await requestService.SubmitResultsEnquiryAsync(windowId, journey);
+
+        // Everything after this point is best-effort: the enquiry is already persisted, so a failure
+        // to email or to record analytics must not tell the school their submission failed.
+        await requestNotificationService.NotifyResultsEnquirySubmittedAsync(reference);
+
+        await analytics.TrackSafeAsync(new ResultsEnquirySubmittedEvent
+        {
+            EnquiryType = ResultIssueViewModel.IncorrectGrade,
+            CohortWide = IsCohortWide(journey),
+            CheckingWindowType = journey.CheckingWindow?.CheckingWindowType.ToString() ?? "",
+            ReferenceNumber = reference,
+        });
+
+        // The reference and the window survive so the confirmation page can render; everything the
+        // user entered goes, so "Report another issue" genuinely starts clean.
+        HttpContext.Session.SetRequestState(windowId, new RequestState
+        {
+            CheckingWindow = journey.CheckingWindow,
+            ReferenceNumber = reference
+        });
+        HttpContext.Session.ClearBulkEditMode(windowId);
+        HttpContext.Session.ClearSingleEditMode(windowId);
+
+        return RedirectToAction(nameof(EnquiryConfirmation), new { windowId });
+    }
+
+    [Route("/Journey/{windowId}/enquiry-confirmation")]
+    public IActionResult EnquiryConfirmation(Guid windowId)
+    {
+        var journey = HttpContext.Session.GetRequestState(windowId);
+        if (string.IsNullOrWhiteSpace(journey.ReferenceNumber) || journey.CheckingWindow is null)
+            return RedirectToCheckYourData(windowId);
+
+        return View("EnquiryConfirmation", new EnquiryConfirmationViewModel
+        {
+            WindowId = windowId,
+            ReferenceNumber = journey.ReferenceNumber
+        });
+    }
+
+    private static bool IsCohortWide(RequestState journey) =>
+        journey.QuestionAnswers.TryGetValue("q-cohort-scope", out var scope)
+        && string.Equals(scope.TextValue, "yes", StringComparison.OrdinalIgnoreCase);
 
     // ── Save draft ─────────────────────────────────────────────────────────
 
@@ -842,9 +1137,7 @@ public sealed class JourneyController(
     private RedirectToActionResult RedirectToJourneyAction(QuestionFlowConfig config, Guid windowId, string pageId)
     {
         var target = flowService.GetPage(config, pageId);
-        return target?.Type == PageType.PupilSearch
-            ? RedirectToAction(nameof(PupilSearchPage), new { windowId, pageId })
-            : RedirectToAction(nameof(Page), new { windowId, pageId });
+        return RedirectToAction(JourneyRouting.ActionFor(target?.Type), new { windowId, pageId });
     }
 
     private Task<QuestionFlowConfig?> GetConfigAsync(RequestState journey) =>

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyRouting.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyRouting.cs
@@ -1,0 +1,23 @@
+using DfE.CheckPerformanceData.Application.Journey;
+
+namespace DfE.CheckPerformanceData.Web.Controllers.Journey;
+
+/// <summary>
+/// Which <see cref="JourneyController"/> action serves a page type.
+///
+/// Most page types share the generic <c>Page</c> action. The two search pages have their own routes
+/// because their POST payloads differ from a question page's. Centralised because a back link that
+/// guesses the wrong action 404s, and there are now three call sites (the page, pupil-search and
+/// result-search back links) that all need the same answer.
+/// </summary>
+public static class JourneyRouting
+{
+    public static string ActionFor(PageType? pageType) => pageType switch
+    {
+        PageType.PupilSearch => nameof(JourneyController.PupilSearchPage),
+        PageType.ResultSearch => nameof(JourneyController.ResultSearchPage),
+        // ResultDetails renders its own view but is otherwise a question page, so it is served by
+        // the generic Page action — the same arrangement EvidenceUpload uses.
+        _ => nameof(JourneyController.Page)
+    };
+}

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyViewModelBuilder.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/JourneyViewModelBuilder.cs
@@ -1,5 +1,6 @@
 using DfE.CheckPerformanceData.Application.CurrentUser;
 using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace DfE.CheckPerformanceData.Web.Controllers.Journey;
@@ -75,9 +76,58 @@ public sealed class JourneyViewModelBuilder(
             FirstRecordDisplay = firstRecordDisplay,
             SecondRecordDisplay = secondRecordDisplay,
             MatchedPupilPageId = matchPupilPage?.Id,
-            BackPageIsPupilSearch = backPage?.Type == PageType.PupilSearch
+            BackPageIsPupilSearch = backPage?.Type == PageType.PupilSearch,
+            BackPageAction = JourneyRouting.ActionFor(backPage?.Type),
+            Enquiry = BuildEnquirySummary(journey, config, pupilName)
         };
     }
+
+    /// <summary>
+    /// The enquiry-shaped summary, or null for an amendment journey. AB#296648.
+    /// </summary>
+    private ResultsEnquirySummary? BuildEnquirySummary(
+        RequestState journey, QuestionFlowConfig config, string pupilName)
+    {
+        if (journey.SelectedWhatToChange != Application.CheckYourPupilData.WhatToChange.IncorrectGrade)
+            return null;
+
+        string? Answer(string questionId) =>
+            journey.QuestionAnswers.TryGetValue(questionId, out var a) ? a.TextValue : null;
+
+        // The page each answer lives on, so a Change link follows a flow-config page rename rather
+        // than pointing at a hardcoded id that no longer exists.
+        string? PageAsking(string questionId) => config.Pages
+            .FirstOrDefault(p => p.Questions.Any(q => q.Id == questionId))?.Id;
+
+        return new ResultsEnquirySummary
+        {
+            DfeNumber = currentUserService.OrganisationLaestab,
+            KeyStageLabel = KeyStageLabelFor(journey.CheckingWindow?.CheckingWindowType),
+            EnquiryTypeLabel = "Incorrect grade",
+            StudentName = pupilName,
+            IsCohortWide = string.Equals(Answer(CohortScopeQuestionId), "yes", StringComparison.OrdinalIgnoreCase),
+            CohortCount = Answer(CohortCountQuestionId),
+            Result = journey.SelectedResult,
+            RevisedGrade = Answer(JourneyController.RevisedGradeQuestionId),
+            RevisedGradePageId = PageAsking(JourneyController.RevisedGradeQuestionId),
+            AdditionalInformation = Answer(AdditionalInfoQuestionId),
+            AdditionalInformationPageId = PageAsking(AdditionalInfoQuestionId)
+        };
+    }
+
+    // Question ids from IncorrectGrade_Post16.json. A serialization contract — see the flow tests.
+    private const string CohortScopeQuestionId = "q-cohort-scope";
+    private const string CohortCountQuestionId = "q-cohort-count";
+    private const string AdditionalInfoQuestionId = "q-additional-info";
+
+    /// <summary>How a window type is named to a school on the summary.</summary>
+    private static string KeyStageLabelFor(Domain.Enums.CheckingWindowType? windowType) => windowType switch
+    {
+        Domain.Enums.CheckingWindowType.Post16 => "16 to 19",
+        Domain.Enums.CheckingWindowType.KS4June or Domain.Enums.CheckingWindowType.KS4Autumn => "Key stage 4",
+        Domain.Enums.CheckingWindowType.KS2 => "Key stage 2",
+        _ => string.Empty
+    };
 
     public PageViewModel BuildPageVm(
         Guid windowId,
@@ -88,7 +138,8 @@ public sealed class JourneyViewModelBuilder(
         ModelStateDictionary modelState,
         QuestionFlowConfig? config = null,
         string? uploadError = null,
-        string? atLeastOneError = null)
+        string? atLeastOneError = null,
+        GradeReference? gradeReference = null)
     {
         var historyIndex = journey.QuestionHistory.IndexOf(page.Id);
         var backPageId = historyIndex switch
@@ -97,8 +148,10 @@ public sealed class JourneyViewModelBuilder(
             0  => null,
             _  => journey.QuestionHistory[historyIndex - 1]
         };
-        var backPageIsPupilSearch = backPageId is not null && config is not null
-            && flowService.GetPage(config, backPageId)?.Type == PageType.PupilSearch;
+        var backPage = backPageId is not null && config is not null
+            ? flowService.GetPage(config, backPageId)
+            : null;
+        var backPageIsPupilSearch = backPage?.Type == PageType.PupilSearch;
 
         var pupilName = GetPupilName(journey);
         var isSingleQuestion = page.Questions.Count == 1;
@@ -126,9 +179,15 @@ public sealed class JourneyViewModelBuilder(
                 Error = error,
                 UploadError = uploadError,
                 ResolvedTitle = JourneyTemplate.Resolve(q.Title, pupilName) + (q.Optional ? " (Optional)" : ""),
-                VisibleOptions = q.Type == QuestionType.Radio
-                    ? optionVisibilityService.GetVisibleOptions(q, conditionContext)
-                    : q.Options ?? [],
+                VisibleOptions = q.Type switch
+                {
+                    QuestionType.Radio => optionVisibilityService.GetVisibleOptions(q, conditionContext),
+                    // AB#297130: grades come from the AODC reference data for the selected result's
+                    // QAN, not from the flow config — the config cannot know which qualification the
+                    // user picked. Pass grades before fail grades, source order preserved within each.
+                    QuestionType.GradeSelect => GradeOptions(gradeReference),
+                    _ => q.Options ?? []
+                },
                 // AB#296081: request-wide file names for the selection-time duplicate warning.
                 ExistingFileNames = q.Type == QuestionType.FileUpload
                     ? answers.Values.SelectMany(qa => qa.FileValues ?? []).Select(f => f.OriginalFileName).ToList()
@@ -143,6 +202,9 @@ public sealed class JourneyViewModelBuilder(
             Answers = answers,
             BackPageId = backPageId,
             BackPageIsPupilSearch = backPageIsPupilSearch,
+            BackPageAction = JourneyRouting.ActionFor(backPage?.Type),
+            WhatToChange = journey.SelectedWhatToChange,
+            SelectedResult = journey.SelectedResult,
             FromSummary = fromSummary,
             PupilName = pupilName,
             ContentKey = contentKey,
@@ -165,19 +227,7 @@ public sealed class JourneyViewModelBuilder(
             ? (journey.MatchedPupilId, journey.MatchedPupilLabel)
             : (journey.SelectedPupilId, journey.SelectedPupilLabel);
 
-        string? backPageId = null;
-        bool backPageIsPupilSearch = false;
-        var historyIndex = journey.QuestionHistory.IndexOf(pageId);
-        var backEntry = historyIndex > 0
-            ? journey.QuestionHistory[historyIndex - 1]
-            : historyIndex < 0 && journey.QuestionHistory.Count > 0
-                ? journey.QuestionHistory[^1]
-                : null;
-        if (backEntry is not null)
-        {
-            backPageId = backEntry;
-            backPageIsPupilSearch = flowService.GetPage(config, backEntry)?.Type == PageType.PupilSearch;
-        }
+        var (backPageId, backPage) = ResolveBackPage(pageId, journey, config);
 
         return new PupilSearchViewModel
         {
@@ -190,9 +240,59 @@ public sealed class JourneyViewModelBuilder(
             SelectedPupilLabel = existingLabel,
             Hint = page.Subheading,
             BackPageId = backPageId,
-            BackPageIsPupilSearch = backPageIsPupilSearch
+            BackPageIsPupilSearch = backPage?.Type == PageType.PupilSearch,
+            BackPageAction = JourneyRouting.ActionFor(backPage?.Type)
         };
     }
+
+    public ResultSearchViewModel BuildResultSearchVm(
+        Guid windowId, string pageId, JourneyPage page, RequestState journey, QuestionFlowConfig config,
+        IReadOnlyList<StudentResultRecord> availableResults)
+    {
+        var pupilName = GetPupilName(journey);
+        var (backPageId, backPage) = ResolveBackPage(pageId, journey, config);
+
+        return new ResultSearchViewModel
+        {
+            WindowId = windowId,
+            PageId = pageId,
+            Title = page.Title is not null ? JourneyTemplate.Resolve(page.Title, pupilName) : string.Empty,
+            Hint = page.Subheading,
+            SelectedResultKey = journey.SelectedResult?.CompositeKey,
+            SelectedResultLabel = journey.SelectedResultLabel,
+            SelectedResult = journey.SelectedResult,
+            AvailableResults = availableResults,
+            BackPageId = backPageId,
+            BackPageAction = JourneyRouting.ActionFor(backPage?.Type)
+        };
+    }
+
+    /// <summary>
+    /// The page the Back link returns to: the entry before this one in the answered history, or the
+    /// last entry when this page is not in the history yet (a forward navigation).
+    /// </summary>
+    private (string? PageId, JourneyPage? Page) ResolveBackPage(
+        string pageId, RequestState journey, QuestionFlowConfig config)
+    {
+        var historyIndex = journey.QuestionHistory.IndexOf(pageId);
+        var backEntry = historyIndex > 0
+            ? journey.QuestionHistory[historyIndex - 1]
+            : historyIndex < 0 && journey.QuestionHistory.Count > 0
+                ? journey.QuestionHistory[^1]
+                : null;
+
+        return backEntry is null ? (null, null) : (backEntry, flowService.GetPage(config, backEntry));
+    }
+
+    /// <summary>
+    /// The qualification's grades as picker options, pass grades before fail grades. Empty when the
+    /// QAN is missing from the reference data, which the view reports rather than rendering an empty
+    /// control with no explanation.
+    /// </summary>
+    private static IReadOnlyList<QuestionOption> GradeOptions(GradeReference? reference) =>
+        reference is null
+            ? []
+            : [.. reference.AllGrades.Select(g => new QuestionOption { Value = g, Label = g })];
 
     private JourneyConditionContext BuildConditionContext(RequestState journey) =>
         JourneyConditionContextFactory.Create(journey, currentUserService);

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/PageViewModel.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/PageViewModel.cs
@@ -9,8 +9,29 @@ public sealed class PageViewModel
     public required Dictionary<string, QuestionAnswer> Answers { get; init; }
     public required IReadOnlyList<QuestionPartialModel> QuestionModels { get; init; }
     public string? BackPageId { get; init; }
+
+    /// <summary>Superseded by <see cref="BackPageAction"/> for building the link; kept because it
+    /// states a distinct fact (the previous page was a pupil search) that callers still assert.</summary>
     public bool BackPageIsPupilSearch { get; init; }
+
+    /// <summary>The JourneyController action that serves <see cref="BackPageId"/>. A bool cannot
+    /// express this now there are three page routes.</summary>
+    public string BackPageAction { get; init; } = nameof(JourneyController.Page);
     public bool FromSummary { get; init; }
+
+    /// <summary>
+    /// Which journey this page belongs to. Used by the Back link on a first page, where there is no
+    /// history to go back through: an amendment journey started at WhatToChange, a results enquiry at
+    /// ResultIssue, and sending the user to the wrong one drops them into a different task.
+    /// </summary>
+    public Application.CheckYourPupilData.WhatToChange? WhatToChange { get; init; }
+
+    /// <summary>
+    /// AB#296648: the exam result a ResultDetails page is about, shown as a summary above the
+    /// revised-grade picker so the user can see they are correcting the right one. Null on every
+    /// other page type.
+    /// </summary>
+    public Application.ResultsEnquiry.StudentResultRecord? SelectedResult { get; init; }
     public string PupilName { get; init; } = string.Empty;
     public string? ContentKey { get; init; }
     public string? UploadError { get; init; }

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/PupilSearchViewModel.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/PupilSearchViewModel.cs
@@ -14,6 +14,9 @@ public sealed class PupilSearchViewModel
     public string? Hint { get; set; }
     public string? BackPageId { get; set; }
     public bool BackPageIsPupilSearch { get; set; }
+
+    /// <summary>The JourneyController action that serves <see cref="BackPageId"/>.</summary>
+    public string BackPageAction { get; set; } = nameof(JourneyController.Page);
     public string? ConflictErrorReference { get; set; }
     public string? ConflictErrorLink { get; set; }
     public string? ConflictPupilName { get; set; }

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/QuestionPartialModel.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/QuestionPartialModel.cs
@@ -22,7 +22,20 @@ public sealed class QuestionPartialModel
     };
     public bool HasError => Error is not null;
     public string ResolvedTitle { get; init; } = string.Empty;
+    /// <summary>
+    /// The options to render. For a Radio these are the config's options after visibility filtering;
+    /// for a <see cref="QuestionType.GradeSelect"/> they are the qualification's grades, pass before
+    /// fail, built from the AODC reference data.
+    /// </summary>
     public IReadOnlyList<QuestionOption> VisibleOptions { get; init; } = [];
+
+    /// <summary>
+    /// True when this is a grade picker with nothing to pick — which can only mean the result's QAN
+    /// is absent from the AODC reference data, since every qualification in that data has at least one
+    /// grade. Drives the "we cannot list grades for this qualification yet" message. AB#297130.
+    /// </summary>
+    public bool GradeOptionsUnavailable =>
+        Question.Type == QuestionType.GradeSelect && VisibleOptions.Count == 0;
 
     public int MaxEvidencePages { get; init; }
 

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/ResultSearchViewModel.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/ResultSearchViewModel.cs
@@ -1,0 +1,43 @@
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+namespace DfE.CheckPerformanceData.Web.Controllers.Journey;
+
+/// <summary>
+/// The "Which of {pupil}'s results is incorrect?" page (AB#296648). Mirrors
+/// <see cref="PupilSearchViewModel"/>: an accessible-autocomplete over a JSON suggestions endpoint,
+/// with a hidden field carrying the machine-readable selection alongside the human-readable label.
+/// </summary>
+public sealed class ResultSearchViewModel
+{
+    public Guid WindowId { get; set; }
+    public string PageId { get; set; } = string.Empty;
+
+    /// <summary>Title with <c>{pupilName}</c> resolved — safe to render, but not into the page title.</summary>
+    public string Title { get; set; } = string.Empty;
+
+    public string? Hint { get; set; }
+
+    /// <summary>
+    /// The composite key (<c>QAN|SESSION|SOURCE</c>) of the current selection, re-rendered on a
+    /// validation redisplay so a valid choice is not silently lost. AB#295434's lesson.
+    /// </summary>
+    public string? SelectedResultKey { get; set; }
+
+    public string? SelectedResultLabel { get; set; }
+
+    /// <summary>The resolved result, shown as a confirmation summary once one is chosen.</summary>
+    public StudentResultRecord? SelectedResult { get; set; }
+
+    /// <summary>
+    /// Every result the selected pupil holds, rendered as real <c>&lt;option&gt;</c> elements so the
+    /// page works with JavaScript off. accessible-autocomplete then enhances the select in place. A
+    /// pupil holds a handful of results, so there is nothing to gain from fetching them as the user
+    /// types — and a server-rendered list is the only version that is accessible without script.
+    /// </summary>
+    public IReadOnlyList<StudentResultRecord> AvailableResults { get; set; } = [];
+
+    public string? BackPageId { get; set; }
+
+    /// <summary>The JourneyController action that serves <see cref="BackPageId"/>.</summary>
+    public string BackPageAction { get; set; } = nameof(JourneyController.Page);
+}

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/ResultsEnquirySummary.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/ResultsEnquirySummary.cs
@@ -1,0 +1,74 @@
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+namespace DfE.CheckPerformanceData.Web.Controllers.Journey;
+
+/// <summary>
+/// The check-answers rows for a results enquiry (AB#296648).
+///
+/// An enquiry's summary is not an amendment's with a few substitutions — it leads with the
+/// establishment, key stage and enquiry type, then identifies the student and the exam result, and
+/// finishes with what the school says the grade should be. So it owns its own row set rather than
+/// bending the amendment one, and <see cref="SummaryViewModel.Lines"/> picks between them.
+///
+/// Only the revised grade and the comments carry a Change link, per the Figma screens. Changing the
+/// student or the result is deliberately not a summary action: a different result invalidates the
+/// grade chosen for it, so that route goes back through the journey where the engine clears the
+/// dependent answer.
+/// </summary>
+public sealed class ResultsEnquirySummary
+{
+    public required string DfeNumber { get; init; }
+    public required string KeyStageLabel { get; init; }
+    public required string EnquiryTypeLabel { get; init; }
+    public required string StudentName { get; init; }
+
+    /// <summary>True when the enquiry covers a whole cohort, which adds the count row and changes
+    /// how the student row is labelled — the student is then an example, not the subject.</summary>
+    public required bool IsCohortWide { get; init; }
+
+    /// <summary>The answer to "how many students", shown only on the cohort branch.</summary>
+    public string? CohortCount { get; init; }
+
+    public StudentResultRecord? Result { get; init; }
+
+    public string? RevisedGrade { get; init; }
+    public string? RevisedGradePageId { get; init; }
+    public string? AdditionalInformation { get; init; }
+    public string? AdditionalInformationPageId { get; init; }
+
+    public IReadOnlyList<SummaryLine> Lines
+    {
+        get
+        {
+            var lines = new List<SummaryLine>
+            {
+                Fixed("DfE number", DfeNumber),
+                Fixed("Key stage", KeyStageLabel),
+                Fixed("Enquiry type", EnquiryTypeLabel)
+            };
+
+            if (IsCohortWide)
+                lines.Add(Fixed("Number of students in affected cohort", CohortCount ?? string.Empty));
+
+            // The label is how the summary conveys the cohort answer — there is no separate yes/no
+            // row on the Figma screens.
+            lines.Add(Fixed(IsCohortWide ? "Name of a student in cohort" : "Name of student", StudentName));
+
+            lines.Add(Fixed("CYPMD ID", Result?.CypmdId ?? string.Empty));
+            lines.Add(Fixed("Qualification number (QAN)", Result?.Qan ?? string.Empty));
+            lines.Add(Fixed("Qualification name and subject", Result?.QualificationName ?? string.Empty));
+            lines.Add(Fixed("Session", Result?.Session ?? string.Empty));
+            lines.Add(Fixed("Current grade", Result?.Grade ?? string.Empty));
+
+            lines.Add(new SummaryLine(
+                "Revised grade", RevisedGrade ?? string.Empty, RevisedGradePageId, true, "revised grade"));
+            lines.Add(new SummaryLine(
+                "Additional information", AdditionalInformation ?? string.Empty,
+                AdditionalInformationPageId, true, "additional information"));
+
+            return lines;
+        }
+    }
+
+    private static SummaryLine Fixed(string key, string value) => new(key, value, null, false, null);
+}

--- a/src/DfE.CheckPerformanceData.Web/Controllers/Journey/SummaryViewModel.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/Journey/SummaryViewModel.cs
@@ -24,6 +24,17 @@ public sealed class SummaryViewModel
     public string? MatchedPupilPageId { get; init; }
     public bool BackPageIsPupilSearch { get; init; }
 
+    /// <summary>The JourneyController action that serves <see cref="BackPageId"/>.</summary>
+    public string BackPageAction { get; init; } = nameof(JourneyController.Page);
+
+    /// <summary>
+    /// AB#296648: the enquiry-shaped summary data, set only for a results enquiry. Its presence is
+    /// what switches <see cref="Lines"/> onto the enquiry row set.
+    /// </summary>
+    public ResultsEnquirySummary? Enquiry { get; init; }
+
+    public bool IsResultsEnquiry => Enquiry is not null;
+
     public int TotalPagesUsed => FileRows.Sum(r => r.PageCount);
 
     public string WhatToChangeLabel => WhatToChange switch
@@ -54,6 +65,8 @@ public sealed class SummaryViewModel
     {
         get
         {
+            if (Enquiry is { } enquiry) return enquiry.Lines;
+
             var lines = new List<SummaryLine>
             {
                 new("What pupil data would you like to change?", WhatToChangeLabel, null, false, null)

--- a/src/DfE.CheckPerformanceData.Web/Controllers/ResultIssue/ResultIssueController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/ResultIssue/ResultIssueController.cs
@@ -1,0 +1,103 @@
+using DfE.CheckPerformanceData.Application.Analytics;
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Web.Analytics;
+using DfE.CheckPerformanceData.Web.Session;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.CheckPerformanceData.Web.Controllers;
+
+/// <summary>
+/// The way in to a 16-19 results enquiry (AB#296648). Mirrors <see cref="WhatToChangeController"/>:
+/// pick what you are reporting, and the journey engine takes it from there.
+/// </summary>
+public sealed class ResultIssueController(
+    ICheckYourPupilDataService service,
+    IQuestionFlowService flowService,
+    ILateResultsAvailability lateResults,
+    ICurrentUserService currentUser,
+    IAnalyticsService analytics) : Controller
+{
+    /// <summary>
+    /// Entered when the school does not yet hold a second-late-results row. Deliberately NOT the
+    /// flow's <c>firstPageId</c> — whether the guidance is shown depends on the school's data at this
+    /// moment, which the static config cannot express.
+    /// </summary>
+    private const string LateResultsGuidancePageId = "check-late-results";
+
+    private const string SelectionRequired = "Select what issue with the results you need to report";
+
+    [Route("/{windowId:guid}/ResultIssue")]
+    public IActionResult Index(Guid windowId)
+        // Never pre-selects: the confirmation page's "Report another issue" link lands here, and the
+        // AC is that nothing carries over from the previous enquiry.
+        => View(new ResultIssueViewModel { WindowId = windowId });
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    [Route("/{windowId:guid}/ResultIssue")]
+    public async Task<IActionResult> Confirm(Guid windowId, ResultIssueViewModel vm, CancellationToken ct = default)
+    {
+        // Fail closed on anything that is not the one option this ticket renders, so a forged or
+        // sibling-ticket value cannot start a journey with no flow behind it.
+        if (vm.IssueType != ResultIssueViewModel.IncorrectGrade)
+        {
+            ModelState.AddModelError(nameof(ResultIssueViewModel.IssueType), SelectionRequired);
+            await analytics.TrackSafeAsync(new ValidationErrorEvent
+            {
+                ErrorCount = 1,
+                ErrorCodes = [ValidationErrorCoding.NoSelection],
+                ErrorFields = [nameof(ResultIssueViewModel.IssueType)]
+            });
+            return View("Index", new ResultIssueViewModel { WindowId = windowId });
+        }
+
+        var window = await service.GetCheckingWindowAsync(windowId);
+
+        var config = await flowService.GetConfigAsync(
+            Application.CheckYourPupilData.WhatToChange.IncorrectGrade, window.CheckingWindowType);
+        if (config is null)
+            return RedirectToAction("Index", "CheckYourPupilData", new { windowId });
+
+        // The one gating branch. BA decision 2026-08-17: the guidance INFORMS, it never blocks — the
+        // option above is always selectable, and both paths continue into the same journey. The Figma
+        // frame that greys the option out ("Incorrect grade option will be available after releasing
+        // second late results") was considered and not chosen.
+        var available = await lateResults.IsSecondLateResultsAvailableAsync(
+            windowId, currentUser.OrganisationLaestab, ct);
+
+        var pageId = available ? config.FirstPageId : LateResultsGuidancePageId;
+
+        // Paired with results_enquiry_submitted to give the start-to-submit funnel. The guidance flag
+        // is the measure that answers the question behind the whole interstitial: are we stopping
+        // enquiries that did not need raising?
+        await analytics.TrackSafeAsync(new ResultsEnquiryStartedEvent
+        {
+            EnquiryType = ResultIssueViewModel.IncorrectGrade,
+            CheckingWindowType = window.CheckingWindowType.ToString(),
+            LateResultsGuidanceShown = !available
+        });
+
+        // A brand-new RequestState rather than an edit of the old one: the AC requires that starting
+        // an enquiry carries nothing over, and listing the fields to clear would silently miss any
+        // field added later.
+        //
+        // When the guidance page is the entry point it is seeded into the history. The flow config's
+        // firstPageId is cohort-scope, so without this the journey engine's out-of-sequence guard
+        // would bounce the user straight past the guidance to cohort-scope and the "tell me to check
+        // that file first" acceptance criterion would never be met. Seeding is also the truthful
+        // record: this controller has decided the journey starts there.
+        HttpContext.Session.SetRequestState(windowId, new RequestState
+        {
+            SelectedWhatToChange = Application.CheckYourPupilData.WhatToChange.IncorrectGrade,
+            CheckingWindow = window,
+            QuestionHistory = available ? [] : [LateResultsGuidancePageId]
+        });
+        HttpContext.Session.ClearBulkEditMode(windowId);
+        HttpContext.Session.ClearSingleEditMode(windowId);
+
+        return RedirectToAction("Page", "Journey", new { windowId, pageId });
+    }
+}

--- a/src/DfE.CheckPerformanceData.Web/Controllers/ResultIssue/ResultIssueViewModel.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/ResultIssue/ResultIssueViewModel.cs
@@ -1,0 +1,16 @@
+namespace DfE.CheckPerformanceData.Web.Controllers;
+
+public sealed class ResultIssueViewModel
+{
+    /// <summary>
+    /// The only issue type this ticket implements. Sibling tickets add "Missing qualification" and
+    /// "Result does not belong to pupil" — both appear on the Figma screen but neither has a journey
+    /// yet, so posting them is rejected as unanswered rather than starting a flow that does not exist.
+    /// </summary>
+    public const string IncorrectGrade = "incorrect-grade";
+
+    public Guid WindowId { get; set; }
+
+    /// <summary>The posted radio value. Null on first render and on a validation redisplay.</summary>
+    public string? IssueType { get; set; }
+}

--- a/src/DfE.CheckPerformanceData.Web/Controllers/ResultSuggestionsController.cs
+++ b/src/DfE.CheckPerformanceData.Web/Controllers/ResultSuggestionsController.cs
@@ -1,0 +1,54 @@
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Web.Session;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DfE.CheckPerformanceData.Web.Controllers;
+
+/// <summary>
+/// The autocomplete source for the "which of {pupil}'s results is incorrect?" page (AB#296648).
+///
+/// The pupil is read from the session, never from the query string. Taking a pupil id from the
+/// request would let a signed-in user at one school enumerate results for any pupil id they could
+/// guess; the session already holds the pupil the journey selected, and that is the only scope this
+/// endpoint will search.
+/// </summary>
+public sealed class ResultSuggestionsController(
+    IStudentResultsClient results,
+    ICurrentUserService currentUser) : Controller
+{
+    // Matches PupilSuggestionsController: below two characters a search is noise, and an
+    // over-long query is not a real search.
+    private const int MinQueryLength = 2;
+    private const int MaxQueryLength = 100;
+
+    [HttpGet]
+    [Route("/results/suggestions")]
+    public async Task<IActionResult> Suggestions(Guid windowId, string? query, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(query) || query.Length < MinQueryLength || query.Length > MaxQueryLength)
+            return Json(Array.Empty<object>());
+
+        var journey = HttpContext.Session.GetRequestState(windowId);
+        var cypmdId = journey.SelectedPupil?.Cypmd_Id;
+        if (string.IsNullOrWhiteSpace(cypmdId))
+            return Json(Array.Empty<object>());
+
+        var held = await results.GetResultsAsync(windowId, currentUser.OrganisationLaestab, cypmdId, ct);
+
+        return Json(held
+            .Where(r => Matches(r, query))
+            // The composite key, not the QAN: a pupil can hold the same qualification across
+            // sessions and across source files, and the server re-resolves this key on POST.
+            .Select(r => new { value = r.CompositeKey, label = ResultLabel.For(r) })
+            .ToArray());
+    }
+
+    // Qualification name matches anywhere (users type a subject, e.g. "French", not a full title);
+    // QAN matches on prefix only, since a substring match on an 8-digit code makes almost any
+    // numeric query match everything.
+    private static bool Matches(StudentResultRecord result, string query)
+        => result.QualificationName.Contains(query, StringComparison.OrdinalIgnoreCase)
+           || result.Qan.StartsWith(query, StringComparison.OrdinalIgnoreCase);
+
+}

--- a/src/DfE.CheckPerformanceData.Web/Data/GradeReference/grade-reference.json
+++ b/src/DfE.CheckPerformanceData.Web/Data/GradeReference/grade-reference.json
@@ -1,0 +1,203 @@
+{
+  "60370683": {
+    "qan": "60370683",
+    "qualificationTitle": "Pearson BTEC L1/L2 Tech Award in Sport",
+    "awardingOrganisation": "Pearson",
+    "passGrades": [
+      "*2",
+      "P1",
+      "P2",
+      "M1",
+      "M2",
+      "D1",
+      "D2"
+    ],
+    "failGrades": [
+      "F",
+      "Q",
+      "R",
+      "U",
+      "X"
+    ]
+  },
+  "10025480": {
+    "qan": "10025480",
+    "qualificationTitle": "OCR Level 3 FSMQ: Additional Maths",
+    "awardingOrganisation": "OCR",
+    "passGrades": [
+      "A",
+      "B",
+      "C",
+      "D",
+      "E"
+    ],
+    "failGrades": [
+      "Q",
+      "R",
+      "U",
+      "X"
+    ]
+  },
+  "50034157": {
+    "qan": "50034157",
+    "qualificationTitle": "IBO Level 3 International Baccalaureate Diploma",
+    "awardingOrganisation": "IBO",
+    "passGrades": [
+      "24B",
+      "24D",
+      "25B",
+      "25D",
+      "26B",
+      "26D",
+      "27B",
+      "27D",
+      "28B",
+      "28D",
+      "29B",
+      "29D",
+      "30B",
+      "30D",
+      "31B",
+      "31D",
+      "32B",
+      "32D",
+      "33B",
+      "33D",
+      "34B",
+      "34D",
+      "35B",
+      "35D",
+      "36B",
+      "36D",
+      "37B",
+      "37D",
+      "38B",
+      "38D",
+      "39B",
+      "39D",
+      "40B",
+      "40D",
+      "41B",
+      "41D",
+      "42B",
+      "42D",
+      "43B",
+      "43D",
+      "44B",
+      "44D",
+      "45B",
+      "45D"
+    ],
+    "failGrades": [
+      "00F",
+      "01F",
+      "02F",
+      "03F",
+      "04F",
+      "05F",
+      "06F",
+      "07F",
+      "08F",
+      "09F",
+      "10F",
+      "11F",
+      "12F",
+      "13F",
+      "14F",
+      "15F",
+      "16F",
+      "17F",
+      "18F",
+      "19F",
+      "20F",
+      "21F",
+      "22F",
+      "23F",
+      "24F",
+      "25F",
+      "26F",
+      "27F",
+      "28F",
+      "29F",
+      "30F",
+      "31F",
+      "32F",
+      "33F",
+      "34F",
+      "35F",
+      "36F",
+      "37F",
+      "38F",
+      "39F",
+      "40F",
+      "41F",
+      "42F",
+      "43F",
+      "44F",
+      "45F",
+      "R",
+      "U",
+      "X"
+    ]
+  },
+  "6037116X": {
+    "qan": "6037116X",
+    "qualificationTitle": "GCSE (9-1) Bus. Studs:Single",
+    "awardingOrganisation": "Pearson",
+    "passGrades": [
+      "9",
+      "8",
+      "7",
+      "6",
+      "5",
+      "4",
+      "3",
+      "2",
+      "1"
+    ],
+    "failGrades": [
+      "U",
+      "X"
+    ]
+  },
+  "60181576": {
+    "qan": "60181576",
+    "qualificationTitle": "GCSE (9-1) French",
+    "awardingOrganisation": "Pearson",
+    "passGrades": [
+      "9",
+      "8",
+      "7",
+      "6",
+      "5",
+      "4",
+      "3",
+      "2",
+      "1"
+    ],
+    "failGrades": [
+      "U",
+      "X"
+    ]
+  },
+  "60180882": {
+    "qan": "60180882",
+    "qualificationTitle": "GCSE (9-1) Art&Des : Fine Art",
+    "awardingOrganisation": "Pearson",
+    "passGrades": [
+      "9",
+      "8",
+      "7",
+      "6",
+      "5",
+      "4",
+      "3",
+      "2",
+      "1"
+    ],
+    "failGrades": [
+      "U",
+      "X"
+    ]
+  }
+}

--- a/src/DfE.CheckPerformanceData.Web/Data/QuestionFlows/IncorrectGrade_Post16.json
+++ b/src/DfE.CheckPerformanceData.Web/Data/QuestionFlows/IncorrectGrade_Post16.json
@@ -10,7 +10,6 @@
     },
     {
       "id": "cohort-scope",
-      "title": "Does the incorrect grade affect the whole cohort?",
       "questions": [
         {
           "id": "q-cohort-scope",
@@ -38,7 +37,6 @@
     },
     {
       "id": "cohort-count",
-      "title": "Enter the number of students who have an incorrect grade for this qualification",
       "nextPageId": "select-student-cohort",
       "questions": [
         {
@@ -98,13 +96,12 @@
     },
     {
       "id": "additional-info",
-      "title": "Additional information (Optional)",
       "pageTitle": "Additional information",
       "questions": [
         {
           "id": "q-additional-info",
           "type": "TextArea",
-          "title": "Additional information (Optional)",
+          "title": "Additional information",
           "hint": "You can provide us with any additional information to support your query if you need to.",
           "optional": true,
           "characterLimit": 250,

--- a/src/DfE.CheckPerformanceData.Web/Data/QuestionFlows/IncorrectGrade_Post16.json
+++ b/src/DfE.CheckPerformanceData.Web/Data/QuestionFlows/IncorrectGrade_Post16.json
@@ -1,0 +1,116 @@
+{
+  "firstPageId": "cohort-scope",
+  "pages": [
+    {
+      "id": "check-late-results",
+      "type": "Content",
+      "title": "Check your second late results file before you report an incorrect grade",
+      "content": "Nearly all incorrect grades are updated in the second late results file. We will email you in late November to let you know it's available.",
+      "nextPageId": "cohort-scope"
+    },
+    {
+      "id": "cohort-scope",
+      "title": "Does the incorrect grade affect the whole cohort?",
+      "questions": [
+        {
+          "id": "q-cohort-scope",
+          "type": "Radio",
+          "title": "Does the incorrect grade affect the whole cohort?",
+          "hint": "Select one option",
+          "validationFailure": "Select if the incorrect grade affects the whole cohort",
+          "summaryTitle": "Affects the whole cohort",
+          "options": [
+            {
+              "value": "yes",
+              "label": "Yes",
+              "subLabel": "Provide an example of one student",
+              "nextPageId": "cohort-count"
+            },
+            {
+              "value": "no",
+              "label": "No",
+              "subLabel": "Complete a separate enquiry for each student affected",
+              "nextPageId": "select-student-single"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cohort-count",
+      "title": "Enter the number of students who have an incorrect grade for this qualification",
+      "nextPageId": "select-student-cohort",
+      "questions": [
+        {
+          "id": "q-cohort-count",
+          "type": "FreeText",
+          "title": "Enter the number of students who have an incorrect grade for this qualification",
+          "hint": "Enter the number of students",
+          "validator": "WholeNumber",
+          "validationFailure": "Enter how many students have an incorrect grade for this qualification",
+          "summaryTitle": "Number of students in affected cohort"
+        }
+      ]
+    },
+    {
+      "id": "select-student-cohort",
+      "type": "PupilSearch",
+      "pupilFilter": "All",
+      "pupilKey": "primary",
+      "title": "What is the name of one of the students from the affected cohort?",
+      "subheading": "Start typing to search by name, ULN, CYPMD ID or date of birth",
+      "validationFailure": "Enter the name of the student with an incorrect grade",
+      "nextPageId": "select-result"
+    },
+    {
+      "id": "select-student-single",
+      "type": "PupilSearch",
+      "pupilFilter": "All",
+      "pupilKey": "primary",
+      "title": "What is the name of the student with an incorrect grade?",
+      "subheading": "Start typing to search by name, ULN, CYPMD ID or date of birth",
+      "validationFailure": "Enter the name of the student with an incorrect grade",
+      "nextPageId": "select-result"
+    },
+    {
+      "id": "select-result",
+      "type": "ResultSearch",
+      "title": "Which of {pupilName}'s results is incorrect?",
+      "pageTitle": "Which result is incorrect?",
+      "subheading": "Start typing to search for results by subject or QAN",
+      "validationFailure": "Enter which of {pupilName}'s results is incorrect",
+      "nextPageId": "grade-details"
+    },
+    {
+      "id": "grade-details",
+      "type": "ResultDetails",
+      "title": "Incorrect grade details",
+      "nextPageId": "additional-info",
+      "questions": [
+        {
+          "id": "q-revised-grade",
+          "type": "GradeSelect",
+          "title": "What should the revised grade be?",
+          "validationFailure": "Select the revised grade",
+          "summaryTitle": "Revised grade"
+        }
+      ]
+    },
+    {
+      "id": "additional-info",
+      "title": "Additional information (Optional)",
+      "pageTitle": "Additional information",
+      "questions": [
+        {
+          "id": "q-additional-info",
+          "type": "TextArea",
+          "title": "Additional information (Optional)",
+          "hint": "You can provide us with any additional information to support your query if you need to.",
+          "optional": true,
+          "characterLimit": 250,
+          "summaryTitle": "Additional information"
+        }
+      ]
+    }
+  ]
+}

--- a/src/DfE.CheckPerformanceData.Web/Seeding/DevDataSeedingOrchestrator.cs
+++ b/src/DfE.CheckPerformanceData.Web/Seeding/DevDataSeedingOrchestrator.cs
@@ -1,6 +1,8 @@
 using DfE.CheckPerformanceData.Application.CheckYourPupilData;
 using DfE.CheckPerformanceData.Application.Journey;
 using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Infrastructure.BlobStorage;
 using DfE.CheckPerformanceData.Infrastructure.RulesEngine;
 using DfE.CheckPerformanceData.Persistence.Seeding;
 using DfE.CheckPerformanceData.Web.QuestionFlow;
@@ -17,11 +19,13 @@ namespace DfE.CheckPerformanceData.Web.Seeding;
 public sealed class DevDataSeedingOrchestrator(
     DevDataSeeder devDataSeeder,
     IPupilDataBlobClient pupilDataBlobClient,
+    IStudentResultsClient studentResultsClient,
     IQuestionFlowBlobClient questionFlowBlobClient,
     IRequestRepository requestRepository,
     IRequestStateBlobClient requestStateBlobClient,
     ICheckYourPupilDataService checkYourPupilDataService,
     RulesConfigSeeder rulesConfigSeeder,
+    GradeReferenceBlobClient gradeReferenceBlobClient,
     IHostEnvironment environment,
     ILogger<DevDataSeedingOrchestrator> logger) : IDevDataSeedingOrchestrator
 {
@@ -31,6 +35,18 @@ public sealed class DevDataSeedingOrchestrator(
 
         await SeedPupilData.ExecuteSeedAsync(pupilDataBlobClient);
         await SeedPupilData.ExecutePost16SeedAsync(pupilDataBlobClient);
+
+        // AB#296648: the 16-19 exam results the incorrect-grade enquiry journey reads. Tolerates the
+        // same Azurite API-version mismatch as the other blob seeds so a version skew degrades the
+        // enquiry journey rather than aborting the whole seed.
+        try
+        {
+            await SeedStudentResults.ExecuteSeedAsync(studentResultsClient);
+        }
+        catch (Azure.RequestFailedException ex) when (environment.IsDevelopment())
+        {
+            logger.LogWarning(ex, "Student results seeding skipped: Azurite returned {Status} {ErrorCode}.", ex.Status, ex.ErrorCode);
+        }
 
         try
         {
@@ -55,5 +71,11 @@ public sealed class DevDataSeedingOrchestrator(
         // local/E2E web stack doesn't run that worker, so the web app self-seeds to keep the admin
         // rules editor usable. Idempotent and version-gated — never clobbers a newer valid blob.
         await rulesConfigSeeder.SeedAsync();
+
+        // AB#297130: the AODC grade reference, seeded into the same rules-config container. Also
+        // seeded by GradeReferenceSeedingService on every startup; repeating it here means the admin
+        // "Reset seed data" action restores it if the blob was deleted. Seed-if-missing, so this is
+        // a no-op whenever it is already there.
+        await SeedGradeReference.ExecuteSeedAsync(gradeReferenceBlobClient, environment.ContentRootPath);
     }
 }

--- a/src/DfE.CheckPerformanceData.Web/Seeding/GradeReferenceSeedingService.cs
+++ b/src/DfE.CheckPerformanceData.Web/Seeding/GradeReferenceSeedingService.cs
@@ -1,0 +1,30 @@
+using DfE.CheckPerformanceData.Infrastructure.BlobStorage;
+using Microsoft.Extensions.Hosting;
+
+namespace DfE.CheckPerformanceData.Web.Seeding;
+
+/// <summary>
+/// Seeds the grade reference blob on web startup in every environment. AB#296648.
+///
+/// Unlike the rest of the dev-data seeding — which only runs in Development or behind
+/// <c>SeedDevelopmentData</c> — the grade reference is real reference data the revised-grade picker
+/// cannot work without, and Terraform provisions the rules-config container empty. So this runs
+/// everywhere, exactly as the rules-engine worker self-seeds <c>rules.json</c>. It is
+/// seed-if-missing, so an environment that has had the full AODC export loaded is untouched.
+///
+/// Failures are swallowed inside <see cref="GradeReferenceBlobClient.SeedIfMissingAsync"/> so a
+/// storage blip degrades the grade picker rather than blocking startup.
+/// </summary>
+public sealed class GradeReferenceSeedingService(
+    IServiceProvider services,
+    IHostEnvironment environment) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        using var scope = services.CreateScope();
+        var client = scope.ServiceProvider.GetRequiredService<GradeReferenceBlobClient>();
+        await SeedGradeReference.ExecuteSeedAsync(client, environment.ContentRootPath, cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/DfE.CheckPerformanceData.Web/Seeding/SeedGradeReference.cs
+++ b/src/DfE.CheckPerformanceData.Web/Seeding/SeedGradeReference.cs
@@ -1,0 +1,23 @@
+using DfE.CheckPerformanceData.Infrastructure.BlobStorage;
+
+namespace DfE.CheckPerformanceData.Web.Seeding;
+
+/// <summary>
+/// Uploads the image-bundled AODC grade reference document to the rules-config container when the
+/// blob is absent. AB#296648 / AB#297130.
+///
+/// Seed-if-missing, never overwrite — matching how <c>country-languages.json</c> is treated, and for
+/// the same reason: once the real AODC export has been loaded into an environment, a redeploy of an
+/// older bundled copy must not undo it.
+/// </summary>
+public static class SeedGradeReference
+{
+    public static async Task ExecuteSeedAsync(
+        GradeReferenceBlobClient client, string contentRootPath, CancellationToken ct = default)
+    {
+        var path = Path.Combine(contentRootPath, "Data", "GradeReference", "grade-reference.json");
+        if (!File.Exists(path)) return;
+
+        await client.SeedIfMissingAsync(await File.ReadAllTextAsync(path, ct), ct);
+    }
+}

--- a/src/DfE.CheckPerformanceData.Web/Seeding/SeedStudentResults.cs
+++ b/src/DfE.CheckPerformanceData.Web/Seeding/SeedStudentResults.cs
@@ -1,0 +1,84 @@
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Persistence.Seeding;
+
+namespace DfE.CheckPerformanceData.Web.Seeding;
+
+/// <summary>
+/// Dev-only: writes the per-school 16-19 exam results JSON (container <c>{windowId}</c>, blob
+/// <c>results-enquiry/data/{laestab}_results.json</c>) so the incorrect-grade enquiry journey works
+/// locally before the six-file ingestion pipeline exists. AB#296648.
+///
+/// The qualifications, QANs, syllabus codes, sessions and grades are the fixtures from the Figma
+/// screens. The CYPMD ids are NOT: they are the ids <see cref="SeedPupilData"/> actually generates
+/// for the seeded Post16 school, because a result must belong to a pupil the school can select —
+/// results keyed to the Figma's own CYPMD id would leave the journey with a selectable pupil who
+/// holds no results.
+///
+/// Deliberately seeds no <see cref="ResultsFileTags.Post16LateResults2"/> row, so
+/// <c>ILateResultsAvailability</c> reports false locally and the "check your second late results
+/// file" interstitial is on the happy path.
+/// </summary>
+public static class SeedStudentResults
+{
+    // Kingsmead School — the Post16 school the change-request seed also uses.
+    private const string Laestab = "860/4070";
+
+    // The first three included Post16 pupils SeedPupilData generates for this school
+    // (Cypmd_Id = $"5{(n + 1):D5}" for n = 0, 1, 2).
+    private const string StudentA = "500001";
+    private const string StudentB = "500002";
+    private const string StudentC = "500003";
+
+    public static async Task ExecuteSeedAsync(IStudentResultsClient client)
+        => await client.UploadResultsAsync(DevDataSeeder.Post16CheckingWindowId, Laestab, Results);
+
+    private static readonly StudentResultRecord[] Results =
+    [
+        // Student A holds the same qualification twice, distinguished only by session — the case the
+        // ticket calls out as the reason the result search cannot key on QAN alone.
+        new()
+        {
+            CypmdId = StudentA, Qan = "6037116X", QualificationName = "GCSE (9-1) Bus. Studs:Single",
+            SyllabusCode = "1BS0", Session = "S2024", Grade = "5", SourceFile = ResultsFileTags.Post16Main
+        },
+        new()
+        {
+            CypmdId = StudentA, Qan = "6037116X", QualificationName = "GCSE (9-1) Bus. Studs:Single",
+            SyllabusCode = "1BS0", Session = "S2023", Grade = "4", SourceFile = ResultsFileTags.Post16Main
+        },
+        new()
+        {
+            CypmdId = StudentA, Qan = "60181576", QualificationName = "GCSE (9-1) French",
+            SyllabusCode = "1FR0", Session = "S2024", Grade = "6", SourceFile = ResultsFileTags.Post16LateResults1
+        },
+        new()
+        {
+            CypmdId = StudentA, Qan = "60180882", QualificationName = "GCSE (9-1) Art&Des : Fine Art",
+            SyllabusCode = "1AD0", Session = "S2024", Grade = "9", SourceFile = ResultsFileTags.Post16Main
+        },
+
+        // Student B: a vocational qualification, so the grade picker shows a non-GCSE scale.
+        new()
+        {
+            CypmdId = StudentB, Qan = "60370683", QualificationName = "Pearson BTEC Level 3 National Extended Certificate in Sport",
+            SyllabusCode = "31525H", Session = "S2024", Grade = "M1", SourceFile = ResultsFileTags.Post16Main
+        },
+        new()
+        {
+            CypmdId = StudentB, Qan = "10025480", QualificationName = "OCR Level 3 FSMQ Additional Mathematics",
+            SyllabusCode = "6993", Session = "S2024", Grade = "B", SourceFile = ResultsFileTags.Post16LateResults1
+        },
+        new()
+        {
+            CypmdId = StudentB, Qan = "60181576", QualificationName = "GCSE (9-1) French",
+            SyllabusCode = "1FR0", Session = "S2024", Grade = "3", SourceFile = ResultsFileTags.Post16Main
+        },
+
+        // Student C: a single result, so the "one obvious choice" case is covered too.
+        new()
+        {
+            CypmdId = StudentC, Qan = "6037116X", QualificationName = "GCSE (9-1) Bus. Studs:Single",
+            SyllabusCode = "1BS0", Session = "S2024", Grade = "2", SourceFile = ResultsFileTags.Post16Main
+        }
+    ];
+}

--- a/src/DfE.CheckPerformanceData.Web/Startup/BlobStorageExtensions.cs
+++ b/src/DfE.CheckPerformanceData.Web/Startup/BlobStorageExtensions.cs
@@ -48,6 +48,17 @@ public static class BlobStorageExtensions
         services.AddScoped<IRequestBlobClient, RequestBlobClient>();
         services.AddScoped<IRequestStateBlobClient, RequestStateBlobClient>();
         services.AddScoped<IPupilDataBlobClient, PupilDataBlobClient>();
+        // AB#296648: the 16-19 exam results the incorrect-grade enquiry journey reads. Registered
+        // here as well as in the Infrastructure DependencyManager because the web host builds its
+        // blob-client set from this seam and never calls AddInfrastructureDependencies.
+        services.AddScoped<Application.ResultsEnquiry.IStudentResultsClient, StudentResultsBlobClient>();
+        // AB#297130: the AODC grade reference lives beside rules.json in the rules-config container.
+        // The concrete type is registered too, because the startup seeder needs SeedIfMissingAsync
+        // (a seeding concern that has no business on the read interface).
+        services.AddScoped<GradeReferenceBlobClient>();
+        services.AddScoped<Application.ResultsEnquiry.IGradeReferenceClient>(
+            sp => sp.GetRequiredService<GradeReferenceBlobClient>());
+        services.AddHostedService<Seeding.GradeReferenceSeedingService>();
         services.AddScoped<ICsvSchemaFileProcessor, CsvSchemaFileProcessor>();
 
         return services;

--- a/src/DfE.CheckPerformanceData.Web/Views/CheckYourPupilData/Index.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/CheckYourPupilData/Index.cshtml
@@ -81,6 +81,14 @@
 
                 <govuk-radios-item value="@NextSteps.RequestChange">Request an amendment to pupil data
                 </govuk-radios-item>
+                @if (Model.ShowResultsEnquiryOption)
+                {
+                    @* AB#296648: the 16-19 way in to a results enquiry, per the agreed decision in
+                       docs/16-19-window-model.md. The full "Review exam results" tabbed page belongs
+                       to the entry-point ticket; this radio is the model-aligned route until then. *@
+                    <govuk-radios-item value="@NextSteps.ResultsEnquiry">Report an issue with an exam result
+                    </govuk-radios-item>
+                }
                 <govuk-radios-divider>or</govuk-radios-divider>
                 <govuk-radios-item value="@NextSteps.Confirm">Confirm pupil data is correct</govuk-radios-item>
             </govuk-radios-fieldset>

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/EnquiryConfirmation.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/EnquiryConfirmation.cshtml
@@ -1,0 +1,35 @@
+@model DfE.CheckPerformanceData.Web.Controllers.Journey.EnquiryConfirmationViewModel
+
+@{
+    ViewBag.Title = "Results enquiry submitted";
+    Layout = "_Layout";
+}
+
+@* No Back link: the enquiry is submitted and the journey state is gone, so there is nothing to go
+   back to. The onward links below are the only routes out. *@
+<govuk-panel>
+    <govuk-panel-title>Results enquiry submitted</govuk-panel-title>
+    <govuk-panel-body>
+        Your reference number<br><strong>@Model.ReferenceNumber</strong>
+    </govuk-panel-body>
+</govuk-panel>
+
+<p class="govuk-body">
+    We have sent you an email to confirm that you have successfully submitted an enquiry.
+</p>
+
+<p class="govuk-body">
+    @* Lands on the ResultIssue page, which builds a fresh RequestState — so the AC "none of my
+       previous answers are carried over" holds by construction rather than by remembering to clear. *@
+    <a asp-action="Index" asp-controller="ResultIssue" asp-route-windowId="@Model.WindowId"
+       class="govuk-link">Report another issue with an exam result</a>
+</p>
+
+<h2 class="govuk-heading-m">What happens next</h2>
+
+<p class="govuk-body">After you submit your changes:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+    <li>the DfE will review your enquiry</li>
+    <li>your performance data will be updated in the Spring, if required</li>
+</ul>

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/PupilSearch.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/PupilSearch.cshtml
@@ -10,7 +10,7 @@
 
 @if (Model.BackPageId is not null)
 {
-    <a asp-action="@(Model.BackPageIsPupilSearch ? "PupilSearchPage" : "Page")" asp-controller="Journey"
+    <a asp-action="@Model.BackPageAction" asp-controller="Journey"
        asp-route-windowId="@Model.WindowId"
        asp-route-pageId="@Model.BackPageId"
        class="govuk-back-link">Back</a>

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/ResultDetails.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/ResultDetails.cshtml
@@ -1,0 +1,69 @@
+@model DfE.CheckPerformanceData.Web.Controllers.Journey.PageViewModel
+
+@*
+    "Incorrect grade details" (AB#296648). A question page that first shows which result is being
+    corrected, so the user can see the grade they are about to change before they change it.
+    Rendered by the generic Page action — only the view differs, exactly as EvidenceUpload does.
+*@
+
+@{
+    ViewBag.Title = Model.PageTitle;
+    Layout = "_Layout";
+}
+
+@await Html.PartialAsync("_JourneyBackLink", Model)
+
+@if (Model.HasErrors)
+{
+    @await Html.PartialAsync("_JourneyErrorSummary", Model)
+}
+
+<h1 class="govuk-heading-xl">@Model.ResolvedTitle</h1>
+
+@if (Model.SelectedResult is not null)
+{
+    <govuk-summary-list>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Student name</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@Model.PupilName</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>CYPMD ID</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@Model.SelectedResult.CypmdId</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Qualification number (QAN)</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@Model.SelectedResult.Qan</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Qualification name and subject</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@Model.SelectedResult.QualificationName</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Session</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@Model.SelectedResult.Session</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+        <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Current grade</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@Model.SelectedResult.Grade</govuk-summary-list-row-value>
+        </govuk-summary-list-row>
+    </govuk-summary-list>
+}
+
+<form method="post" action="@Url.Action("PagePost", "Journey", new { windowId = Model.WindowId, pageId = Model.Page.Id })">
+    @Html.AntiForgeryToken()
+    <input type="hidden" name="fromSummary" value="@Model.FromSummary.ToString().ToLower()" />
+
+    @foreach (var qm in Model.NonFileUploadModels)
+    {
+        await Html.RenderPartialAsync("_Question", qm);
+    }
+
+    @* Sits after the picker, as the Figma screen has it: a reminder, not a precondition. *@
+    <div class="govuk-inset-text">
+        Before you report an incorrect grade, check the second late results (issued in November) to
+        make sure the grade is not included there.
+    </div>
+
+    <govuk-button type="submit">Continue</govuk-button>
+</form>

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/ResultSearch.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/ResultSearch.cshtml
@@ -1,0 +1,140 @@
+@model DfE.CheckPerformanceData.Web.Controllers.Journey.ResultSearchViewModel
+
+@{
+    @* The student's name is in Model.Title, so the browser title (which also reaches analytics)
+       uses a name-free form instead. *@
+    ViewBag.Title = "Which result is incorrect?";
+    Layout = "_Layout";
+    var hasError = !ViewData.ModelState.IsValid;
+    var fieldErrorMessage = ViewData.ModelState["selectedResultKey"]?.Errors.FirstOrDefault()?.ErrorMessage
+        ?? "Enter which result is incorrect";
+    var hintText = Model.Hint ?? "Start typing to search for results by subject or QAN";
+}
+
+@if (Model.BackPageId is not null)
+{
+    <a asp-action="@Model.BackPageAction" asp-controller="Journey"
+       asp-route-windowId="@Model.WindowId"
+       asp-route-pageId="@Model.BackPageId"
+       class="govuk-back-link">Back</a>
+}
+else
+{
+    <a asp-action="Index" asp-controller="CheckYourPupilData" asp-route-windowId="@Model.WindowId" class="govuk-back-link">Back</a>
+}
+
+@if (hasError)
+{
+    <govuk-error-summary>
+        <govuk-error-summary-title>There is a problem</govuk-error-summary-title>
+        <govuk-error-summary-item href="#result-search">@fieldErrorMessage</govuk-error-summary-item>
+    </govuk-error-summary>
+}
+
+@* Progressive enhancement: a real <select> carrying every result the student holds, which
+   accessible-autocomplete upgrades in place via enhanceSelectElement. With script off the page is a
+   working GOV.UK select; with script on it becomes a type-ahead. This is why the options are rendered
+   server-side rather than fetched — a student holds a handful of results, so there is nothing to gain
+   from a round-trip, and a fetch-only version would not work without JavaScript at all.
+
+   enhanceSelectElement hides the select, moves its id to "{id}-select" and gives the new input the
+   original id, so the <label for="result-search"> keeps naming whichever control is visible. The
+   select keeps its name, so it is still what posts. *@
+<form method="post" action="@Url.Action("ResultSearchPost", "Journey", new { windowId = Model.WindowId, pageId = Model.PageId })">
+    @Html.AntiForgeryToken()
+
+    <div class="govuk-form-group @(hasError ? "govuk-form-group--error" : "")">
+        <h1 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--l" for="result-search">@Model.Title</label>
+        </h1>
+        <div class="govuk-hint" id="result-search-hint">@hintText</div>
+        @if (hasError)
+        {
+            <p id="result-search-error" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span>
+                @fieldErrorMessage
+            </p>
+        }
+        <select class="govuk-select @(hasError ? "govuk-select--error" : "")"
+                id="result-search" name="selectedResultKey"
+                aria-describedby="result-search-hint @(hasError ? "result-search-error" : "")">
+            @* Empty first option so nothing is preselected — the user must choose. *@
+            <option value=""></option>
+            @foreach (var result in Model.AvailableResults)
+            {
+                <option value="@result.CompositeKey" selected="@(result.CompositeKey == Model.SelectedResultKey)">
+                    @DfE.CheckPerformanceData.Application.ResultsEnquiry.ResultLabel.For(result)
+                </option>
+            }
+        </select>
+    </div>
+
+    @if (Model.SelectedResult is not null)
+    {
+        <govuk-summary-list>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Qualification name and subject</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.SelectedResult.QualificationName</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Qualification number (QAN)</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.SelectedResult.Qan</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Syllabus code</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.SelectedResult.SyllabusCode</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Session</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.SelectedResult.Session</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Current Grade</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.SelectedResult.Grade</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>CSV file</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.SelectedResult.SourceFile</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+        </govuk-summary-list>
+    }
+
+    <govuk-button type="submit">Continue</govuk-button>
+</form>
+
+@section Scripts {
+    <script>
+        (function () {
+            var select = document.getElementById('result-search');
+            if (!select || typeof accessibleAutocomplete === 'undefined') return;
+
+            var hasError = @(hasError ? "true" : "false");
+            var hintText = @Json.Serialize(hintText);
+            var errorText = @Json.Serialize(fieldErrorMessage);
+
+            // accessible-autocomplete owns the input's aria-describedby, rewriting it on every
+            // re-render, so tAssistiveHint is the supported way to get the hint and error announced.
+            // See PupilSearch.cshtml for the full rationale.
+            var assistiveHint = (hasError ? 'Error: ' + errorText + '. ' : '')
+                + hintText + '. '
+                + 'When autocomplete results are available use up and down arrows to review and '
+                + 'enter to select. Touch device users, explore by touch or with swipe gestures.';
+
+            accessibleAutocomplete.enhanceSelectElement({
+                selectElement: select,
+                // The empty first <option> is a placeholder, not a choice, so it must not appear in
+                // the suggestion list.
+                preserveNullOptions: false,
+                // Qualification titles are long and a student holds few results, so showing the whole
+                // list on focus is more useful than making them guess a search term.
+                showAllValues: true,
+                // Never silently pick the first match — the user must confirm which result is wrong.
+                autoselect: false,
+                confirmOnBlur: false,
+                defaultValue: @Json.Serialize(Model.SelectedResultLabel ?? ""),
+                inputClasses: 'govuk-input' + (hasError ? ' govuk-input--error' : ''),
+                tAssistiveHint: function () { return assistiveHint; }
+            });
+        })();
+    </script>
+}

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/Summary.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/Summary.cshtml
@@ -2,7 +2,9 @@
 @model SummaryViewModel
 
 @{
-    ViewBag.Title = "Summary of amendment request";
+    // A results enquiry is a different thing from a pupil-data amendment, so it is named as one.
+    // The student's name stays out of the browser title (and therefore analytics) — AB#296648.
+    ViewBag.Title = Model.IsResultsEnquiry ? "Summary of result enquiry" : "Summary of amendment request";
     Layout = "_Layout";
     // The duplicate-request conflict is carried on the view model, not ModelState, so the
     // layout's "Error: " title rule needs telling about it explicitly.
@@ -19,7 +21,7 @@ else if (Model.FromEdit)
 }
 else
 {
-    <a asp-action="@(Model.BackPageIsPupilSearch ? "PupilSearchPage" : "Page")" asp-controller="Journey"
+    <a asp-action="@Model.BackPageAction" asp-controller="Journey"
        asp-route-windowId="@Model.WindowId"
        asp-route-pageId="@Model.BackPageId"
        class="govuk-back-link">Back</a>
@@ -39,12 +41,23 @@ else
     </govuk-error-summary>
 }
 
-<h1 class="govuk-heading-xl">Summary of amendment request</h1>
-<h2 class="govuk-heading-m">Check details for the @Model.WhatToChangeNoun of @Model.PupilName</h2>
+@if (Model.IsResultsEnquiry)
+{
+    <span class="govuk-caption-xl">Check details</span>
+    <h1 class="govuk-heading-xl">Summary of result enquiry for @Model.PupilName</h1>
+}
+else
+{
+    <h1 class="govuk-heading-xl">Summary of amendment request</h1>
+    <h2 class="govuk-heading-m">Check details for the @Model.WhatToChangeNoun of @Model.PupilName</h2>
+}
 
 <partial name="_SummaryDetails" model="Model" />
 
-<partial name="_SummaryEvidenceFiles" model="Model" />
+@if (!Model.IsResultsEnquiry)
+{
+    <partial name="_SummaryEvidenceFiles" model="Model" />
+}
 
 <form method="post" action="@Url.Action("SummaryConfirm", "Journey", new { windowId = Model.WindowId })">
     @Html.AntiForgeryToken()
@@ -54,7 +67,20 @@ else
     {
         <govuk-button type="submit">Submit request</govuk-button>
     }
-    <govuk-button type="submit"
-        formaction="@Url.Action("SaveDraft", "Journey", new { windowId = Model.WindowId })"
-        class="govuk-button--secondary">Save and continue later</govuk-button>
+    @if (!Model.IsResultsEnquiry)
+    {
+        <govuk-button type="submit"
+            formaction="@Url.Action("SaveDraft", "Journey", new { windowId = Model.WindowId })"
+            class="govuk-button--secondary">Save and continue later</govuk-button>
+    }
 </form>
+
+@if (Model.IsResultsEnquiry)
+{
+    @* Drafts were decided against for enquiries, so there is no "save and continue later" above —
+       the way out is to abandon this enquiry and start a new one, which resets the journey. *@
+    <p class="govuk-body">
+        <a asp-action="Index" asp-controller="ResultIssue" asp-route-windowId="@Model.WindowId"
+           class="govuk-link">Cancel and go back to create a new enquiry</a>
+    </p>
+}

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/_GradeSelect.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/_GradeSelect.cshtml
@@ -1,0 +1,91 @@
+@using DfE.CheckPerformanceData.Web.Controllers.Journey
+@model QuestionPartialModel
+
+@*
+    The revised-grade picker (AB#297130). A plain GOV.UK <select> so the page works with JavaScript
+    off, enhanced into a searchable type-ahead when script is available — some qualifications award
+    93 grades, which is far too many to scan in a dropdown.
+
+    Options come from the AODC reference data for the selected result's QAN: pass grades first, then
+    fail grades, in source order. Nothing is preselected — the user must choose.
+*@
+
+@{
+    var hintId = $"{Model.FieldName}-hint";
+    var errorId = $"{Model.FieldName}-error";
+    var unavailableId = $"{Model.FieldName}-unavailable";
+    var describedBy = string.Join(" ", new[]
+        {
+            Model.Question.Hint is not null ? hintId : null,
+            Model.GradeOptionsUnavailable ? unavailableId : null,
+            Model.HasError ? errorId : null
+        }.Where(s => s is not null));
+}
+
+<div class="govuk-form-group @(Model.HasError ? "govuk-form-group--error" : "")">
+    @if (Model.IsPageHeading)
+    {
+        <h1 class="govuk-label-wrapper">
+            <label class="govuk-label govuk-label--l" for="@Model.FieldName">@Model.ResolvedTitle</label>
+        </h1>
+    }
+    else
+    {
+        <label class="govuk-label govuk-label--m" for="@Model.FieldName">@Model.ResolvedTitle</label>
+    }
+
+    @if (Model.Question.Hint is not null)
+    {
+        <div class="govuk-hint" id="@hintId">@Model.Question.Hint</div>
+    }
+
+    @if (Model.GradeOptionsUnavailable)
+    {
+        @* A reference-data gap, not a user error — so it is stated plainly rather than as a
+           validation failure. Validation still holds the enquiry back, because a grade nobody can
+           confirm is valid is worse than no enquiry. FLAGGED: copy needs content sign-off. *@
+        <div class="govuk-inset-text" id="@unavailableId">
+            We cannot list grades for this qualification yet
+        </div>
+    }
+
+    @if (Model.HasError)
+    {
+        <p class="govuk-error-message" id="@errorId">
+            <span class="govuk-visually-hidden">Error:</span> @Model.Error
+        </p>
+    }
+
+    <select class="govuk-select @(Model.HasError ? "govuk-select--error" : "")"
+            id="@Model.FieldName" name="@Model.FieldName"
+            @(describedBy.Length > 0 ? $"aria-describedby=\"{describedBy}\"" : "")>
+        <option value="">Select revised grade</option>
+        @foreach (var option in Model.VisibleOptions)
+        {
+            <option value="@option.Value" selected="@(option.Value == Model.ExistingAnswer?.TextValue)">@option.Label</option>
+        }
+    </select>
+</div>
+
+<script>
+    (function () {
+        var select = document.getElementById('@Model.FieldName');
+        if (!select || typeof accessibleAutocomplete === 'undefined') return;
+        // Nothing to enhance when the reference data has no grades for this qualification.
+        if (select.options.length <= 1) return;
+
+        accessibleAutocomplete.enhanceSelectElement({
+            selectElement: select,
+            // "Select revised grade" is a placeholder, not a grade.
+            preserveNullOptions: false,
+            // A grade code is short and unguessable, so the user needs to see the scale rather than
+            // type into an empty box.
+            showAllValues: true,
+            // Grades like 24F and 24D differ by one character; auto-picking the first match would
+            // silently choose a pass where the user meant a fail.
+            autoselect: false,
+            confirmOnBlur: false,
+            inputClasses: 'govuk-input@(Model.HasError ? " govuk-input--error" : "")'
+        });
+    })();
+</script>

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/_JourneyBackLink.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/_JourneyBackLink.cshtml
@@ -6,9 +6,18 @@
 }
 else if (Model.BackPageId is not null)
 {
-    <a asp-action="@(Model.BackPageIsPupilSearch ? "PupilSearchPage" : "Page")" asp-controller="Journey"
+    @* BackPageAction rather than a bool: there are three page routes now (Page, PupilSearchPage,
+       ResultSearchPage) and a back link pointing at the wrong one 404s. *@
+    <a asp-action="@Model.BackPageAction" asp-controller="Journey"
        asp-route-windowId="@Model.WindowId" asp-route-pageId="@Model.BackPageId"
        class="govuk-back-link">Back</a>
+}
+else if (Model.WhatToChange == DfE.CheckPerformanceData.Application.CheckYourPupilData.WhatToChange.IncorrectGrade)
+{
+    @* A results enquiry started at the ResultIssue page, not the pupil-data amendment chooser.
+       AB#296648: the guidance page is the journey's first page when the second late results file has
+       not landed, so this is the branch it takes. *@
+    <a asp-action="Index" asp-controller="ResultIssue" asp-route-windowId="@Model.WindowId" class="govuk-back-link">Back</a>
 }
 else
 {

--- a/src/DfE.CheckPerformanceData.Web/Views/Journey/_Question.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/Journey/_Question.cshtml
@@ -17,6 +17,9 @@
     case QuestionType.Autocomplete:
         await Html.RenderPartialAsync("_Autocomplete", Model);
         break;
+    case QuestionType.GradeSelect:
+        await Html.RenderPartialAsync("_GradeSelect", Model);
+        break;
 }
 
 @if (Model.Question.QuestionHelpTitle is not null)

--- a/src/DfE.CheckPerformanceData.Web/Views/ResultIssue/Index.cshtml
+++ b/src/DfE.CheckPerformanceData.Web/Views/ResultIssue/Index.cshtml
@@ -1,0 +1,69 @@
+@model DfE.CheckPerformanceData.Web.Controllers.ResultIssueViewModel
+
+@{
+    // Matches the page heading the radios legend renders (is-page-heading="true"), so the
+    // browser title and the visible heading cannot drift apart.
+    ViewBag.Title = "What issue with the results do you need to report?";
+    Layout = "_Layout";
+    var hasError = !ViewData.ModelState.IsValid;
+    var fieldErrorMessage = ViewData.ModelState[nameof(Model.IssueType)]?.Errors.FirstOrDefault()?.ErrorMessage;
+}
+
+<a asp-action="Index" asp-controller="CheckYourPupilData" asp-route-windowId="@Model.WindowId" class="govuk-back-link">Back</a>
+
+@if (hasError && fieldErrorMessage is not null)
+{
+    <govuk-error-summary>
+        <govuk-error-summary-title>There is a problem</govuk-error-summary-title>
+        @* Anchors the id set explicitly on the first radio below, so the summary link always
+           lands on the group rather than depending on generated id numbering. *@
+        <govuk-error-summary-item href="#issueType">@fieldErrorMessage</govuk-error-summary-item>
+    </govuk-error-summary>
+}
+
+<form method="post" action="@Url.Action("Confirm", "ResultIssue", new { windowId = Model.WindowId })">
+    @Html.AntiForgeryToken()
+
+    <govuk-radios for="IssueType">
+        <govuk-radios-fieldset>
+            <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+                What issue with the results do you need to report?
+            </govuk-radios-fieldset-legend>
+
+            <govuk-radios-hint>
+                Select one option
+            </govuk-radios-hint>
+
+            @if (hasError && fieldErrorMessage is not null)
+            {
+                <govuk-radios-error-message>@fieldErrorMessage</govuk-radios-error-message>
+            }
+
+            @* Only the incorrect-grade option ships in AB#296648. The two other options on the same
+               Figma screen belong to sibling tickets — rendering them here without a journey behind
+               them would dead-end the user, so the controller rejects their values as unanswered
+               until those flows exist. *@
+            <govuk-radios-item value="@DfE.CheckPerformanceData.Web.Controllers.ResultIssueViewModel.IncorrectGrade" id="issueType">
+                Incorrect grade (once you have checked your second late results file in late November)
+            </govuk-radios-item>
+        </govuk-radios-fieldset>
+    </govuk-radios>
+
+    <govuk-button type="submit">Continue</govuk-button>
+</form>
+
+@* Guidance, not a gate. The BA confirmed on 2026-08-17 that the late-results message informs the
+   user and never blocks them, so this expander sits below Continue exactly as the Figma screen has
+   it. FLAGGED: the Figma frame shows this expander collapsed, so its body copy was never captured —
+   the wording below reuses the interstitial copy the plan already pins, and needs content sign-off. *@
+<details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">Have you checked your second late results file?</span>
+    </summary>
+    <div class="govuk-details__text">
+        <p class="govuk-body">
+            Nearly all incorrect grades are updated in the second late results file. We will email you
+            in late November to let you know it's available.
+        </p>
+    </div>
+</details>

--- a/src/DfE.CheckPerformanceData.Web/appsettings.json
+++ b/src/DfE.CheckPerformanceData.Web/appsettings.json
@@ -60,6 +60,8 @@
     "ServiceId": "mockoon-service-id"
   },
   "Notify": {
-    "ApiKey": "YOUR_ACTUAL_API_KEY_HERE"
+    "ApiKey": "YOUR_ACTUAL_API_KEY_HERE",
+    "_comment": "Template ids come from the per-environment terraform config. ResultsEnquirySubmittedTemplateId (AB#296648) has no template yet: left empty, NotifyService logs a warning and sends nothing, so the enquiry journey still completes.",
+    "ResultsEnquirySubmittedTemplateId": ""
   }
 }

--- a/terraform/application/config/development.yml
+++ b/terraform/application/config/development.yml
@@ -8,6 +8,10 @@ Notify__SubmissionNotificationTemplateId: f123aa5f-be65-4a57-8e6e-66b323337095
 Notify__BulkSubmissionNotificationTemplateId: 1a0b1085-f942-49cf-82f3-0270c4339513
 Notify__WithdrawNotificationTemplateId: e8667eed-7b52-42f7-a7e6-875b470e31c7
 Notify__DlqThresholdTemplateId: 517c069b-1566-473d-b8ad-8167f05ce723
+# AB#296648: the 16-19 results-enquiry confirmation. The template has not been created yet;
+# an empty value makes NotifyService log a warning and send nothing, so the enquiry journey
+# still works without it. Replace with the template id once GOV.UK Notify has it.
+Notify__ResultsEnquirySubmittedTemplateId: ""
 Notify__LinkBaseUrl: https://check-performance-data-development.test.teacherservices.cloud/
 Notify__UtmSource: dev-check-performance-data
 Notify__UtmMedium: email

--- a/terraform/application/config/preproduction.yml
+++ b/terraform/application/config/preproduction.yml
@@ -17,6 +17,10 @@ Notify__SubmissionNotificationTemplateId: f123aa5f-be65-4a57-8e6e-66b323337095
 Notify__BulkSubmissionNotificationTemplateId: 1a0b1085-f942-49cf-82f3-0270c4339513
 Notify__WithdrawNotificationTemplateId: e8667eed-7b52-42f7-a7e6-875b470e31c7
 Notify__DlqThresholdTemplateId: 517c069b-1566-473d-b8ad-8167f05ce723
+# AB#296648: the 16-19 results-enquiry confirmation. The template has not been created yet;
+# an empty value makes NotifyService log a warning and send nothing, so the enquiry journey
+# still works without it. Replace with the template id once GOV.UK Notify has it.
+Notify__ResultsEnquirySubmittedTemplateId: ""
 Notify__LinkBaseUrl: https://check-performance-data-development.preprod.teacherservices.cloud/
 Notify__UtmSource: preprod-check-performance-data
 Notify__UtmMedium: email

--- a/terraform/application/config/production.yml
+++ b/terraform/application/config/production.yml
@@ -17,6 +17,10 @@ Notify__SubmissionNotificationTemplateId: f123aa5f-be65-4a57-8e6e-66b323337095
 Notify__BulkSubmissionNotificationTemplateId: 1a0b1085-f942-49cf-82f3-0270c4339513
 Notify__WithdrawNotificationTemplateId: e8667eed-7b52-42f7-a7e6-875b470e31c7
 Notify__DlqThresholdTemplateId: 517c069b-1566-473d-b8ad-8167f05ce723
+# AB#296648: the 16-19 results-enquiry confirmation. The template has not been created yet;
+# an empty value makes NotifyService log a warning and send nothing, so the enquiry journey
+# still works without it. Replace with the template id once GOV.UK Notify has it.
+Notify__ResultsEnquirySubmittedTemplateId: ""
 Notify__LinkBaseUrl: https://check-performance-data.education.gov.uk/
 Notify__UtmSource: prod-check-performance-data
 Notify__UtmMedium: email

--- a/terraform/application/config/qa.yml
+++ b/terraform/application/config/qa.yml
@@ -8,6 +8,10 @@ Notify__SubmissionNotificationTemplateId: f123aa5f-be65-4a57-8e6e-66b323337095
 Notify__BulkSubmissionNotificationTemplateId: 1a0b1085-f942-49cf-82f3-0270c4339513
 Notify__WithdrawNotificationTemplateId: e8667eed-7b52-42f7-a7e6-875b470e31c7
 Notify__DlqThresholdTemplateId: 517c069b-1566-473d-b8ad-8167f05ce723
+# AB#296648: the 16-19 results-enquiry confirmation. The template has not been created yet;
+# an empty value makes NotifyService log a warning and send nothing, so the enquiry journey
+# still works without it. Replace with the template id once GOV.UK Notify has it.
+Notify__ResultsEnquirySubmittedTemplateId: ""
 Notify__LinkBaseUrl: https://check-performance-data-development.qa.teacherservices.cloud/
 Notify__UtmSource: qa-check-performance-data
 Notify__UtmMedium: email

--- a/terraform/application/config/review.yml
+++ b/terraform/application/config/review.yml
@@ -8,6 +8,10 @@ Notify__SubmissionNotificationTemplateId: f123aa5f-be65-4a57-8e6e-66b323337095
 Notify__BulkSubmissionNotificationTemplateId: 1a0b1085-f942-49cf-82f3-0270c4339513
 Notify__WithdrawNotificationTemplateId: e8667eed-7b52-42f7-a7e6-875b470e31c7
 Notify__DlqThresholdTemplateId: 517c069b-1566-473d-b8ad-8167f05ce723
+# AB#296648: the 16-19 results-enquiry confirmation. The template has not been created yet;
+# an empty value makes NotifyService log a warning and send nothing, so the enquiry journey
+# still works without it. Replace with the template id once GOV.UK Notify has it.
+Notify__ResultsEnquirySubmittedTemplateId: ""
 Notify__LinkBaseUrl: https://check-performance-data-development.test.teacherservices.cloud/
 Notify__UtmSource: dev-check-performance-data
 Notify__UtmMedium: email

--- a/tests/DfE.CheckPerformanceData.E2ETests/Journey/IncorrectGradeEnquiryTests.cs
+++ b/tests/DfE.CheckPerformanceData.E2ETests/Journey/IncorrectGradeEnquiryTests.cs
@@ -1,0 +1,356 @@
+using DfE.CheckPerformanceData.E2ETests.Fixtures;
+using DfE.CheckPerformanceData.E2ETests.Helpers;
+using Microsoft.Playwright;
+using xRetry;
+
+namespace DfE.CheckPerformanceData.E2ETests.Journey;
+
+// AB#296648: the 16-19 "report an incorrect grade" journey, driven through a real browser.
+//
+// These cover what only a browser can: that the accessible-autocomplete enhancement of the result and
+// grade pickers actually works (both are server-rendered <select>s upgraded in place), that the
+// journey holds together across every redirect, and that starting a second enquiry genuinely carries
+// nothing over.
+//
+// The seed (SeedStudentResults) deliberately writes no 16to19_LR2 rows, so the late-results
+// interstitial is on the happy path locally.
+[Collection("E2E")]
+public sealed class IncorrectGradeEnquiryTests(PlaywrightFixture fixture) : SeedingPageTest(fixture)
+{
+    // The seeded Post16 window (DevDataSeeder.Post16CheckingWindowId).
+    private static readonly Guid WindowId = Guid.Parse("6C2E1F4A-9B7D-4E38-8A15-3D9C2B4E7F01");
+
+    // Kingsmead's first seeded Post16 student, and the results SeedStudentResults gives them.
+    private const string StudentCypmdId = "500001";
+    private const string StudentName = "Alice Smith";
+    private const string BusStudsS2024 = "GCSE (9-1) Bus. Studs:Single, QAN: 6037116X, Session: S2024";
+    private const string BusStudsCurrentGrade = "5";
+
+    // ── The cohort-wide happy path, end to end ───────────────────────────────
+
+    [RetryFact(3)]
+    public async Task CohortWide_HappyPath_SubmitsAndShowsAReference()
+    {
+        await StartEnquiryAsync();
+
+        // The interstitial is shown because the seed holds no second-late-results rows.
+        await Expect(Page.GetByRole(AriaRole.Heading, new() { Level = 1 })).ToContainTextAsync(
+            "Check your second late results file before you report an incorrect grade");
+        await ContinueAsync();
+
+        await ChooseCohortScopeAsync("yes");
+        await FillCohortCountAsync("10");
+        await ChooseStudentAsync("select-student-cohort");
+        await ChooseResultAsync(BusStudsS2024);
+        await ChooseRevisedGradeAsync("1");
+        await FillAdditionalInfoAsync("The whole class was marked against the wrong paper.");
+
+        // Check answers.
+        await Expect(Page.GetByRole(AriaRole.Heading, new() { Level = 1 }))
+            .ToContainTextAsync($"Summary of result enquiry for {StudentName}");
+        var summary = await Page.Locator(".govuk-summary-list").InnerTextAsync();
+        Assert.Contains("Number of students in affected cohort", summary);
+        Assert.Contains("Name of a student in cohort", summary);
+        Assert.Contains("6037116X", summary);
+        Assert.Contains("Incorrect grade", summary);
+
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Submit request" }).ClickAsync();
+
+        await Expect(Page.Locator(".govuk-panel")).ToContainTextAsync("Results enquiry submitted");
+        var reference = await ReadReferenceAsync();
+        Assert.Matches(@"^CYPMD_16to19_RE_[0-9A-F]{7}$", reference);
+    }
+
+    // ── The single-student branch ────────────────────────────────────────────
+
+    [RetryFact(3)]
+    public async Task SingleStudent_Branch_AsksForOneStudentAndSubmits()
+    {
+        await StartEnquiryAsync();
+        await ContinueAsync();
+
+        await ChooseCohortScopeAsync("no");
+
+        // No count page on this branch — straight to the single-student page, with its own heading.
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/pupil-search/select-student-single");
+        await Expect(Page.Locator("label[for='pupil-search']"))
+            .ToContainTextAsync("What is the name of the student with an incorrect grade?");
+
+        await ChooseStudentAsync("select-student-single");
+        await ChooseResultAsync(BusStudsS2024);
+        await ChooseRevisedGradeAsync("2");
+        await FillAdditionalInfoAsync(string.Empty);
+
+        var summary = await Page.Locator(".govuk-summary-list").InnerTextAsync();
+        Assert.Contains("Name of student", summary);
+        Assert.DoesNotContain("Number of students in affected cohort", summary);
+
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Submit request" }).ClickAsync();
+        Assert.Matches(@"^CYPMD_16to19_RE_[0-9A-F]{7}$", await ReadReferenceAsync());
+    }
+
+    // ── Nothing carries over into the next enquiry ───────────────────────────
+
+    [RetryFact(3)]
+    public async Task AfterSubmitting_ReportingAnotherIssue_StartsClean()
+    {
+        await StartEnquiryAsync();
+        await ContinueAsync();
+        await ChooseCohortScopeAsync("yes");
+        await FillCohortCountAsync("10");
+        await ChooseStudentAsync("select-student-cohort");
+        await ChooseResultAsync(BusStudsS2024);
+        await ChooseRevisedGradeAsync("3");
+        await FillAdditionalInfoAsync(string.Empty);
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Submit request" }).ClickAsync();
+        var first = await ReadReferenceAsync();
+
+        await Page.GetByRole(AriaRole.Link, new() { Name = "Report another issue with an exam result" })
+            .ClickAsync();
+
+        // The issue page must be blank: nothing selected.
+        await Page.WaitForURLAsync($"**/{WindowId}/ResultIssue");
+        await Expect(Page.Locator("#issueType")).Not.ToBeCheckedAsync();
+
+        // And continuing in must land on a cohort question with nothing selected either.
+        await Page.Locator("#issueType").CheckAsync(new() { Force = true });
+        await ContinueAsync();
+        await ContinueAsync();
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/page/cohort-scope");
+        Assert.Empty(await Page.Locator("input[name='q_q_cohort_scope']:checked").AllAsync());
+
+        // A second enquiry for the same student and result is allowed, with its own reference.
+        await ChooseCohortScopeAsync("no");
+        await ChooseStudentAsync("select-student-single");
+        await ChooseResultAsync(BusStudsS2024);
+        await ChooseRevisedGradeAsync("4");
+        await FillAdditionalInfoAsync(string.Empty);
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Submit request" }).ClickAsync();
+
+        var second = await ReadReferenceAsync();
+        Assert.Matches(@"^CYPMD_16to19_RE_[0-9A-F]{7}$", second);
+        Assert.NotEqual(first, second);
+    }
+
+    // ── Error states ────────────────────────────────────────────────────────
+
+    [RetryFact(3)]
+    public async Task ContinuingWithoutChoosingAnIssue_ShowsTheError()
+    {
+        await Page.GotoAsync($"{Fixture.BaseUrl}/{WindowId}/ResultIssue");
+        await ContinueAsync();
+
+        await AssertErrorAsync("Select what issue with the results you need to report");
+    }
+
+    [RetryFact(3)]
+    public async Task ContinuingWithoutAnsweringTheCohortQuestion_ShowsTheError()
+    {
+        await StartEnquiryAsync();
+        await ContinueAsync();
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/page/cohort-scope");
+
+        await ContinueAsync();
+
+        await AssertErrorAsync("Select if the incorrect grade affects the whole cohort");
+    }
+
+    [RetryFact(3)]
+    public async Task ANonNumericCohortCount_ShowsTheError()
+    {
+        await StartEnquiryAsync();
+        await ContinueAsync();
+        await ChooseCohortScopeAsync("yes");
+
+        await Page.Locator("#q_q_cohort_count").FillAsync("ten");
+        await ContinueAsync();
+
+        await AssertErrorAsync("Enter how many students have an incorrect grade for this qualification");
+    }
+
+    [RetryFact(3)]
+    public async Task ContinuingWithoutChoosingAResult_ShowsTheTemplatedError()
+    {
+        await StartEnquiryAsync();
+        await ContinueAsync();
+        await ChooseCohortScopeAsync("no");
+        await ChooseStudentAsync("select-student-single");
+
+        await ContinueAsync();
+
+        await AssertErrorAsync($"Enter which of {StudentName}'s results is incorrect");
+    }
+
+    [RetryFact(3)]
+    public async Task ContinuingWithoutChoosingAGrade_ShowsTheError()
+    {
+        await NavigateToGradePageAsync();
+
+        await ContinueAsync();
+
+        await AssertErrorAsync("Select the revised grade");
+    }
+
+    [RetryFact(3)]
+    public async Task ChoosingTheCurrentGrade_ShowsTheMustDifferError()
+    {
+        // The result's current grade is 5, so choosing 5 reports no change.
+        await NavigateToGradePageAsync();
+
+        await SelectGradeAsync(BusStudsCurrentGrade);
+        await ContinueAsync();
+
+        await AssertErrorAsync("The revised grade must be different from the current grade");
+    }
+
+    [RetryFact(3)]
+    public async Task TheGradePickerOffersTheQualificationsOwnScale()
+    {
+        // The GCSE 9-1 scale for this QAN, pass grades before fail grades, with a placeholder first.
+        await NavigateToGradePageAsync();
+
+        var values = await Page.Locator("#q_q_revised_grade option").EvaluateAllAsync<string[]>(
+            "options => options.map(o => o.value)");
+
+        Assert.Equal(["", "9", "8", "7", "6", "5", "4", "3", "2", "1", "U", "X"], values);
+    }
+
+    // ── The way in, and the auth gate ───────────────────────────────────────
+
+    [RetryFact(3)]
+    public async Task TheCheckYourStudentDataPageOffersTheEnquiryOption()
+    {
+        await Page.GotoAsync($"{Fixture.BaseUrl}/CheckYourPupilData/{WindowId}");
+
+        var option = Page.Locator("input[name='SelectedNextStep'][value='ResultsEnquiry']");
+        await Expect(option).ToBeAttachedAsync();
+
+        await option.CheckAsync(new() { Force = true });
+        await ContinueAsync();
+
+        await Page.WaitForURLAsync($"**/{WindowId}/ResultIssue");
+        await Expect(Page.GetByRole(AriaRole.Heading, new() { Level = 1 }))
+            .ToContainTextAsync("What issue with the results do you need to report?");
+    }
+
+    [RetryFact(3)]
+    public async Task AnAnonymousRequestForTheIssuePageIsSentToSignIn()
+    {
+        // TestHttpClients.NoRedirect has UseCookies=false and no impersonation cookie attached, so
+        // this request is genuinely anonymous.
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get, $"{Fixture.BaseUrl}/{WindowId}/ResultIssue");
+
+        var response = await TestHttpClients.NoRedirect.SendAsync(request);
+
+        Assert.Equal(System.Net.HttpStatusCode.Found, response.StatusCode);
+        Assert.Contains("signin.education.gov.uk", response.Headers.Location?.ToString() ?? string.Empty);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private async Task StartEnquiryAsync()
+    {
+        await Page.GotoAsync($"{Fixture.BaseUrl}/{WindowId}/ResultIssue");
+        await Page.Locator("#issueType").CheckAsync(new() { Force = true });
+        await ContinueAsync();
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/page/check-late-results");
+    }
+
+    private async Task NavigateToGradePageAsync()
+    {
+        await StartEnquiryAsync();
+        await ContinueAsync();
+        await ChooseCohortScopeAsync("no");
+        await ChooseStudentAsync("select-student-single");
+        await ChooseResultAsync(BusStudsS2024);
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/page/grade-details");
+    }
+
+    private async Task ChooseCohortScopeAsync(string value)
+    {
+        // By option value, not label, so a copy edit cannot break the test.
+        await Page.Locator($"input[name='q_q_cohort_scope'][value='{value}']").CheckAsync(new() { Force = true });
+        await ContinueAsync();
+    }
+
+    private async Task FillCohortCountAsync(string count)
+    {
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/page/cohort-count");
+        await Page.Locator("#q_q_cohort_count").FillAsync(count);
+        await ContinueAsync();
+    }
+
+    private async Task ChooseStudentAsync(string pageId)
+    {
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/pupil-search/{pageId}");
+        var search = Page.Locator("#pupil-search").First;
+        await Expect(search).ToBeVisibleAsync();
+        await search.FillAsync(StudentCypmdId);
+        var option = Page.Locator("li[role='option']").GetByText(StudentCypmdId);
+        await Expect(option.First).ToBeVisibleAsync();
+        await option.First.ClickAsync();
+        await ContinueAsync();
+    }
+
+    /// <summary>
+    /// Picks a result through the enhanced autocomplete. The control is a server-rendered
+    /// &lt;select&gt; that accessible-autocomplete upgrades in place, so exercising it here is what
+    /// proves the enhancement works — a unit test can only see the select.
+    /// </summary>
+    private async Task ChooseResultAsync(string label)
+    {
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/result-search/select-result");
+        var search = Page.Locator("#result-search").First;
+        await Expect(search).ToBeVisibleAsync();
+        await search.FillAsync("Bus");
+        var option = Page.Locator("li[role='option']").GetByText(label, new() { Exact = false });
+        await Expect(option.First).ToBeVisibleAsync();
+        await option.First.ClickAsync();
+        await ContinueAsync();
+    }
+
+    private async Task ChooseRevisedGradeAsync(string grade)
+    {
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/page/grade-details");
+        await SelectGradeAsync(grade);
+        await ContinueAsync();
+    }
+
+    // The grade picker is also an enhanced select, so the option list lives in the DOM either way;
+    // setting the underlying select keeps this robust whether or not the enhancement has run.
+    private async Task SelectGradeAsync(string grade)
+    {
+        var enhanced = Page.Locator("#q_q_revised_grade-select");
+        var target = await enhanced.CountAsync() > 0 ? enhanced : Page.Locator("#q_q_revised_grade");
+        await target.SelectOptionAsync(grade);
+    }
+
+    private async Task FillAdditionalInfoAsync(string text)
+    {
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/page/additional-info");
+        if (text.Length > 0)
+            await Page.Locator("#q_q_additional_info").FillAsync(text);
+        await ContinueAsync();
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/summary");
+    }
+
+    private async Task<string> ReadReferenceAsync()
+    {
+        await Page.WaitForURLAsync($"**/Journey/{WindowId}/enquiry-confirmation");
+        var panel = await Page.Locator(".govuk-panel").InnerTextAsync();
+        var match = System.Text.RegularExpressions.Regex.Match(panel, @"CYPMD_16to19_RE_[0-9A-F]{7}");
+        Assert.True(match.Success, $"No reference number in the confirmation panel: {panel}");
+        return match.Value;
+    }
+
+    private async Task ContinueAsync() =>
+        await Page.GetByRole(AriaRole.Button, new() { Name = "Continue" }).ClickAsync();
+
+    private async Task AssertErrorAsync(string expected)
+    {
+        await Expect(Page.Locator(".govuk-error-summary")).ToBeVisibleAsync();
+        var text = await Page.Locator(".govuk-error-summary").InnerTextAsync();
+        Assert.Contains(expected, text);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/ResultsEnquiry/GradeReferenceBlobClientTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/ResultsEnquiry/GradeReferenceBlobClientTests.cs
@@ -1,0 +1,173 @@
+using Azure.Storage.Blobs;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Infrastructure.BlobStorage;
+using DfE.CheckPerformanceData.Infrastructure.RulesEngine;
+using DfE.CheckPerformanceData.IntegrationTests.Fixtures;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace DfE.CheckPerformanceData.IntegrationTests.ResultsEnquiry;
+
+// AB#297130: the grade reference against real blob storage — the read, the seed-if-missing guard
+// that must never clobber a loaded AODC export, and the caching that keeps every details-page render
+// from re-downloading a document that changes once a year.
+[Collection(nameof(AzuriteCollection))]
+public sealed class GradeReferenceBlobClientTests(AzuriteFixture azurite)
+{
+    private const string SeedJson = """
+    {
+      "60370683": {
+        "qan": "60370683",
+        "qualificationTitle": "Pearson BTEC L1/L2 Tech Award in Sport",
+        "awardingOrganisation": "Pearson",
+        "passGrades": ["*2", "P1", "P2", "M1", "M2", "D1", "D2"],
+        "failGrades": ["F", "Q", "R", "U", "X"]
+      }
+    }
+    """;
+
+    private const string ReplacementJson = """
+    {
+      "99999999": {
+        "qan": "99999999",
+        "qualificationTitle": "Loaded from the real AODC export",
+        "awardingOrganisation": "AODC",
+        "passGrades": ["A"],
+        "failGrades": ["U"]
+      }
+    }
+    """;
+
+    // Each test gets its own container so the shared Azurite instance stays test-independent.
+    private (GradeReferenceBlobClient Client, BlobServiceClient Service, string Container) NewClient(
+        IMemoryCache? cache = null)
+    {
+        var container = $"rules-config-{Guid.NewGuid():N}";
+        var service = new BlobServiceClient(azurite.ConnectionString);
+        var options = Options.Create(new BlobRulesProviderOptions { RulesBlobContainer = container });
+        var client = new GradeReferenceBlobClient(
+            service,
+            cache ?? new MemoryCache(new MemoryCacheOptions()),
+            options,
+            NullLogger<GradeReferenceBlobClient>.Instance);
+        return (client, service, container);
+    }
+
+    [Fact]
+    public async Task Seeds_the_document_and_reads_it_back()
+    {
+        var (client, _, _) = NewClient();
+
+        await client.SeedIfMissingAsync(SeedJson);
+        var reference = await client.GetByQanAsync("60370683");
+
+        Assert.NotNull(reference);
+        Assert.Equal("Pearson BTEC L1/L2 Tech Award in Sport", reference.QualificationTitle);
+        Assert.Equal(
+            ["*2", "P1", "P2", "M1", "M2", "D1", "D2", "F", "Q", "R", "U", "X"],
+            reference.AllGrades.ToArray());
+    }
+
+    [Fact]
+    public async Task Seeds_into_the_configured_container_under_the_expected_blob_name()
+    {
+        var (client, service, container) = NewClient();
+
+        await client.SeedIfMissingAsync(SeedJson);
+
+        var blob = service.GetBlobContainerClient(container).GetBlobClient("grade-reference.json");
+        Assert.True(await blob.ExistsAsync());
+    }
+
+    [Fact]
+    public async Task Seeding_never_overwrites_an_existing_document()
+    {
+        // Once an environment has the real AODC export loaded, redeploying an older bundled copy
+        // must not undo it. This is the whole point of the If-None-Match guard.
+        var (client, _, _) = NewClient();
+        await client.SeedIfMissingAsync(ReplacementJson);
+
+        await client.SeedIfMissingAsync(SeedJson);
+
+        Assert.NotNull(await client.GetByQanAsync("99999999"));
+        Assert.Null(await client.GetByQanAsync("60370683"));
+    }
+
+    [Fact]
+    public async Task Seeding_twice_does_not_throw()
+    {
+        var (client, _, _) = NewClient();
+
+        await client.SeedIfMissingAsync(SeedJson);
+        await client.SeedIfMissingAsync(SeedJson);
+
+        Assert.NotNull(await client.GetByQanAsync("60370683"));
+    }
+
+    [Fact]
+    public async Task A_missing_document_reads_as_no_grades_rather_than_throwing()
+    {
+        // The details page must degrade to "we cannot list grades yet", not 500.
+        var (client, _, _) = NewClient();
+
+        Assert.Null(await client.GetByQanAsync("60370683"));
+    }
+
+    [Fact]
+    public async Task A_missing_container_reads_as_no_grades_rather_than_throwing()
+    {
+        var (client, _, _) = NewClient();
+
+        Assert.Null(await client.GetByQanAsync("anything"));
+    }
+
+    [Fact]
+    public async Task An_unknown_qan_returns_null()
+    {
+        var (client, _, _) = NewClient();
+        await client.SeedIfMissingAsync(SeedJson);
+
+        Assert.Null(await client.GetByQanAsync("00000000"));
+    }
+
+    [Fact]
+    public async Task The_document_is_downloaded_once_and_then_served_from_cache()
+    {
+        var (client, service, container) = NewClient();
+        await client.SeedIfMissingAsync(SeedJson);
+        Assert.NotNull(await client.GetByQanAsync("60370683"));
+
+        // Overwriting out-of-band and still seeing the old content proves the second read never
+        // went to storage.
+        await service.GetBlobContainerClient(container).GetBlobClient("grade-reference.json")
+            .UploadAsync(BinaryData.FromString(ReplacementJson), overwrite: true);
+
+        Assert.NotNull(await client.GetByQanAsync("60370683"));
+        Assert.Null(await client.GetByQanAsync("99999999"));
+    }
+
+    [Fact]
+    public async Task Seeding_invalidates_a_cached_empty_lookup()
+    {
+        // Startup order matters: if anything reads the reference before the seeder runs, the empty
+        // result must not stick around for five minutes and leave every picker blank.
+        var (client, _, _) = NewClient();
+        Assert.Null(await client.GetByQanAsync("60370683"));
+
+        await client.SeedIfMissingAsync(SeedJson);
+
+        Assert.NotNull(await client.GetByQanAsync("60370683"));
+    }
+
+    [Fact]
+    public async Task Malformed_stored_json_throws_so_a_corrupt_reference_file_surfaces()
+    {
+        var (client, service, container) = NewClient();
+        var containerClient = service.GetBlobContainerClient(container);
+        await containerClient.CreateAsync();
+        await containerClient.UploadBlobAsync("grade-reference.json", BinaryData.FromString("{not json"));
+
+        await Assert.ThrowsAnyAsync<System.Text.Json.JsonException>(() => client.GetByQanAsync("60370683"));
+    }
+}

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/ResultsEnquiry/ResultsEnquirySubmissionTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/ResultsEnquiry/ResultsEnquirySubmissionTests.cs
@@ -1,0 +1,365 @@
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.LandingPage;
+using DfE.CheckPerformanceData.Application.Notify;
+using DfE.CheckPerformanceData.Application.Queue;
+using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Domain.Enums;
+using DfE.CheckPerformanceData.IntegrationTests.Fixtures;
+using DfE.CheckPerformanceData.Persistence.Entities;
+using DfE.CheckPerformanceData.Persistence.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.IntegrationTests.ResultsEnquiry;
+
+// AB#296648: submitting a results enquiry against a real Postgres.
+//
+// The unit tests pin what the service ASKS the repository to do; these pin what actually lands in the
+// database — in particular that RequestType and AmendmentType round-trip as their readable enum names
+// through the HasConversion<string>() columns. "ResultsEnquiry" (14) and "IncorrectGrade" (14) fit the
+// 20-character columns, which is why this ticket needed no migration; a regression there would be a
+// truncation error at submit time and nowhere earlier.
+[Collection(nameof(PostgresCollection))]
+public sealed class ResultsEnquirySubmissionTests(PostgresFixture fixture)
+{
+    private readonly PostgresFixture _fixture = fixture;
+
+    private static readonly Guid UserId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    private static readonly Guid PupilId = Guid.Parse("55555555-5555-5555-5555-555555555555");
+
+    private sealed class InMemoryRequestStateBlobClient : IRequestStateBlobClient
+    {
+        public Dictionary<(Guid, string), RequestState> Saved { get; } = [];
+
+        public Task SaveAsync(Guid windowId, string referenceNumber, RequestState state)
+        {
+            // Round-tripped through JSON so the test sees exactly what a real blob would return —
+            // a property the journey state cannot serialise would otherwise go unnoticed.
+            var json = System.Text.Json.JsonSerializer.Serialize(state);
+            Saved[(windowId, referenceNumber)] =
+                System.Text.Json.JsonSerializer.Deserialize<RequestState>(json)!;
+            return Task.CompletedTask;
+        }
+
+        public Task<RequestState?> GetAsync(Guid windowId, string referenceNumber) =>
+            Task.FromResult(Saved.TryGetValue((windowId, referenceNumber), out var s) ? s : null);
+
+        public Task DeleteAsync(Guid windowId, string referenceNumber)
+        {
+            Saved.Remove((windowId, referenceNumber));
+            return Task.CompletedTask;
+        }
+    }
+
+    private (RequestService Service, InMemoryRequestStateBlobClient Blob, IQueueService Queue) BuildService()
+    {
+        var currentUser = Substitute.For<ICurrentUserService>();
+        currentUser.UserId.Returns(UserId.ToString());
+        currentUser.OrganisationUrn.Returns("142313");
+        currentUser.OrganisationLaestab.Returns("860/4070");
+        currentUser.DisplayName.Returns("Ada Editor");
+        currentUser.Email.Returns("ada@school.test");
+
+        var blob = new InMemoryRequestStateBlobClient();
+        var queue = Substitute.For<IQueueService>();
+
+        var service = new RequestService(
+            Substitute.For<IQuestionFlowService>(),
+            blob,
+            new RequestRepository(_fixture.CreateContext()),
+            currentUser,
+            NullLogger<RequestService>.Instance,
+            queue,
+            Substitute.For<IRequestNotificationService>(),
+            Substitute.For<ICheckYourPupilDataService>());
+
+        return (service, blob, queue);
+    }
+
+    private static RequestState Journey(Guid windowId, string reference, bool cohortWide = true) => new()
+    {
+        SelectedWhatToChange = WhatToChange.IncorrectGrade,
+        CheckingWindow = new CheckingWindowDto
+        {
+            Title = "16 to 19 2026", KeyStage = KeyStages.Post16,
+            CheckingWindowType = CheckingWindowType.Post16,
+            StartDate = new DateTime(2026, 10, 1), EndDate = new DateTime(2027, 3, 31)
+        },
+        ReferenceNumber = reference,
+        SelectedPupilId = PupilId.ToString(),
+        SelectedPupil = new PupilDto
+        {
+            Id = PupilId, Firstname = "Billy", Surname = "B", Sex = "M",
+            DateOfBirth = "12/03/2007", Age = 19, Cypmd_Id = "1596410810", Identifier = "9900000001"
+        },
+        SelectedResult = new StudentResultRecord
+        {
+            CypmdId = "1596410810", Qan = "60180882",
+            QualificationName = "GCSE (9-1) Art&Des : Fine Art", SyllabusCode = "1AD0",
+            Session = "S2024", Grade = "9", SourceFile = ResultsFileTags.Post16Main
+        },
+        QuestionAnswers = new Dictionary<string, QuestionAnswer>
+        {
+            ["q-cohort-scope"] = new() { TextValue = cohortWide ? "yes" : "no" },
+            ["q-cohort-count"] = new() { TextValue = cohortWide ? "10" : null },
+            ["q-revised-grade"] = new() { TextValue = "U" },
+            ["q-additional-info"] = new() { TextValue = "Marked against the wrong paper." }
+        },
+        QuestionHistory = ["cohort-scope", "cohort-count", "select-student-cohort", "select-result", "grade-details", "additional-info"]
+    };
+
+    [Fact]
+    public async Task An_enquiry_is_persisted_as_a_results_enquiry_row()
+    {
+        await TruncateAsync();
+        var windowId = await SeedPost16WindowAsync();
+        var (service, _, _) = BuildService();
+
+        var reference = await service.SubmitResultsEnquiryAsync(windowId, Journey(windowId, "CYPMD_16to19_RE_AAAAAA1"));
+
+        Assert.Equal("CYPMD_16to19_RE_AAAAAA1", reference);
+        await using var ctx = _fixture.CreateContext();
+        var row = await ctx.ChangeRequests.SingleAsync(r => r.ReferenceNumber == reference);
+        Assert.Equal(RequestType.ResultsEnquiry, row.RequestType);
+        Assert.Equal(WhatToChange.IncorrectGrade, row.AmendmentType);
+        Assert.Equal(RequestStatus.SubmittedUnCommitted, row.Status);
+        Assert.Equal("Results enquiry - Incorrect grade", row.RequestTypeDescription);
+        Assert.Equal(PupilId, row.PupilId);
+        Assert.Equal("Billy", row.PupilFirstname);
+        Assert.Equal(142313L, row.OrganisationUrn);
+    }
+
+    [Fact]
+    public async Task The_enum_columns_hold_readable_names_not_ordinals()
+    {
+        // Both columns are HasConversion<string>() and capped at 20 characters. This is the assertion
+        // that proves no migration was needed.
+        await TruncateAsync();
+        var windowId = await SeedPost16WindowAsync();
+        var (service, _, _) = BuildService();
+
+        await service.SubmitResultsEnquiryAsync(windowId, Journey(windowId, "CYPMD_16to19_RE_BBBBBB2"));
+
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            @"SELECT ""RequestType"", ""AmendmentType"" FROM ""ChangeRequests""
+              WHERE ""ReferenceNumber"" = 'CYPMD_16to19_RE_BBBBBB2';";
+        await using var reader = await cmd.ExecuteReaderAsync();
+        Assert.True(await reader.ReadAsync());
+        Assert.Equal("ResultsEnquiry", reader.GetString(0));
+        Assert.Equal("IncorrectGrade", reader.GetString(1));
+    }
+
+    [Fact]
+    public async Task The_journey_json_round_trips_with_the_selected_result_and_answers()
+    {
+        await TruncateAsync();
+        var windowId = await SeedPost16WindowAsync();
+        var (service, blob, _) = BuildService();
+
+        await service.SubmitResultsEnquiryAsync(windowId, Journey(windowId, "CYPMD_16to19_RE_CCCCCC3"));
+
+        var saved = await blob.GetAsync(windowId, "CYPMD_16to19_RE_CCCCCC3");
+        Assert.NotNull(saved);
+        Assert.Equal(WhatToChange.IncorrectGrade, saved.SelectedWhatToChange);
+        Assert.NotNull(saved.SelectedResult);
+        Assert.Equal("60180882", saved.SelectedResult.Qan);
+        Assert.Equal("9", saved.SelectedResult.Grade);
+        Assert.Equal("S2024", saved.SelectedResult.Session);
+        Assert.Equal("GCSE (9-1) Art&Des : Fine Art", saved.SelectedResult.QualificationName);
+        Assert.Equal("U", saved.QuestionAnswers["q-revised-grade"].TextValue);
+        Assert.Equal("10", saved.QuestionAnswers["q-cohort-count"].TextValue);
+        Assert.Equal("Marked against the wrong paper.", saved.QuestionAnswers["q-additional-info"].TextValue);
+    }
+
+    [Fact]
+    public async Task Nothing_is_enqueued()
+    {
+        // BA decision 2026-08-17: Zendesk dispatch is a separate story.
+        await TruncateAsync();
+        var windowId = await SeedPost16WindowAsync();
+        var (service, _, queue) = BuildService();
+
+        await service.SubmitResultsEnquiryAsync(windowId, Journey(windowId, "CYPMD_16to19_RE_DDDDDD4"));
+
+        await queue.DidNotReceiveWithAnyArgs().EnqueueAsync<object>(default!, default!);
+    }
+
+    [Fact]
+    public async Task A_second_enquiry_for_the_same_pupil_and_result_also_persists()
+    {
+        // "The spec allows multiple enquiries per pupil/result; the docs never restrict."
+        await TruncateAsync();
+        var windowId = await SeedPost16WindowAsync();
+        var (service, _, _) = BuildService();
+
+        await service.SubmitResultsEnquiryAsync(windowId, Journey(windowId, "CYPMD_16to19_RE_EEEEEE5"));
+        await service.SubmitResultsEnquiryAsync(windowId, Journey(windowId, "CYPMD_16to19_RE_FFFFFF6"));
+
+        await using var ctx = _fixture.CreateContext();
+        var rows = await ctx.ChangeRequests
+            .Where(r => r.RequestType == RequestType.ResultsEnquiry)
+            .ToListAsync();
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(2, rows.Select(r => r.ReferenceNumber).Distinct().Count());
+        Assert.All(rows, r => Assert.Equal(PupilId, r.PupilId));
+    }
+
+    [Fact]
+    public async Task An_enquiry_does_not_block_a_pupil_data_amendment_for_the_same_pupil()
+    {
+        // The duplicate rule exists to stop two competing amendments to one pupil's record. An
+        // enquiry does not change pupil data, so it must not consume that slot — otherwise a school
+        // that reports a wrong grade for Billy can no longer ask to remove Billy, and gets a
+        // duplicate-request error naming an enquiry that has nothing to do with it.
+        await TruncateAsync();
+        var windowId = await SeedPost16WindowAsync();
+        var (service, _, _) = BuildService();
+        await service.SubmitResultsEnquiryAsync(windowId, Journey(windowId, "CYPMD_16to19_RE_9999999"));
+
+        await new RequestRepository(_fixture.CreateContext()).UpsertAsync(new ChangeRequestData
+        {
+            WindowId = windowId,
+            ReferenceNumber = "CYPMD_Post16_AMEND01",
+            OrganisationUrn = 142313,
+            PupilId = PupilId,
+            PupilFirstname = "Billy",
+            PupilSurname = "B",
+            Timestamp = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
+            SubmittedById = UserId,
+            SubmittedByName = "Ada Editor",
+            Status = RequestStatus.SubmittedUnCommitted,
+            RequestType = RequestType.Amendment,
+            RequestTypeDescription = "Remove - not-on-roll",
+            AmendmentType = WhatToChange.Remove
+        });
+
+        await using var ctx = _fixture.CreateContext();
+        Assert.Equal(2, await ctx.ChangeRequests.CountAsync(r => r.PupilId == PupilId));
+    }
+
+    [Fact]
+    public async Task An_existing_amendment_does_not_block_an_enquiry_for_the_same_pupil()
+    {
+        // The other direction. A school mid-way through a removal request must still be able to
+        // report a wrong grade for the same student.
+        await TruncateAsync();
+        var windowId = await SeedPost16WindowAsync();
+        await new RequestRepository(_fixture.CreateContext()).UpsertAsync(new ChangeRequestData
+        {
+            WindowId = windowId,
+            ReferenceNumber = "CYPMD_Post16_AMEND02",
+            OrganisationUrn = 142313,
+            PupilId = PupilId,
+            PupilFirstname = "Billy",
+            PupilSurname = "B",
+            Timestamp = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
+            SubmittedById = UserId,
+            SubmittedByName = "Ada Editor",
+            Status = RequestStatus.SubmittedUnCommitted,
+            RequestType = RequestType.Amendment,
+            RequestTypeDescription = "Remove - not-on-roll",
+            AmendmentType = WhatToChange.Remove
+        });
+        var (service, _, _) = BuildService();
+
+        await service.SubmitResultsEnquiryAsync(windowId, Journey(windowId, "CYPMD_16to19_RE_ABCDEF1"));
+
+        await using var ctx = _fixture.CreateContext();
+        Assert.Equal(2, await ctx.ChangeRequests.CountAsync(r => r.PupilId == PupilId));
+    }
+
+    [Fact]
+    public async Task Two_competing_amendments_for_one_pupil_are_still_blocked()
+    {
+        // The rule the exclusion must not weaken.
+        await TruncateAsync();
+        var windowId = await SeedPost16WindowAsync();
+
+        ChangeRequestData Amendment(string reference) => new()
+        {
+            WindowId = windowId,
+            ReferenceNumber = reference,
+            OrganisationUrn = 142313,
+            PupilId = PupilId,
+            PupilFirstname = "Billy",
+            PupilSurname = "B",
+            Timestamp = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
+            SubmittedById = UserId,
+            SubmittedByName = "Ada Editor",
+            Status = RequestStatus.SubmittedUnCommitted,
+            RequestType = RequestType.Amendment,
+            RequestTypeDescription = "Remove - not-on-roll",
+            AmendmentType = WhatToChange.Remove
+        };
+
+        await new RequestRepository(_fixture.CreateContext()).UpsertAsync(Amendment("CYPMD_Post16_AMEND03"));
+
+        await Assert.ThrowsAsync<DuplicateRequestException>(() =>
+            new RequestRepository(_fixture.CreateContext()).UpsertAsync(Amendment("CYPMD_Post16_AMEND04")));
+    }
+
+    [Fact]
+    public async Task The_single_pupil_branch_persists_without_a_cohort_count()
+    {
+        await TruncateAsync();
+        var windowId = await SeedPost16WindowAsync();
+        var (service, blob, _) = BuildService();
+
+        await service.SubmitResultsEnquiryAsync(
+            windowId, Journey(windowId, "CYPMD_16to19_RE_7777777", cohortWide: false));
+
+        var saved = await blob.GetAsync(windowId, "CYPMD_16to19_RE_7777777");
+        Assert.NotNull(saved);
+        Assert.Equal("no", saved.QuestionAnswers["q-cohort-scope"].TextValue);
+        Assert.Null(saved.QuestionAnswers["q-cohort-count"].TextValue);
+    }
+
+    [Fact]
+    public async Task The_submitted_timestamp_is_stored()
+    {
+        await TruncateAsync();
+        var windowId = await SeedPost16WindowAsync();
+        var (service, _, _) = BuildService();
+        var before = DateTime.UtcNow.AddSeconds(-5);
+
+        await service.SubmitResultsEnquiryAsync(windowId, Journey(windowId, "CYPMD_16to19_RE_8888888"));
+
+        await using var ctx = _fixture.CreateContext();
+        var row = await ctx.ChangeRequests.SingleAsync(r => r.ReferenceNumber == "CYPMD_16to19_RE_8888888");
+        Assert.True(row.Submitted >= before, $"Submitted {row.Submitted} should be at or after {before}.");
+    }
+
+    private async Task TruncateAsync()
+    {
+        await using var conn = new NpgsqlConnection(_fixture.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"TRUNCATE ""ChangeRequests"" CASCADE;";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<Guid> SeedPost16WindowAsync()
+    {
+        await using var ctx = _fixture.CreateContext();
+        var window = new CheckingWindow
+        {
+            Id = Guid.NewGuid(),
+            Title = "16 to 19 2026",
+            KeyStage = KeyStages.Post16,
+            CheckingWindowType = CheckingWindowType.Post16,
+            StartDate = DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(-10), DateTimeKind.Unspecified),
+            EndDate = DateTime.SpecifyKind(DateTime.UtcNow.Date.AddDays(20), DateTimeKind.Unspecified)
+        };
+        ctx.CheckingWindows.Add(window);
+        await ctx.SaveChangesAsync();
+        return window.Id;
+    }
+}

--- a/tests/DfE.CheckPerformanceData.IntegrationTests/ResultsEnquiry/StudentResultsBlobClientTests.cs
+++ b/tests/DfE.CheckPerformanceData.IntegrationTests/ResultsEnquiry/StudentResultsBlobClientTests.cs
@@ -1,0 +1,197 @@
+using Azure.Storage.Blobs;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Infrastructure.BlobStorage;
+using DfE.CheckPerformanceData.IntegrationTests.Fixtures;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace DfE.CheckPerformanceData.IntegrationTests.ResultsEnquiry;
+
+// AB#296648: the results blob client against real blob storage — the blob path (activity-scoped
+// per docs/16-19-window-model.md), the per-student filter, the source-tag probe that drives late
+// results availability, and the caching that keeps a journey from re-downloading the file on
+// every page.
+[Collection(nameof(AzuriteCollection))]
+public sealed class StudentResultsBlobClientTests(AzuriteFixture azurite)
+{
+    private const string Laestab = "8604070";
+
+    private const string ResultsJson = """
+    [
+      { "CYPMD_ID": "1606464434", "QAN": "6037116X", "QUAL_NAME": "GCSE (9-1) Bus. Studs:Single",
+        "SYLLABUS": "1BS0", "SESSION": "S2024", "GRADE": "5", "SOURCE": "16to19_MAIN" },
+      { "CYPMD_ID": "1606464434", "QAN": "60181576", "QUAL_NAME": "GCSE (9-1) French",
+        "SYLLABUS": "1FR0", "SESSION": "S2024", "GRADE": "7", "SOURCE": "16to19_LR1" },
+      { "CYPMD_ID": "9999999999", "QAN": "60180882", "QUAL_NAME": "GCSE (9-1) Art&Des : Fine Art",
+        "SYLLABUS": "1AD0", "SESSION": "S2024", "GRADE": "9", "SOURCE": "16to19_MAIN" }
+    ]
+    """;
+
+    private static StudentResultsBlobClient NewClient(BlobServiceClient service)
+        => new(service, new MemoryCache(new MemoryCacheOptions()));
+
+    private async Task<(Guid WindowId, BlobServiceClient Service)> SeededWindowAsync(string json = ResultsJson)
+    {
+        var windowId = Guid.NewGuid();
+        var service = new BlobServiceClient(azurite.ConnectionString);
+        var container = service.GetBlobContainerClient(windowId.ToString());
+        await container.CreateAsync();
+        await container.UploadBlobAsync(
+            ResultsEnquiryBlobPaths.ResultsBlobName(Laestab), BinaryData.FromString(json));
+        return (windowId, service);
+    }
+
+    [Fact]
+    public async Task GetResultsAsync_returns_only_the_requested_students_results()
+    {
+        var (windowId, service) = await SeededWindowAsync();
+
+        var results = await NewClient(service).GetResultsAsync(windowId, Laestab, "1606464434");
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(["6037116X", "60181576"], results.Select(r => r.Qan).ToArray());
+        Assert.All(results, r => Assert.Equal("1606464434", r.CypmdId));
+    }
+
+    [Fact]
+    public async Task GetResultsAsync_reads_the_activity_scoped_blob_path()
+    {
+        // Pinning the path proves the reader and the (future) per-activity ingress agree.
+        var (windowId, service) = await SeededWindowAsync();
+        var blob = service.GetBlobContainerClient(windowId.ToString())
+            .GetBlobClient("results-enquiry/data/8604070_results.json");
+
+        Assert.True(await blob.ExistsAsync());
+        Assert.NotEmpty(await NewClient(service).GetResultsAsync(windowId, Laestab, "1606464434"));
+    }
+
+    [Fact]
+    public async Task GetResultsAsync_normalises_a_laestab_that_is_not_digits_only()
+    {
+        var (windowId, service) = await SeededWindowAsync();
+
+        var results = await NewClient(service).GetResultsAsync(windowId, "860/4070", "1606464434");
+
+        Assert.Equal(2, results.Count);
+    }
+
+    [Fact]
+    public async Task GetResultsAsync_unknown_student_returns_empty()
+    {
+        var (windowId, service) = await SeededWindowAsync();
+
+        Assert.Empty(await NewClient(service).GetResultsAsync(windowId, Laestab, "0000000000"));
+    }
+
+    [Fact]
+    public async Task GetResultsAsync_missing_container_returns_empty()
+    {
+        var service = new BlobServiceClient(azurite.ConnectionString);
+
+        Assert.Empty(await NewClient(service).GetResultsAsync(Guid.NewGuid(), Laestab, "1606464434"));
+    }
+
+    [Fact]
+    public async Task GetResultsAsync_missing_blob_returns_empty()
+    {
+        var windowId = Guid.NewGuid();
+        var service = new BlobServiceClient(azurite.ConnectionString);
+        await service.GetBlobContainerClient(windowId.ToString()).CreateAsync();
+
+        Assert.Empty(await NewClient(service).GetResultsAsync(windowId, Laestab, "1606464434"));
+    }
+
+    [Fact]
+    public async Task GetResultsAsync_malformed_json_throws_so_a_corrupt_file_surfaces()
+    {
+        var (windowId, service) = await SeededWindowAsync("{not json");
+
+        await Assert.ThrowsAnyAsync<System.Text.Json.JsonException>(
+            () => NewClient(service).GetResultsAsync(windowId, Laestab, "1606464434"));
+    }
+
+    [Theory]
+    [InlineData(ResultsFileTags.Post16Main, true)]
+    [InlineData(ResultsFileTags.Post16LateResults1, true)]
+    [InlineData(ResultsFileTags.Post16LateResults2, false)]
+    [InlineData(ResultsFileTags.Post16Revised, false)]
+    public async Task AnyForSourceAsync_reports_whether_a_source_file_has_landed(string tag, bool expected)
+    {
+        var (windowId, service) = await SeededWindowAsync();
+
+        Assert.Equal(expected, await NewClient(service).AnyForSourceAsync(windowId, Laestab, tag));
+    }
+
+    [Fact]
+    public async Task AnyForSourceAsync_is_not_scoped_to_one_student()
+    {
+        // The Art&Des row belongs to a different student but still proves MAIN has landed.
+        var (windowId, service) = await SeededWindowAsync("""
+        [{ "CYPMD_ID": "9999999999", "QAN": "60180882", "SESSION": "S2024", "GRADE": "9", "SOURCE": "16to19_MAIN" }]
+        """);
+
+        Assert.True(await NewClient(service).AnyForSourceAsync(windowId, Laestab, ResultsFileTags.Post16Main));
+    }
+
+    [Fact]
+    public async Task The_school_file_is_downloaded_once_and_then_served_from_cache()
+    {
+        // A journey reads the results file on the search page, the details page and the summary.
+        // Overwriting the blob and still seeing the old value proves the second read never went
+        // to storage — the same stale-read assertion the pupil cache tests make.
+        var (windowId, service) = await SeededWindowAsync();
+        var client = NewClient(service);
+
+        Assert.Equal(2, (await client.GetResultsAsync(windowId, Laestab, "1606464434")).Count);
+
+        await service.GetBlobContainerClient(windowId.ToString())
+            .GetBlobClient(ResultsEnquiryBlobPaths.ResultsBlobName(Laestab))
+            .UploadAsync(BinaryData.FromString("[]"), overwrite: true);
+
+        Assert.Equal(2, (await client.GetResultsAsync(windowId, Laestab, "1606464434")).Count);
+        // A different client instance has its own cache, so it sees the truth.
+        Assert.Empty(await NewClient(service).GetResultsAsync(windowId, Laestab, "1606464434"));
+    }
+
+    [Fact]
+    public async Task AnyForSourceAsync_shares_the_cached_file_with_GetResultsAsync()
+    {
+        var (windowId, service) = await SeededWindowAsync();
+        var client = NewClient(service);
+
+        await client.GetResultsAsync(windowId, Laestab, "1606464434");
+        await service.GetBlobContainerClient(windowId.ToString())
+            .GetBlobClient(ResultsEnquiryBlobPaths.ResultsBlobName(Laestab))
+            .UploadAsync(BinaryData.FromString("[]"), overwrite: true);
+
+        Assert.True(await client.AnyForSourceAsync(windowId, Laestab, ResultsFileTags.Post16Main));
+    }
+
+    [Fact]
+    public async Task UploadResultsAsync_writes_a_readable_file_and_invalidates_the_cache()
+    {
+        var windowId = Guid.NewGuid();
+        var service = new BlobServiceClient(azurite.ConnectionString);
+        var client = NewClient(service);
+
+        // Prime the cache with the empty state, as dev seeding would after a health-check read.
+        Assert.Empty(await client.GetResultsAsync(windowId, Laestab, "1606464434"));
+
+        await client.UploadResultsAsync(windowId, Laestab, [new StudentResultRecord
+        {
+            CypmdId = "1606464434",
+            Qan = "6037116X",
+            QualificationName = "GCSE (9-1) Bus. Studs:Single",
+            SyllabusCode = "1BS0",
+            Session = "S2024",
+            Grade = "5",
+            SourceFile = ResultsFileTags.Post16Main
+        }]);
+
+        var results = await client.GetResultsAsync(windowId, Laestab, "1606464434");
+
+        var only = Assert.Single(results);
+        Assert.Equal("6037116X", only.Qan);
+        Assert.Equal("5", only.Grade);
+        Assert.Equal(ResultsFileTags.Post16Main, only.SourceFile);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Analytics/ResultsEnquiryEventsTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Analytics/ResultsEnquiryEventsTests.cs
@@ -1,0 +1,155 @@
+using DfE.CheckPerformanceData.Application.Analytics;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Web.Analytics;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Analytics;
+
+// AB#296648: the results-enquiry analytics contract.
+//
+// Two things are pinned. The field and event NAMES, because they become BigQuery columns that reports
+// are written against — a rename is a breaking change downstream, not a refactor. And what is NOT in
+// the payload: house law says no grade, QAN, student name or free text ever leaves as a plain field,
+// and the reference number is always masked.
+public sealed class ResultsEnquiryEventsTests
+{
+    private static ResultsEnquiryStartedEvent Started(bool guidanceShown = true) => new()
+    {
+        EnquiryType = "incorrect-grade",
+        CheckingWindowType = "Post16",
+        LateResultsGuidanceShown = guidanceShown
+    };
+
+    private static ResultsEnquirySubmittedEvent Submitted(bool cohortWide = true) => new()
+    {
+        EnquiryType = "incorrect-grade",
+        CohortWide = cohortWide,
+        CheckingWindowType = "Post16",
+        ReferenceNumber = "CYPMD_16to19_RE_4F9C2A1"
+    };
+
+    // ── Event names ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_event_names_are_snake_case_and_plural_to_match_the_window_model()
+    {
+        // "ResultsEnquiry" (plural) throughout, per docs/16-19-window-model.md.
+        Assert.Equal("results_enquiry_started", Started().EventType);
+        Assert.Equal("results_enquiry_submitted", Submitted().EventType);
+    }
+
+    // ── Started ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_started_event_carries_its_three_fields()
+    {
+        var fields = Started().Fields.ToDictionary(f => f.Name, f => f.Value);
+
+        Assert.Equal("incorrect-grade", fields["enquiry_type"]);
+        Assert.Equal("Post16", fields["checking_window_type"]);
+        Assert.Equal("true", fields["late_results_guidance_shown"]);
+    }
+
+    [Fact]
+    public void The_guidance_flag_is_lowercase_so_it_reads_as_a_boolean_downstream()
+    {
+        // .ToString() on a bool gives "True"; BigQuery consumers expect "true"/"false".
+        Assert.Equal("false", Started(guidanceShown: false).Fields
+            .Single(f => f.Name == "late_results_guidance_shown").Value);
+    }
+
+    [Fact]
+    public void Nothing_in_the_started_event_is_masked_because_nothing_in_it_is_personal()
+        => Assert.All(Started().Fields, f => Assert.False(f.Hidden));
+
+    // ── Submitted ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_submitted_event_carries_its_four_fields()
+    {
+        var fields = Submitted().Fields.ToDictionary(f => f.Name, f => f.Value);
+
+        Assert.Equal("incorrect-grade", fields["enquiry_type"]);
+        Assert.Equal("true", fields["cohort_wide"]);
+        Assert.Equal("Post16", fields["checking_window_type"]);
+        Assert.Equal("CYPMD_16to19_RE_4F9C2A1", fields["reference_number"]);
+    }
+
+    [Fact]
+    public void The_reference_number_is_always_masked()
+    {
+        // House law, pending the DPIA classification. The hash still links started -> submitted.
+        Assert.True(Submitted().Fields.Single(f => f.Name == "reference_number").Hidden);
+    }
+
+    [Fact]
+    public void Only_the_reference_number_is_masked()
+    {
+        var hidden = Submitted().Fields.Where(f => f.Hidden).Select(f => f.Name).ToArray();
+
+        Assert.Equal(["reference_number"], hidden);
+    }
+
+    [Fact]
+    public void The_cohort_flag_reflects_the_branch()
+        => Assert.Equal("false", Submitted(cohortWide: false).Fields
+            .Single(f => f.Name == "cohort_wide").Value);
+
+    // ── What must never appear ───────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("grade")]
+    [InlineData("qan")]
+    [InlineData("pupil")]
+    [InlineData("student")]
+    [InlineData("name")]
+    [InlineData("comment")]
+    [InlineData("additional")]
+    [InlineData("session")]
+    [InlineData("count")]
+    public void No_field_carries_grade_qualification_identity_or_free_text(string forbidden)
+    {
+        // A grade paired with a school and a date is identifying, and the comments box is free text by
+        // definition. cohort_wide is a boolean deliberately, not the count.
+        foreach (var evt in new AnalyticsEvent[] { Started(), Submitted() })
+            Assert.DoesNotContain(forbidden, string.Join(" ", evt.Fields.Select(f => f.Name)));
+    }
+
+    // ── The validation-error taxonomy ────────────────────────────────────────
+
+    [Fact]
+    public void An_unanswered_grade_picker_codes_as_required()
+    {
+        var question = new Question
+        {
+            Id = "q-revised-grade", Type = QuestionType.GradeSelect, Title = "What should the revised grade be?"
+        };
+
+        Assert.Equal("required", ValidationErrorCoding.ForQuestion(question, isAnswered: false));
+    }
+
+    [Fact]
+    public void An_answered_but_rejected_grade_codes_as_a_bad_selection_not_generic_invalid()
+    {
+        // A grade picker is a selection control, so it should code alongside Radio and Autocomplete.
+        // Without an explicit case it fell through to "invalid", which loses the distinction the
+        // taxonomy exists to make.
+        var question = new Question
+        {
+            Id = "q-revised-grade", Type = QuestionType.GradeSelect, Title = "What should the revised grade be?"
+        };
+
+        Assert.Equal("selection_invalid", ValidationErrorCoding.ForQuestion(question, isAnswered: true));
+    }
+
+    [Fact]
+    public void The_existing_question_types_keep_their_codes()
+    {
+        Question Q(QuestionType type) => new() { Id = "q", Type = type, Title = "t" };
+
+        Assert.Equal("bad_date", ValidationErrorCoding.ForQuestion(Q(QuestionType.Date), true));
+        Assert.Equal("too_long", ValidationErrorCoding.ForQuestion(Q(QuestionType.TextArea), true));
+        Assert.Equal("selection_invalid", ValidationErrorCoding.ForQuestion(Q(QuestionType.Radio), true));
+        Assert.Equal("selection_invalid", ValidationErrorCoding.ForQuestion(Q(QuestionType.Autocomplete), true));
+        Assert.Equal("invalid", ValidationErrorCoding.ForQuestion(Q(QuestionType.FreeText), true));
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/CheckYourPupilData/PupilSuggestionFormatTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/CheckYourPupilData/PupilSuggestionFormatTests.cs
@@ -1,0 +1,124 @@
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Domain.Enums;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.CheckYourPupilData;
+
+// AB#297004: the 16-19 pupil search. The suggestion has to carry enough identity for a user to tell
+// apart two pupils with the same name, and has to be findable by everything a school actually knows
+// about a pupil — name, ULN, CYPMD ID or date of birth.
+public sealed class PupilSuggestionFormatTests
+{
+    private static Post16PupilRecord Post16(
+        string firstname = "Billy", string surname = "B", string cypmdId = "500001",
+        string uln = "9900000001", string dob = "2007-03-12 00:00:00.0000000", bool included = true) => new()
+        {
+            Id = Guid.NewGuid(),
+            Firstname = firstname,
+            Surname = surname,
+            Cypmd_Id = cypmdId,
+            Uln = uln,
+            DateOfBirth = dob,
+            Included = included
+        };
+
+    private static PupilRecord Ks4(
+        string firstname = "Jane", string surname = "Smith",
+        string upn = "A8604070001B", string dob = "01/01/2010") => new()
+        {
+            Id = Guid.NewGuid(),
+            Firstname = firstname,
+            Surname = surname,
+            Upn = upn,
+            DateOfBirth = dob,
+            Cypmd_Id = "000001"
+        };
+
+    // ── Label ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_post16_label_carries_forename_surname_and_every_identifier()
+    {
+        // AB#297004 asks for UPN here; 16-19 pupils have a ULN and no UPN, so the label says ULN.
+        // FLAGGED to the BA — the ticket's wording predates that distinction.
+        var label = PupilSuggestionFormat.Label(Post16(), CheckingWindowType.Post16);
+
+        Assert.Equal("Billy, B, (CYPMD ID:500001, ULN:9900000001, DOB:12/03/2007, INCLUDED)", label);
+    }
+
+    [Fact]
+    public void The_post16_label_marks_a_pupil_from_the_non_included_file()
+    {
+        // A pupil missing from the included data can still hold a wrong grade, so both populations
+        // are searchable — and the user has to be able to see which is which.
+        var label = PupilSuggestionFormat.Label(Post16(included: false), CheckingWindowType.Post16);
+
+        Assert.EndsWith("DOB:12/03/2007, NOT INCLUDED)", label);
+    }
+
+    [Fact]
+    public void The_post16_label_normalises_a_supplier_timestamp_date_of_birth()
+    {
+        var label = PupilSuggestionFormat.Label(
+            Post16(dob: "2007-03-12 00:00:00.0000000"), CheckingWindowType.Post16);
+
+        Assert.Contains("DOB:12/03/2007", label);
+    }
+
+    [Theory]
+    [InlineData(CheckingWindowType.KS4June)]
+    public void Other_window_types_keep_the_existing_label(CheckingWindowType windowType)
+    {
+        // The KS4 journeys are live; their suggestion text must not change under this ticket.
+        var label = PupilSuggestionFormat.Label(Ks4(), windowType);
+
+        Assert.Equal("Smith, Jane, 01/01/2010", label);
+    }
+
+    // ── Matching ─────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Bil")]              // forename, partial
+    [InlineData("bil")]              // case-insensitive
+    [InlineData("B")]                // surname
+    [InlineData("500001")]           // CYPMD ID, exact
+    [InlineData("5000")]             // CYPMD ID, prefix
+    [InlineData("9900000001")]       // ULN
+    [InlineData("990")]              // ULN prefix
+    [InlineData("12/03/2007")]       // DOB, as displayed
+    [InlineData("12/03")]            // DOB, partial
+    public void A_post16_pupil_is_found_by_name_identifier_cypmd_id_or_date_of_birth(string query)
+        => Assert.True(PupilSuggestionFormat.Matches(Post16(), query, CheckingWindowType.Post16));
+
+    [Theory]
+    [InlineData("Zeta")]
+    [InlineData("600001")]
+    [InlineData("01/01/2007")]
+    public void A_post16_pupil_that_matches_nothing_is_excluded(string query)
+        => Assert.False(PupilSuggestionFormat.Matches(Post16(), query, CheckingWindowType.Post16));
+
+    [Fact]
+    public void The_date_of_birth_is_matched_in_its_displayed_form_not_the_raw_supplier_form()
+    {
+        // The user types what they see. The raw value is a timestamp nobody would type.
+        var pupil = Post16(dob: "2007-03-12 00:00:00.0000000");
+
+        Assert.True(PupilSuggestionFormat.Matches(pupil, "12/03/2007", CheckingWindowType.Post16));
+        Assert.False(PupilSuggestionFormat.Matches(pupil, "2007-03-12", CheckingWindowType.Post16));
+    }
+
+    [Fact]
+    public void Date_of_birth_matching_is_post16_only_so_ks4_search_behaviour_is_unchanged()
+    {
+        // Widening KS4 search is outside this ticket; keeping it out means no live journey changes.
+        var pupil = Ks4(dob: "01/01/2010");
+
+        Assert.False(PupilSuggestionFormat.Matches(pupil, "01/01/2010", CheckingWindowType.KS4June));
+        Assert.True(PupilSuggestionFormat.Matches(pupil, "Smi", CheckingWindowType.KS4June));
+        Assert.True(PupilSuggestionFormat.Matches(pupil, "A8604070001B", CheckingWindowType.KS4June));
+        Assert.True(PupilSuggestionFormat.Matches(pupil, "000001", CheckingWindowType.KS4June));
+    }
+
+    [Fact]
+    public void A_pupil_with_no_date_of_birth_does_not_throw()
+        => Assert.False(PupilSuggestionFormat.Matches(Post16(dob: string.Empty), "12/03", CheckingWindowType.Post16));
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/EnquiryConfirmationViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/EnquiryConfirmationViewSourceTests.cs
@@ -1,0 +1,78 @@
+using System.Runtime.CompilerServices;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#296648: the confirmation page (Figma p-148581). Every string is pinned — this is where the school
+// gets the reference they will quote to the DfE, so the copy is a contract with the support team as
+// much as with the user.
+public sealed class EnquiryConfirmationViewSourceTests
+{
+    private static string ViewSource() =>
+        File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "DfE.CheckPerformanceData.Web", "Views", "Journey", "EnquiryConfirmation.cshtml"));
+
+    [Fact]
+    public void The_panel_confirms_the_submission_and_shows_the_reference()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("<govuk-panel-title>Results enquiry submitted</govuk-panel-title>", view);
+        Assert.Contains("Your reference number", view);
+        Assert.Contains("<strong>@Model.ReferenceNumber</strong>", view);
+    }
+
+    [Fact]
+    public void The_email_confirmation_sentence_is_pinned()
+        => Assert.Contains(
+            "We have sent you an email to confirm that you have successfully submitted an enquiry.",
+            ViewSource());
+
+    [Fact]
+    public void The_onward_link_starts_a_fresh_enquiry()
+    {
+        // Routing to ResultIssue is what makes "none of my previous answers are carried over" true —
+        // that controller builds a brand-new RequestState.
+        var view = ViewSource();
+
+        Assert.Contains("Report another issue with an exam result", view);
+        Assert.Contains("asp-controller=\"ResultIssue\"", view);
+    }
+
+    [Fact]
+    public void The_what_happens_next_section_is_pinned()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("<h2 class=\"govuk-heading-m\">What happens next</h2>", view);
+        Assert.Contains("After you submit your changes:", view);
+        Assert.Contains("<li>the DfE will review your enquiry</li>", view);
+        Assert.Contains("<li>your performance data will be updated in the Spring, if required</li>", view);
+    }
+
+    [Fact]
+    public void There_is_no_back_link()
+    {
+        // The journey state is cleared on submission, so Back would lead somewhere that no longer
+        // exists — and re-submitting is not something to invite.
+        Assert.DoesNotContain("govuk-back-link", ViewSource());
+    }
+
+    [Fact]
+    public void The_page_title_matches_the_panel()
+        => Assert.Contains("ViewBag.Title = \"Results enquiry submitted\"", ViewSource());
+
+    [Fact]
+    public void The_page_needs_no_javascript()
+        => Assert.DoesNotContain("<script", ViewSource());
+
+    private static string RepoRoot
+    {
+        get
+        {
+            var thisFile = ThisFilePath();
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+        }
+    }
+
+    private static string ThisFilePath([CallerFilePath] string path = "") => path;
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/EnquirySummaryViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/EnquirySummaryViewSourceTests.cs
@@ -1,0 +1,94 @@
+using System.Runtime.CompilerServices;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#296648: the summary page serves both an amendment and a results enquiry. These pin the enquiry
+// branch's copy and — just as importantly — that the amendment branch is still there.
+public sealed class EnquirySummaryViewSourceTests
+{
+    private static string ViewSource() =>
+        File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "DfE.CheckPerformanceData.Web", "Views", "Journey", "Summary.cshtml"));
+
+    [Fact]
+    public void The_enquiry_heading_names_the_student_and_carries_the_check_details_caption()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("<span class=\"govuk-caption-xl\">Check details</span>", view);
+        Assert.Contains("Summary of result enquiry for @Model.PupilName", view);
+    }
+
+    [Fact]
+    public void The_browser_title_does_not_carry_the_student_name()
+    {
+        // ViewBag.Title reaches analytics.
+        var view = ViewSource();
+
+        Assert.Contains("ViewBag.Title = Model.IsResultsEnquiry ? \"Summary of result enquiry\"", view);
+        Assert.DoesNotContain("ViewBag.Title = $\"Summary of result enquiry for", view);
+    }
+
+    [Fact]
+    public void The_amendment_heading_is_unchanged()
+    {
+        // The live KS4 journeys share this view.
+        var view = ViewSource();
+
+        Assert.Contains("<h1 class=\"govuk-heading-xl\">Summary of amendment request</h1>", view);
+        Assert.Contains("Check details for the @Model.WhatToChangeNoun of @Model.PupilName", view);
+    }
+
+    [Fact]
+    public void An_enquiry_offers_no_draft_saving()
+    {
+        // Decided: enquiries have no drafts. The button must be absent rather than present-and-broken.
+        var view = ViewSource();
+
+        var saveIndex = view.IndexOf("Save and continue later", StringComparison.Ordinal);
+        Assert.True(saveIndex > 0, "The amendment journey still needs its draft button.");
+        Assert.Contains("@if (!Model.IsResultsEnquiry)", view);
+    }
+
+    [Fact]
+    public void An_enquiry_can_be_submitted()
+        => Assert.Contains("<govuk-button type=\"submit\">Submit request</govuk-button>", ViewSource());
+
+    [Fact]
+    public void An_enquiry_offers_a_cancel_link_back_to_a_fresh_enquiry()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("Cancel and go back to create a new enquiry", view);
+        Assert.Contains("asp-controller=\"ResultIssue\"", view);
+    }
+
+    [Fact]
+    public void An_enquiry_does_not_render_the_evidence_files_section()
+    {
+        // There is no evidence upload on the enquiry journey, so the section would always be empty.
+        var view = ViewSource();
+
+        var guardIndex = view.IndexOf("@if (!Model.IsResultsEnquiry)", StringComparison.Ordinal);
+        var evidenceIndex = view.IndexOf("_SummaryEvidenceFiles", StringComparison.Ordinal);
+        Assert.True(guardIndex > 0 && evidenceIndex > guardIndex);
+    }
+
+    [Fact]
+    public void The_rows_still_come_from_the_shared_summary_details_partial()
+    {
+        // One renderer for both shapes: only the row data differs, via SummaryViewModel.Lines.
+        Assert.Contains("<partial name=\"_SummaryDetails\" model=\"Model\" />", ViewSource());
+    }
+
+    private static string RepoRoot
+    {
+        get
+        {
+            var thisFile = ThisFilePath();
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+        }
+    }
+
+    private static string ThisFilePath([CallerFilePath] string path = "") => path;
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyBackLinkViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyBackLinkViewSourceTests.cs
@@ -1,0 +1,61 @@
+using System.Runtime.CompilerServices;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// The shared journey Back link. Three things can be behind "Back": the summary, an earlier page in
+// the history, or — on a journey's very first page, where there is no history — the chooser the
+// journey started from. AB#296648 added a second chooser, so that last case is now a branch: an
+// amendment journey began at WhatToChange, a results enquiry at ResultIssue, and sending the user to
+// the wrong one drops them into a different task entirely.
+public sealed class JourneyBackLinkViewSourceTests
+{
+    private static string ViewSource() =>
+        File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "DfE.CheckPerformanceData.Web", "Views", "Journey", "_JourneyBackLink.cshtml"));
+
+    [Fact]
+    public void An_enquiry_first_page_goes_back_to_the_result_issue_chooser()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("WhatToChange.IncorrectGrade", view);
+        Assert.Contains("asp-controller=\"ResultIssue\"", view);
+    }
+
+    [Fact]
+    public void An_amendment_first_page_still_goes_back_to_the_what_to_change_chooser()
+    {
+        // The live KS4 journeys must be unaffected.
+        Assert.Contains("asp-controller=\"WhatToChange\"", ViewSource());
+    }
+
+    [Fact]
+    public void A_page_with_history_uses_the_resolved_action_for_the_previous_page()
+    {
+        // A bool cannot express three routes; pointing at the wrong action 404s.
+        var view = ViewSource();
+
+        Assert.Contains("asp-action=\"@Model.BackPageAction\"", view);
+        Assert.DoesNotContain("BackPageIsPupilSearch ?", view);
+    }
+
+    [Fact]
+    public void Coming_from_the_summary_returns_to_the_summary()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("Model.FromSummary", view);
+        Assert.Contains("asp-action=\"Summary\"", view);
+    }
+
+    private static string RepoRoot
+    {
+        get
+        {
+            var thisFile = ThisFilePath();
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+        }
+    }
+
+    private static string ThisFilePath([CallerFilePath] string path = "") => path;
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerResultDetailsTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerResultDetailsTests.cs
@@ -1,0 +1,430 @@
+using DfE.CheckPerformanceData.Application.Analytics;
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.FileStorage;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.LandingPage;
+using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Domain.Enums;
+using DfE.CheckPerformanceData.Web.Controllers.Journey;
+using DfE.CheckPerformanceData.Web.Session;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#296648 / AB#297130: the "Incorrect grade details" page. Uses the real view-model builder rather
+// than a substitute, because the thing most worth pinning is that the grade options reaching the view
+// come from the AODC reference data for the SELECTED result's QAN — not from the flow config, which
+// cannot know which qualification the user picked.
+public sealed class JourneyControllerResultDetailsTests
+{
+    private static readonly Guid WindowId = Guid.Parse("6C2E1F4A-9B7D-4E38-8A15-3D9C2B4E7F01");
+    private const string Laestab = "860/4070";
+    private const string CypmdId = "500001";
+
+    private readonly IQuestionFlowService _flowService = Substitute.For<IQuestionFlowService>();
+    private readonly IJourneyValidationService _journeyService = new JourneyValidationService();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IOptionVisibilityService _optionVisibility = Substitute.For<IOptionVisibilityService>();
+    private readonly IQuestionOptionalityService _optionality = Substitute.For<IQuestionOptionalityService>();
+    private readonly IGradeReferenceClient _gradeReference = Substitute.For<IGradeReferenceClient>();
+    private readonly DfE.CheckPerformanceData.Application.Notify.IRequestNotificationService _notifications =
+        Substitute.For<DfE.CheckPerformanceData.Application.Notify.IRequestNotificationService>();
+    private readonly IAnalyticsService _analytics = Substitute.For<IAnalyticsService>();
+    private readonly FakeSession _session = new();
+    private readonly DefaultHttpContext _httpContext = new();
+    private readonly JourneyController _sut;
+
+    private static readonly Question RevisedGrade = new()
+    {
+        Id = "q-revised-grade",
+        Type = QuestionType.GradeSelect,
+        Title = "What should the revised grade be?",
+        ValidationFailure = "Select the revised grade"
+    };
+
+    private static readonly JourneyPage GradeDetails = new()
+    {
+        Id = "grade-details",
+        Type = PageType.ResultDetails,
+        Title = "Incorrect grade details",
+        NextPageId = "additional-info",
+        Questions = [RevisedGrade]
+    };
+
+    private static readonly JourneyPage AdditionalInfo = new() { Id = "additional-info" };
+
+    private static readonly QuestionFlowConfig Flow = new()
+    {
+        FirstPageId = "cohort-scope",
+        Pages = [GradeDetails, AdditionalInfo]
+    };
+
+    private static readonly GradeReference Btec = new()
+    {
+        Qan = "60370683",
+        QualificationTitle = "Pearson BTEC L1/L2 Tech Award in Sport",
+        AwardingOrganisation = "Pearson",
+        PassGrades = ["*2", "P1", "P2", "M1", "M2", "D1", "D2"],
+        FailGrades = ["F", "Q", "R", "U", "X"]
+    };
+
+    public JourneyControllerResultDetailsTests()
+    {
+        _currentUser.OrganisationLaestab.Returns(Laestab);
+        _currentUser.OrganisationUrn.Returns("142313");
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16).Returns(Flow);
+        _flowService.GetPage(Flow, "grade-details").Returns(GradeDetails);
+        _flowService.GetPage(Flow, "additional-info").Returns(AdditionalInfo);
+        _flowService.GetNextPageId(Flow, "grade-details", Arg.Any<Dictionary<string, QuestionAnswer>>())
+            .Returns("additional-info");
+        _flowService.GetNavigationGuard(Arg.Any<QuestionFlowConfig>(), Arg.Any<RequestState>(), Arg.Any<string>())
+            .Returns((JourneyNavigation?)null);
+        _optionality.GetConditionallyOptionalQuestionIds(Arg.Any<JourneyPage>(), Arg.Any<JourneyConditionContext>())
+            .Returns(new HashSet<string>());
+        _gradeReference.GetByQanAsync("60370683", Arg.Any<CancellationToken>()).Returns(Btec);
+
+        _httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(_session));
+
+        var builder = new JourneyViewModelBuilder(_flowService, _journeyService, _optionVisibility, _currentUser);
+
+        _sut = new JourneyController(
+            _flowService, _journeyService, Substitute.For<IFileStorageService>(),
+            Substitute.For<IRequestService>(), Substitute.For<ICheckYourPupilDataService>(), builder,
+            _analytics, _currentUser, _optionVisibility, _optionality,
+            Substitute.For<IOriginCountryLanguageCapture>(),
+            Substitute.For<IStudentResultsClient>(), _gradeReference, _notifications,
+            NullLogger<JourneyController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = _httpContext },
+            TempData = new TempDataDictionary(_httpContext, Substitute.For<ITempDataProvider>())
+        };
+    }
+
+    private static StudentResultRecord Result(string qan = "60370683", string grade = "M1") => new()
+    {
+        CypmdId = CypmdId, Qan = qan, QualificationName = "Pearson BTEC L1/L2 Tech Award in Sport",
+        SyllabusCode = "31525H", Session = "S2024", Grade = grade, SourceFile = ResultsFileTags.Post16Main
+    };
+
+    private void Ready(StudentResultRecord? result = null, Dictionary<string, QuestionAnswer>? answers = null)
+        => _session.SetRequestState(WindowId, new RequestState
+        {
+            SelectedWhatToChange = WhatToChange.IncorrectGrade,
+            CheckingWindow = new CheckingWindowDto
+            {
+                Title = "16 to 19", KeyStage = KeyStages.Post16,
+                CheckingWindowType = CheckingWindowType.Post16,
+                StartDate = new DateTime(2026, 10, 1), EndDate = new DateTime(2027, 3, 31)
+            },
+            SelectedPupilId = Guid.NewGuid().ToString(),
+            SelectedPupil = new PupilDto
+            {
+                Id = Guid.NewGuid(), Firstname = "Billy", Surname = "B", Sex = "M",
+                DateOfBirth = "12/03/2007", Age = 19, Cypmd_Id = CypmdId, Identifier = "9900000001"
+            },
+            SelectedResult = result ?? Result(),
+            QuestionAnswers = answers ?? [],
+            QuestionHistory = ["select-result", "grade-details"]
+        });
+
+    private void Post(string? grade)
+    {
+        _httpContext.Request.Form = new FormCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+        {
+            ["q_q_revised_grade"] = grade ?? string.Empty
+        });
+    }
+
+    // ── GET ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Get_renders_the_result_details_view()
+    {
+        Ready();
+
+        var view = Assert.IsType<ViewResult>(await _sut.Page(WindowId, "grade-details"));
+
+        Assert.Equal("ResultDetails", view.ViewName);
+    }
+
+    [Fact]
+    public async Task Get_offers_the_qualifications_own_grades_pass_before_fail()
+    {
+        Ready();
+
+        var view = Assert.IsType<ViewResult>(await _sut.Page(WindowId, "grade-details"));
+        var vm = Assert.IsType<PageViewModel>(view.Model);
+        var options = vm.NonFileUploadModels.Single().VisibleOptions;
+
+        Assert.Equal(
+            ["*2", "P1", "P2", "M1", "M2", "D1", "D2", "F", "Q", "R", "U", "X"],
+            options.Select(o => o.Value).ToArray());
+        Assert.Equal(options.Select(o => o.Value), options.Select(o => o.Label));
+    }
+
+    [Fact]
+    public async Task Get_looks_the_grades_up_by_the_selected_results_qan()
+    {
+        Ready(Result(qan: "10025480"));
+
+        await _sut.Page(WindowId, "grade-details");
+
+        await _gradeReference.Received(1).GetByQanAsync("10025480", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Get_passes_the_selected_result_to_the_view_for_the_summary()
+    {
+        Ready(Result(grade: "D1"));
+
+        var view = Assert.IsType<ViewResult>(await _sut.Page(WindowId, "grade-details"));
+        var vm = Assert.IsType<PageViewModel>(view.Model);
+
+        Assert.NotNull(vm.SelectedResult);
+        Assert.Equal("D1", vm.SelectedResult.Grade);
+        Assert.Equal("Billy B", vm.PupilName);
+    }
+
+    [Fact]
+    public async Task Get_with_no_reference_data_offers_nothing_and_says_so()
+    {
+        // A gap between the results CSVs and the AODC export is a real state — the two come from
+        // different teams. The page must explain it rather than showing an empty control.
+        Ready(Result(qan: "99999999"));
+        _gradeReference.GetByQanAsync("99999999", Arg.Any<CancellationToken>()).Returns((GradeReference?)null);
+
+        var view = Assert.IsType<ViewResult>(await _sut.Page(WindowId, "grade-details"));
+        var qm = Assert.IsType<PageViewModel>(view.Model).NonFileUploadModels.Single();
+
+        Assert.Empty(qm.VisibleOptions);
+        Assert.True(qm.GradeOptionsUnavailable);
+    }
+
+    [Fact]
+    public async Task A_page_without_a_grade_picker_never_reads_the_reference_data()
+    {
+        // Guards against every page in every journey paying for a blob read.
+        Ready();
+
+        await _sut.Page(WindowId, "additional-info");
+
+        await _gradeReference.DidNotReceiveWithAnyArgs().GetByQanAsync(default!);
+    }
+
+    // ── POST ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Post_a_valid_different_grade_continues()
+    {
+        Ready();
+        Post("D1");
+
+        var redirect = Assert.IsType<RedirectToActionResult>(await _sut.PagePost(WindowId, "grade-details", false));
+
+        Assert.Equal("additional-info", redirect.RouteValues!["pageId"]);
+        Assert.Equal("D1", _session.GetRequestState(WindowId).QuestionAnswers["q-revised-grade"].TextValue);
+    }
+
+    [Fact]
+    public async Task Post_nothing_redisplays_the_page_with_the_required_message()
+    {
+        Ready();
+        Post(null);
+
+        var view = Assert.IsType<ViewResult>(await _sut.PagePost(WindowId, "grade-details", false));
+
+        Assert.Equal("ResultDetails", view.ViewName);
+        Assert.Equal("Select the revised grade", _sut.ModelState["q-revised-grade"]!.Errors[0].ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Post_the_current_grade_redisplays_the_page_with_the_must_differ_message()
+    {
+        Ready(Result(grade: "M1"));
+        Post("M1");
+
+        var view = Assert.IsType<ViewResult>(await _sut.PagePost(WindowId, "grade-details", false));
+
+        Assert.Equal("ResultDetails", view.ViewName);
+        Assert.Equal(
+            "The revised grade must be different from the current grade",
+            _sut.ModelState["q-revised-grade"]!.Errors[0].ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Post_a_grade_the_qualification_does_not_offer_is_rejected()
+    {
+        Ready();
+        Post("9");
+
+        var view = Assert.IsType<ViewResult>(await _sut.PagePost(WindowId, "grade-details", false));
+
+        Assert.Equal("ResultDetails", view.ViewName);
+        Assert.Equal("Select the revised grade", _sut.ModelState["q-revised-grade"]!.Errors[0].ErrorMessage);
+        Assert.DoesNotContain("q-revised-grade", _session.GetRequestState(WindowId).QuestionAnswers.Keys);
+    }
+
+    [Fact]
+    public async Task Post_with_no_reference_data_cannot_succeed()
+    {
+        Ready(Result(qan: "99999999"));
+        _gradeReference.GetByQanAsync("99999999", Arg.Any<CancellationToken>()).Returns((GradeReference?)null);
+        Post("M1");
+
+        Assert.IsType<ViewResult>(await _sut.PagePost(WindowId, "grade-details", false));
+    }
+
+    [Fact]
+    public async Task A_rejected_post_still_renders_the_grade_options()
+    {
+        // Without the reference data on the redisplay path the picker would come back empty and the
+        // user would be stuck with an error they cannot clear.
+        Ready();
+        Post("9");
+
+        var view = Assert.IsType<ViewResult>(await _sut.PagePost(WindowId, "grade-details", false));
+        var qm = Assert.IsType<PageViewModel>(view.Model).NonFileUploadModels.Single();
+
+        Assert.Equal(12, qm.VisibleOptions.Count);
+        Assert.False(qm.GradeOptionsUnavailable);
+    }
+
+    [Fact]
+    public async Task A_rejected_post_reports_a_coded_validation_error()
+    {
+        Ready();
+        Post(null);
+
+        await _sut.PagePost(WindowId, "grade-details", false);
+
+        await _analytics.Received(1).TrackSafeAsync(Arg.Is<ValidationErrorEvent>(e =>
+            e.ErrorFields.Contains("q-revised-grade")));
+    }
+
+    [Fact]
+    public async Task Prefix_sharing_grades_are_accepted_as_a_real_change()
+    {
+        // The IB Diploma case: 24F is a fail, 24D is a pass.
+        var ib = new GradeReference
+        {
+            Qan = "50034157", QualificationTitle = "IBO Level 3 International Baccalaureate Diploma",
+            PassGrades = ["24B", "24D"], FailGrades = ["24F", "U"]
+        };
+        _gradeReference.GetByQanAsync("50034157", Arg.Any<CancellationToken>()).Returns(ib);
+        Ready(Result(qan: "50034157", grade: "24F"));
+        Post("24D");
+
+        Assert.IsType<RedirectToActionResult>(await _sut.PagePost(WindowId, "grade-details", false));
+        Assert.Equal("24D", _session.GetRequestState(WindowId).QuestionAnswers["q-revised-grade"].TextValue);
+    }
+
+    // ── The summary's completeness guard ─────────────────────────────────────
+
+    [Fact]
+    public async Task The_summary_sends_an_enquiry_with_no_chosen_result_back_to_the_result_page()
+    {
+        // The result lives outside QuestionAnswers, so the flow engine's answer walk cannot see it is
+        // missing — the summary would otherwise render blank rows and accept a submission.
+        var flow = FlowWithSearchPages();
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16).Returns(flow);
+        _flowService.GetNextPageId(flow, Arg.Any<string>(), Arg.Any<Dictionary<string, QuestionAnswer>>())
+            .Returns((string?)null);
+        Ready();
+        _session.SaveRequestState(WindowId, s => s.SelectedResult = null);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(await _sut.Summary(WindowId));
+
+        Assert.Equal(nameof(JourneyController.ResultSearchPage), redirect.ActionName);
+        Assert.Equal("select-result", redirect.RouteValues!["pageId"]);
+    }
+
+    [Fact]
+    public async Task The_summary_sends_an_enquiry_with_no_revised_grade_back_to_the_grade_page()
+    {
+        var flow = FlowWithSearchPages();
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16).Returns(flow);
+        _flowService.GetNextPageId(flow, Arg.Any<string>(), Arg.Any<Dictionary<string, QuestionAnswer>>())
+            .Returns((string?)null);
+        Ready();
+
+        var redirect = Assert.IsType<RedirectToActionResult>(await _sut.Summary(WindowId));
+
+        Assert.Equal(nameof(JourneyController.Page), redirect.ActionName);
+        Assert.Equal("grade-details", redirect.RouteValues!["pageId"]);
+    }
+
+    [Fact]
+    public async Task A_complete_enquiry_reaches_the_summary()
+    {
+        var flow = FlowWithSearchPages();
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16).Returns(flow);
+        _flowService.GetNextPageId(flow, Arg.Any<string>(), Arg.Any<Dictionary<string, QuestionAnswer>>())
+            .Returns((string?)null);
+        Ready(answers: new Dictionary<string, QuestionAnswer>
+        {
+            ["q-revised-grade"] = new() { TextValue = "D1" }
+        });
+
+        var view = Assert.IsType<ViewResult>(await _sut.Summary(WindowId));
+
+        Assert.True(Assert.IsType<SummaryViewModel>(view.Model).IsResultsEnquiry);
+    }
+
+    [Fact]
+    public async Task A_blank_revised_grade_counts_as_missing()
+    {
+        var flow = FlowWithSearchPages();
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16).Returns(flow);
+        _flowService.GetNextPageId(flow, Arg.Any<string>(), Arg.Any<Dictionary<string, QuestionAnswer>>())
+            .Returns((string?)null);
+        Ready(answers: new Dictionary<string, QuestionAnswer>
+        {
+            ["q-revised-grade"] = new() { TextValue = "   " }
+        });
+
+        var redirect = Assert.IsType<RedirectToActionResult>(await _sut.Summary(WindowId));
+
+        Assert.Equal("grade-details", redirect.RouteValues!["pageId"]);
+    }
+
+    private QuestionFlowConfig FlowWithSearchPages()
+    {
+        var selectResult = new JourneyPage { Id = "select-result", Type = PageType.ResultSearch };
+        var flow = new QuestionFlowConfig
+        {
+            FirstPageId = "cohort-scope",
+            Pages = [selectResult, GradeDetails, AdditionalInfo]
+        };
+        _flowService.GetPage(flow, "select-result").Returns(selectResult);
+        _flowService.GetPage(flow, "grade-details").Returns(GradeDetails);
+        _flowService.GetPage(flow, "additional-info").Returns(AdditionalInfo);
+        return flow;
+    }
+
+    private sealed class FakeSession : ISession
+    {
+        private readonly Dictionary<string, byte[]> _store = new();
+
+        public bool TryGetValue(string key, out byte[] value) => _store.TryGetValue(key, out value!);
+        public void Set(string key, byte[] value) => _store[key] = value;
+        public void Remove(string key) => _store.Remove(key);
+        public void Clear() => _store.Clear();
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public bool IsAvailable => true;
+        public string Id => "test-session";
+        public IEnumerable<string> Keys => _store.Keys;
+    }
+
+    private sealed class TestSessionFeature(ISession session) : ISessionFeature
+    {
+        public ISession Session { get; set; } = session;
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerResultSearchTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerResultSearchTests.cs
@@ -1,0 +1,550 @@
+using DfE.CheckPerformanceData.Application.Analytics;
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.FileStorage;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.LandingPage;
+using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Domain.Enums;
+using DfE.CheckPerformanceData.Web.Controllers.Journey;
+using DfE.CheckPerformanceData.Web.Session;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#296648: the ResultSearch page — "Which of {pupil}'s results is incorrect?".
+//
+// The load-bearing behaviour is that the posted value is NOT trusted. The browser sends a composite
+// key; the server re-resolves it against the results the selected pupil actually holds and rejects
+// anything else as if nothing was chosen. Same fail-closed spirit as the hidden-radio-option
+// rejection in PBI 292525.
+public sealed class JourneyControllerResultSearchTests
+{
+    private static readonly Guid WindowId = Guid.Parse("6C2E1F4A-9B7D-4E38-8A15-3D9C2B4E7F01");
+    private const string Laestab = "860/4070";
+    private const string CypmdId = "500001";
+    private const string BusStudsKey = "6037116X|S2024|16to19_MAIN";
+    private const string FrenchKey = "60181576|S2024|16to19_LR1";
+
+    private readonly IQuestionFlowService _flowService = Substitute.For<IQuestionFlowService>();
+    private readonly IJourneyValidationService _journeyService = Substitute.For<IJourneyValidationService>();
+    private readonly IFileStorageService _fileStorage = Substitute.For<IFileStorageService>();
+    private readonly IRequestService _requestService = Substitute.For<IRequestService>();
+    private readonly ICheckYourPupilDataService _pupilData = Substitute.For<ICheckYourPupilDataService>();
+    private readonly IJourneyViewModelBuilder _vmBuilder = Substitute.For<IJourneyViewModelBuilder>();
+    private readonly IAnalyticsService _analytics = Substitute.For<IAnalyticsService>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IOptionVisibilityService _optionVisibility = Substitute.For<IOptionVisibilityService>();
+    private readonly IQuestionOptionalityService _optionality = Substitute.For<IQuestionOptionalityService>();
+    private readonly IOriginCountryLanguageCapture _originCapture = Substitute.For<IOriginCountryLanguageCapture>();
+    private readonly IStudentResultsClient _results = Substitute.For<IStudentResultsClient>();
+    private readonly IGradeReferenceClient _gradeReference = Substitute.For<IGradeReferenceClient>();
+    private readonly DfE.CheckPerformanceData.Application.Notify.IRequestNotificationService _notifications =
+        Substitute.For<DfE.CheckPerformanceData.Application.Notify.IRequestNotificationService>();
+    private readonly FakeSession _session = new();
+    private readonly JourneyController _sut;
+
+    private static readonly JourneyPage SelectResultPage = new()
+    {
+        Id = "select-result",
+        Type = PageType.ResultSearch,
+        Title = "Which of {pupilName}'s results is incorrect?",
+        ValidationFailure = "Enter which of {pupilName}'s results is incorrect",
+        NextPageId = "grade-details"
+    };
+
+    private static readonly JourneyPage GradeDetailsPage = new()
+    {
+        Id = "grade-details",
+        Type = PageType.ResultDetails,
+        Title = "Incorrect grade details"
+    };
+
+    private static readonly QuestionFlowConfig Flow = new()
+    {
+        FirstPageId = "cohort-scope",
+        Pages = [SelectResultPage, GradeDetailsPage]
+    };
+
+    private static StudentResultRecord Result(string qan, string qualName, string session, string source, string grade) => new()
+    {
+        CypmdId = CypmdId, Qan = qan, QualificationName = qualName,
+        SyllabusCode = "1BS0", Session = session, Grade = grade, SourceFile = source
+    };
+
+    private static readonly StudentResultRecord BusStuds =
+        Result("6037116X", "GCSE (9-1) Bus. Studs:Single", "S2024", ResultsFileTags.Post16Main, "5");
+
+    private static readonly StudentResultRecord French =
+        Result("60181576", "GCSE (9-1) French", "S2024", ResultsFileTags.Post16LateResults1, "6");
+
+    public JourneyControllerResultSearchTests()
+    {
+        _currentUser.OrganisationLaestab.Returns(Laestab);
+        _currentUser.OrganisationUrn.Returns("142313");
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16).Returns(Flow);
+        _flowService.GetPage(Flow, "select-result").Returns(SelectResultPage);
+        _flowService.GetPage(Flow, "grade-details").Returns(GradeDetailsPage);
+        _flowService.GetNavigationGuard(Arg.Any<QuestionFlowConfig>(), Arg.Any<RequestState>(), Arg.Any<string>())
+            .Returns((JourneyNavigation?)null);
+        _results.GetResultsAsync(WindowId, Laestab, CypmdId, Arg.Any<CancellationToken>())
+            .Returns([BusStuds, French]);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(_session));
+
+        _sut = new JourneyController(
+            _flowService, _journeyService, _fileStorage, _requestService, _pupilData, _vmBuilder,
+            _analytics, _currentUser, _optionVisibility, _optionality, _originCapture, _results,
+            _gradeReference, _notifications, NullLogger<JourneyController>.Instance)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+    }
+
+    private static PupilDto Pupil() => new()
+    {
+        Id = Guid.NewGuid(), Firstname = "Billy", Surname = "B", Sex = "M",
+        DateOfBirth = "12/03/2007", Age = 19, Cypmd_Id = CypmdId, Identifier = "9900000001"
+    };
+
+    private RequestState ReadyJourney(Action<RequestState>? tweak = null)
+    {
+        var state = new RequestState
+        {
+            SelectedWhatToChange = WhatToChange.IncorrectGrade,
+            CheckingWindow = new CheckingWindowDto
+            {
+                Title = "16 to 19", KeyStage = KeyStages.Post16,
+                CheckingWindowType = CheckingWindowType.Post16,
+                StartDate = new DateTime(2026, 10, 1), EndDate = new DateTime(2027, 3, 31)
+            },
+            SelectedPupilId = Guid.NewGuid().ToString(),
+            SelectedPupil = Pupil(),
+            QuestionHistory = ["select-student-single", "select-result"]
+        };
+        tweak?.Invoke(state);
+        _session.SetRequestState(WindowId, state);
+        return state;
+    }
+
+    // ── GET ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Page_get_hands_a_result_search_page_to_its_own_route()
+    {
+        // The POST payload differs from a normal question page, so ResultSearch has its own
+        // action — exactly as PupilSearch does.
+        ReadyJourney();
+
+        var redirect = Assert.IsType<RedirectToActionResult>(await _sut.Page(WindowId, "select-result"));
+
+        Assert.Equal(nameof(JourneyController.ResultSearchPage), redirect.ActionName);
+        Assert.Equal("select-result", redirect.RouteValues!["pageId"]);
+    }
+
+    [Fact]
+    public async Task Get_renders_the_result_search_view()
+    {
+        ReadyJourney();
+
+        var view = Assert.IsType<ViewResult>(await _sut.ResultSearchPage(WindowId, "select-result"));
+
+        Assert.Equal("ResultSearch", view.ViewName);
+    }
+
+    [Fact]
+    public async Task Get_without_a_started_journey_goes_back_to_the_pupil_data_page()
+    {
+        _session.SetRequestState(WindowId, new RequestState());
+
+        var redirect = Assert.IsType<RedirectToActionResult>(await _sut.ResultSearchPage(WindowId, "select-result"));
+
+        Assert.Equal("CheckYourPupilData", redirect.ControllerName);
+    }
+
+    [Fact]
+    public async Task Get_for_a_page_that_is_not_a_result_search_is_not_found()
+    {
+        ReadyJourney();
+
+        Assert.IsType<NotFoundResult>(await _sut.ResultSearchPage(WindowId, "grade-details"));
+    }
+
+    [Fact]
+    public async Task Get_honours_an_out_of_sequence_navigation_guard()
+    {
+        // Deep-linking to the result page before choosing a pupil must bounce, like every other page.
+        ReadyJourney();
+        _flowService.GetNavigationGuard(Flow, Arg.Any<RequestState>(), "select-result")
+            .Returns(new RedirectToJourneyPage("select-student-single"));
+
+        var redirect = Assert.IsType<RedirectToActionResult>(await _sut.ResultSearchPage(WindowId, "select-result"));
+
+        Assert.Equal("select-student-single", redirect.RouteValues!["pageId"]);
+    }
+
+    // ── POST: happy path ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Post_stores_the_result_the_server_resolved_not_the_one_the_browser_described()
+    {
+        ReadyJourney();
+
+        await _sut.ResultSearchPost(WindowId, "select-result", BusStudsKey, "anything at all");
+
+        var stored = _session.GetRequestState(WindowId).SelectedResult;
+        Assert.NotNull(stored);
+        Assert.Equal("6037116X", stored.Qan);
+        Assert.Equal("S2024", stored.Session);
+        Assert.Equal("5", stored.Grade);
+        Assert.Equal("GCSE (9-1) Bus. Studs:Single", stored.QualificationName);
+    }
+
+    [Fact]
+    public async Task Post_stores_the_label_so_the_autocomplete_can_be_repopulated()
+    {
+        ReadyJourney();
+
+        await _sut.ResultSearchPost(WindowId, "select-result", FrenchKey, "GCSE (9-1) French, QAN: 60181576, Session: S2024");
+
+        Assert.Equal(
+            "GCSE (9-1) French, QAN: 60181576, Session: S2024",
+            _session.GetRequestState(WindowId).SelectedResultLabel);
+    }
+
+    [Fact]
+    public async Task Post_continues_to_the_next_page()
+    {
+        ReadyJourney();
+
+        var redirect = Assert.IsType<RedirectToActionResult>(
+            await _sut.ResultSearchPost(WindowId, "select-result", BusStudsKey, "label"));
+
+        Assert.Equal(nameof(JourneyController.Page), redirect.ActionName);
+        Assert.Equal("grade-details", redirect.RouteValues!["pageId"]);
+    }
+
+    [Fact]
+    public async Task Post_scopes_the_lookup_to_the_session_pupil_and_the_signed_in_school()
+    {
+        ReadyJourney();
+
+        await _sut.ResultSearchPost(WindowId, "select-result", BusStudsKey, "label");
+
+        await _results.Received(1).GetResultsAsync(WindowId, Laestab, CypmdId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Post_records_the_page_in_the_history()
+    {
+        ReadyJourney(s => s.QuestionHistory = ["select-student-single"]);
+
+        await _sut.ResultSearchPost(WindowId, "select-result", BusStudsKey, "label");
+
+        Assert.Contains("select-result", _session.GetRequestState(WindowId).QuestionHistory);
+    }
+
+    // ── POST: fail closed ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Post_with_no_selection_shows_the_templated_validation_message()
+    {
+        ReadyJourney();
+
+        var view = Assert.IsType<ViewResult>(
+            await _sut.ResultSearchPost(WindowId, "select-result", null, null));
+
+        Assert.Equal("ResultSearch", view.ViewName);
+        Assert.Equal(
+            "Enter which of Billy B's results is incorrect",
+            _sut.ModelState["selectedResultKey"]!.Errors[0].ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Post_with_no_selection_reports_a_coded_validation_error()
+    {
+        ReadyJourney();
+
+        await _sut.ResultSearchPost(WindowId, "select-result", "", null);
+
+        await _analytics.Received(1).TrackSafeAsync(Arg.Is<ValidationErrorEvent>(e =>
+            e.ErrorCodes.Contains("no_selection") && e.ErrorFields.Contains("selectedResultKey")));
+    }
+
+    [Fact]
+    public async Task Post_with_a_key_the_pupil_does_not_hold_is_treated_as_unanswered()
+    {
+        // A forged or stale key must not put a result into the enquiry that this pupil never sat.
+        ReadyJourney();
+
+        var view = Assert.IsType<ViewResult>(
+            await _sut.ResultSearchPost(WindowId, "select-result", "99999999|S2024|16to19_MAIN", "Forged"));
+
+        Assert.Equal("ResultSearch", view.ViewName);
+        Assert.Null(_session.GetRequestState(WindowId).SelectedResult);
+        Assert.Equal(
+            "Enter which of Billy B's results is incorrect",
+            _sut.ModelState["selectedResultKey"]!.Errors[0].ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Post_with_a_key_belonging_to_a_different_pupil_is_rejected()
+    {
+        // The lookup is already pupil-scoped, so a key from another pupil's list simply will not
+        // resolve. Pinned because it is the property that makes the scoping meaningful.
+        ReadyJourney();
+        _results.GetResultsAsync(WindowId, Laestab, CypmdId, Arg.Any<CancellationToken>()).Returns([French]);
+
+        Assert.IsType<ViewResult>(await _sut.ResultSearchPost(WindowId, "select-result", BusStudsKey, "label"));
+        Assert.Null(_session.GetRequestState(WindowId).SelectedResult);
+    }
+
+    [Fact]
+    public async Task Post_without_a_pupil_in_session_is_treated_as_unanswered()
+    {
+        ReadyJourney(s => { s.SelectedPupil = null; s.SelectedPupilId = null; });
+
+        Assert.IsType<ViewResult>(await _sut.ResultSearchPost(WindowId, "select-result", BusStudsKey, "label"));
+        await _results.DidNotReceiveWithAnyArgs().GetResultsAsync(default, default!, default!);
+    }
+
+    [Fact]
+    public async Task Post_does_not_navigate_when_the_selection_is_rejected()
+    {
+        ReadyJourney();
+
+        var result = await _sut.ResultSearchPost(WindowId, "select-result", "bogus", "label");
+
+        Assert.IsNotType<RedirectToActionResult>(result);
+    }
+
+    // ── POST: changing the result clears the grade ───────────────────────────
+
+    [Fact]
+    public async Task Choosing_a_different_result_clears_a_previously_chosen_revised_grade()
+    {
+        // A revised grade belongs to one result. Carrying "5" over from the Business Studies result
+        // to the French one would submit a grade the user never chose for that qualification.
+        ReadyJourney(s =>
+        {
+            s.SelectedResult = BusStuds;
+            s.SelectedResultLabel = "GCSE (9-1) Bus. Studs:Single, QAN: 6037116X, Session: S2024";
+            s.QuestionAnswers["q-revised-grade"] = new QuestionAnswer { TextValue = "7" };
+        });
+
+        await _sut.ResultSearchPost(WindowId, "select-result", FrenchKey, "GCSE (9-1) French, QAN: 60181576, Session: S2024");
+
+        var state = _session.GetRequestState(WindowId);
+        Assert.Equal("60181576", state.SelectedResult!.Qan);
+        Assert.DoesNotContain("q-revised-grade", state.QuestionAnswers.Keys);
+    }
+
+    [Fact]
+    public async Task Reselecting_the_same_result_keeps_the_revised_grade()
+    {
+        // Coming back through the page and confirming the same result is not a change, so retyping
+        // the grade would be busywork.
+        ReadyJourney(s =>
+        {
+            s.SelectedResult = BusStuds;
+            s.QuestionAnswers["q-revised-grade"] = new QuestionAnswer { TextValue = "7" };
+        });
+
+        await _sut.ResultSearchPost(WindowId, "select-result", BusStudsKey, "label");
+
+        Assert.Equal("7", _session.GetRequestState(WindowId).QuestionAnswers["q-revised-grade"].TextValue);
+    }
+
+    [Fact]
+    public async Task Choosing_a_different_result_leaves_other_answers_alone()
+    {
+        // Only the grade is tied to the result. The cohort answers are not.
+        ReadyJourney(s =>
+        {
+            s.SelectedResult = BusStuds;
+            s.QuestionAnswers["q-cohort-scope"] = new QuestionAnswer { TextValue = "yes" };
+            s.QuestionAnswers["q-cohort-count"] = new QuestionAnswer { TextValue = "10" };
+            s.QuestionAnswers["q-revised-grade"] = new QuestionAnswer { TextValue = "7" };
+        });
+
+        await _sut.ResultSearchPost(WindowId, "select-result", FrenchKey, "label");
+
+        var answers = _session.GetRequestState(WindowId).QuestionAnswers;
+        Assert.Equal("yes", answers["q-cohort-scope"].TextValue);
+        Assert.Equal("10", answers["q-cohort-count"].TextValue);
+    }
+
+    [Fact]
+    public async Task Post_for_a_page_that_is_not_a_result_search_is_not_found()
+    {
+        ReadyJourney();
+
+        Assert.IsType<NotFoundResult>(await _sut.ResultSearchPost(WindowId, "grade-details", BusStudsKey, "label"));
+    }
+
+    [Fact]
+    public async Task Post_with_no_next_page_goes_to_the_summary()
+    {
+        var lastPage = new JourneyPage
+        {
+            Id = "select-result",
+            Type = PageType.ResultSearch,
+            Title = "Which of {pupilName}'s results is incorrect?",
+            NextPageId = null
+        };
+        var flow = new QuestionFlowConfig { FirstPageId = "select-result", Pages = [lastPage] };
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16).Returns(flow);
+        _flowService.GetPage(flow, "select-result").Returns(lastPage);
+        ReadyJourney();
+
+        var redirect = Assert.IsType<RedirectToActionResult>(
+            await _sut.ResultSearchPost(WindowId, "select-result", BusStudsKey, "label"));
+
+        Assert.Equal(nameof(JourneyController.Summary), redirect.ActionName);
+    }
+
+    // ── Choosing a pupil must not discard the cohort answers ─────────────────
+
+    [Fact]
+    public async Task Choosing_the_student_keeps_answers_given_before_that_page()
+    {
+        // On the amendment journeys the pupil page is first, so selecting a pupil discarded every
+        // answer. The enquiry journey asks about the cohort BEFORE the student, and those answers are
+        // not about the student — wiping them lost the scope and count, and the summary then silently
+        // presented a cohort-wide enquiry as a single-pupil one. Caught by walking the journey; no
+        // unit test existed that could have.
+        var cohortScope = new JourneyPage
+        {
+            Id = "cohort-scope",
+            Questions =
+            [
+                new Question { Id = "q-cohort-scope", Type = QuestionType.Radio, Title = "Whole cohort?" }
+            ]
+        };
+        var cohortCount = new JourneyPage
+        {
+            Id = "cohort-count",
+            Questions =
+            [
+                new Question { Id = "q-cohort-count", Type = QuestionType.FreeText, Title = "How many?" }
+            ]
+        };
+        var studentPage = new JourneyPage
+        {
+            Id = "select-student-cohort",
+            Type = PageType.PupilSearch,
+            PupilKey = JourneyPage.PrimaryKey,
+            PupilFilter = PupilFilter.All,
+            NextPageId = "select-result"
+        };
+        var flow = new QuestionFlowConfig
+        {
+            FirstPageId = "cohort-scope",
+            Pages = [cohortScope, cohortCount, studentPage, SelectResultPage, GradeDetailsPage]
+        };
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16).Returns(flow);
+        foreach (var page in flow.Pages)
+            _flowService.GetPage(flow, page.Id).Returns(page);
+
+        var pupil = Pupil();
+        _pupilData.GetPupilAsync(WindowId, pupil.Id).Returns(pupil);
+        _requestService.HasSubmittedRequestAsync(WindowId, pupil.Id, Arg.Any<long>())
+            .Returns(new DuplicateCheckResult.NoConflict());
+        _journeyService.GenerateEnquiryReference().Returns("CYPMD_16to19_RE_ABCDEF1");
+
+        _session.SetRequestState(WindowId, new RequestState
+        {
+            SelectedWhatToChange = WhatToChange.IncorrectGrade,
+            CheckingWindow = new CheckingWindowDto
+            {
+                Title = "16 to 19", KeyStage = KeyStages.Post16,
+                CheckingWindowType = CheckingWindowType.Post16,
+                StartDate = new DateTime(2026, 10, 1), EndDate = new DateTime(2027, 3, 31)
+            },
+            QuestionAnswers = new Dictionary<string, QuestionAnswer>
+            {
+                ["q-cohort-scope"] = new() { TextValue = "yes" },
+                ["q-cohort-count"] = new() { TextValue = "10" }
+            },
+            QuestionHistory = ["cohort-scope", "cohort-count"]
+        });
+
+        await _sut.PupilSearchPost(WindowId, "select-student-cohort", pupil.Id.ToString(), "Alice, Smith");
+
+        var state = _session.GetRequestState(WindowId);
+        Assert.Equal("yes", state.QuestionAnswers["q-cohort-scope"].TextValue);
+        Assert.Equal("10", state.QuestionAnswers["q-cohort-count"].TextValue);
+        Assert.Equal(["cohort-scope", "cohort-count", "select-student-cohort"], state.QuestionHistory);
+        Assert.Equal("CYPMD_16to19_RE_ABCDEF1", state.ReferenceNumber);
+    }
+
+    [Fact]
+    public async Task Choosing_a_student_discards_answers_given_after_that_page()
+    {
+        // The behaviour the wipe existed for: a grade chosen for the previous student's result must
+        // not survive, and neither must the result itself.
+        var studentPage = new JourneyPage
+        {
+            Id = "select-student-single",
+            Type = PageType.PupilSearch,
+            PupilKey = JourneyPage.PrimaryKey,
+            PupilFilter = PupilFilter.All,
+            NextPageId = "select-result"
+        };
+        var flow = new QuestionFlowConfig
+        {
+            FirstPageId = "select-student-single",
+            Pages = [studentPage, SelectResultPage, GradeDetailsPage]
+        };
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16).Returns(flow);
+        foreach (var page in flow.Pages)
+            _flowService.GetPage(flow, page.Id).Returns(page);
+
+        var pupil = Pupil();
+        _pupilData.GetPupilAsync(WindowId, pupil.Id).Returns(pupil);
+        _requestService.HasSubmittedRequestAsync(WindowId, pupil.Id, Arg.Any<long>())
+            .Returns(new DuplicateCheckResult.NoConflict());
+
+        ReadyJourney(s =>
+        {
+            s.QuestionHistory = ["select-student-single", "select-result", "grade-details"];
+            s.SelectedResult = BusStuds;
+            s.SelectedResultLabel = "GCSE (9-1) Bus. Studs:Single, QAN: 6037116X, Session: S2024";
+            s.QuestionAnswers["q-revised-grade"] = new QuestionAnswer { TextValue = "7" };
+        });
+
+        await _sut.PupilSearchPost(WindowId, "select-student-single", pupil.Id.ToString(), "Alice, Smith");
+
+        var state = _session.GetRequestState(WindowId);
+        Assert.Empty(state.QuestionAnswers);
+        Assert.Null(state.SelectedResult);
+        Assert.Null(state.SelectedResultLabel);
+        Assert.Equal(["select-student-single"], state.QuestionHistory);
+    }
+
+    private sealed class FakeSession : ISession
+    {
+        private readonly Dictionary<string, byte[]> _store = new();
+
+        public bool TryGetValue(string key, out byte[] value) => _store.TryGetValue(key, out value!);
+        public void Set(string key, byte[] value) => _store[key] = value;
+        public void Remove(string key) => _store.Remove(key);
+        public void Clear() => _store.Clear();
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public bool IsAvailable => true;
+        public string Id => "test-session";
+        public IEnumerable<string> Keys => _store.Keys;
+    }
+
+    private sealed class TestSessionFeature(ISession session) : ISessionFeature
+    {
+        public ISession Session { get; set; } = session;
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyControllerTests.cs
@@ -105,7 +105,11 @@ public class JourneyControllerTests
 
         _sut = new JourneyController(_flowService, _journeyService, _fileStorageService,
             _requestService, _pupilDataService, viewModelBuilder, _analytics, _currentUserService,
-            _optionVisibilityService, _optionalityService, _languageCapture)
+            _optionVisibilityService, _optionalityService, _languageCapture,
+            Substitute.For<DfE.CheckPerformanceData.Application.ResultsEnquiry.IStudentResultsClient>(),
+            Substitute.For<DfE.CheckPerformanceData.Application.ResultsEnquiry.IGradeReferenceClient>(),
+            Substitute.For<DfE.CheckPerformanceData.Application.Notify.IRequestNotificationService>(),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<JourneyController>.Instance)
         {
             ControllerContext = new ControllerContext { HttpContext = _httpContext },
             TempData = new TempDataDictionary(_httpContext, Substitute.For<ITempDataProvider>())

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyValidationServiceGradeSelectTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyValidationServiceGradeSelectTests.cs
@@ -1,0 +1,209 @@
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#296648 / AB#297130: the revised-grade rules. All four are server-authoritative — the picker is
+// built from the same reference data, but a posted value is never trusted.
+//
+// The BTEC fixture is the ticket's own example. The IB Diploma fixture is the case that makes
+// ordinal, case-sensitive comparison load-bearing: 24F is a fail and 24D is a pass, so a comparison
+// that normalised or truncated would let the user "change" a grade to itself.
+public sealed class JourneyValidationServiceGradeSelectTests
+{
+    private readonly JourneyValidationService _sut = new();
+
+    private static readonly Question RevisedGrade = new()
+    {
+        Id = "q-revised-grade",
+        Type = QuestionType.GradeSelect,
+        Title = "What should the revised grade be?",
+        ValidationFailure = "Select the revised grade"
+    };
+
+    private const string Required = "Select the revised grade";
+    private const string MustDiffer = "The revised grade must be different from the current grade";
+
+    private static readonly GradeReference Btec = new()
+    {
+        Qan = "60370683",
+        QualificationTitle = "Pearson BTEC L1/L2 Tech Award in Sport",
+        AwardingOrganisation = "Pearson",
+        PassGrades = ["*2", "P1", "P2", "M1", "M2", "D1", "D2"],
+        FailGrades = ["F", "Q", "R", "U", "X"]
+    };
+
+    private static readonly GradeReference Ib = new()
+    {
+        Qan = "50034157",
+        QualificationTitle = "IBO Level 3 International Baccalaureate Diploma",
+        AwardingOrganisation = "IBO",
+        PassGrades = ["24B", "24D", "25B", "25D"],
+        FailGrades = ["24F", "25F", "R", "U", "X"]
+    };
+
+    private string? Validate(string? chosen, GradeReference? reference, string? currentGrade) =>
+        _sut.ValidateGradeSelect(
+            RevisedGrade,
+            chosen is null ? null : new QuestionAnswer { TextValue = chosen },
+            reference,
+            currentGrade,
+            RevisedGrade.ValidationFailure);
+
+    // ── 1. Unanswered ────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void An_unanswered_grade_is_required(string? chosen)
+        => Assert.Equal(Required, Validate(chosen, Btec, "M1"));
+
+    [Fact]
+    public void The_required_message_falls_back_when_the_flow_config_supplies_none()
+    {
+        var error = _sut.ValidateGradeSelect(
+            RevisedGrade, null, Btec, "M1", resolvedValidationFailure: null);
+
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+
+    // ── 2. Same as the current grade ─────────────────────────────────────────
+
+    [Fact]
+    public void The_current_grade_cannot_be_the_revised_grade()
+    {
+        // "A revised grade that matches the current grade reports no change."
+        Assert.Equal(MustDiffer, Validate("M1", Btec, "M1"));
+    }
+
+    [Fact]
+    public void The_must_differ_check_is_case_sensitive()
+    {
+        // Grades are opaque codes. Treating "m1" as "M1" would be guessing at the user's intent, and
+        // no qualification in the reference data uses case to distinguish grades anyway — so a
+        // differently-cased value is simply not a grade this qualification offers.
+        Assert.Equal(Required, Validate("m1", Btec, "M1"));
+    }
+
+    [Fact]
+    public void Surrounding_whitespace_does_not_defeat_the_must_differ_check()
+        => Assert.Equal(MustDiffer, Validate("  M1  ", Btec, "M1"));
+
+    [Fact]
+    public void A_different_grade_from_the_same_scale_passes()
+        => Assert.Null(Validate("D1", Btec, "M1"));
+
+    [Fact]
+    public void A_fail_grade_is_a_valid_revised_grade()
+    {
+        // "A grade can be wrong in either direction, so both are needed."
+        Assert.Null(Validate("U", Btec, "M1"));
+    }
+
+    [Fact]
+    public void A_pass_grade_is_a_valid_revision_of_a_fail_grade()
+        => Assert.Null(Validate("D2", Btec, "U"));
+
+    // ── The prefix-sharing case ──────────────────────────────────────────────
+
+    [Fact]
+    public void Grades_sharing_a_prefix_are_treated_as_distinct()
+    {
+        // 24F (fail) and 24D (pass) differ only by suffix. Changing 24F to 24D is a real enquiry and
+        // must be accepted; a sloppier comparison would reject it as "no change".
+        Assert.Null(Validate("24D", Ib, "24F"));
+        Assert.Null(Validate("24F", Ib, "24D"));
+    }
+
+    [Fact]
+    public void The_same_prefix_sharing_grade_is_still_rejected()
+    {
+        Assert.Equal(MustDiffer, Validate("24F", Ib, "24F"));
+        Assert.Equal(MustDiffer, Validate("24D", Ib, "24D"));
+    }
+
+    // ── 3. Not a grade this qualification offers ─────────────────────────────
+
+    [Theory]
+    [InlineData("9")]        // a GCSE grade posted against a BTEC
+    [InlineData("A*")]
+    [InlineData("D3")]       // plausible but not in this scale
+    [InlineData("<script>")]
+    public void A_grade_the_qualification_does_not_offer_is_treated_as_unanswered(string chosen)
+    {
+        // Fail closed: a forged post must not smuggle a value the picker never offered into an
+        // enquiry the DfE will act on.
+        Assert.Equal(Required, Validate(chosen, Btec, "M1"));
+    }
+
+    [Fact]
+    public void A_grade_from_a_different_qualifications_scale_is_rejected()
+        => Assert.Equal(Required, Validate("24D", Btec, "M1"));
+
+    // ── 4. The qualification is missing from the reference data ──────────────
+
+    [Fact]
+    public void With_no_reference_data_nothing_can_be_submitted()
+    {
+        // A reference-data gap is not the user's fault, but letting the enquiry through would send
+        // the DfE a grade nobody could confirm is valid. The page explains the gap; validation holds.
+        Assert.Equal(Required, Validate(null, null, "M1"));
+        Assert.Equal(Required, Validate("D1", null, "M1"));
+    }
+
+    [Fact]
+    public void With_an_empty_grade_scale_nothing_can_be_submitted()
+    {
+        var empty = new GradeReference
+        {
+            Qan = "00000000", QualificationTitle = "Unknown", PassGrades = [], FailGrades = []
+        };
+
+        Assert.Equal(Required, Validate("D1", empty, "M1"));
+    }
+
+    [Fact]
+    public void Must_differ_is_reported_before_the_grade_is_checked_against_the_scale()
+    {
+        // Rule order matters: a user who picks the grade the result already holds gets the message
+        // that explains their mistake, not a bare "select a grade". The only way to reach this with
+        // no reference data is a forged post — the picker would be empty — so either message would
+        // do there; the ordering is chosen for the case a real user can hit.
+        Assert.Equal(MustDiffer, Validate("M1", null, "M1"));
+        Assert.Equal(MustDiffer, Validate("M1", Btec, "M1"));
+    }
+
+    // ── Current grade edge cases ─────────────────────────────────────────────
+
+    [Fact]
+    public void A_valid_grade_passes_when_the_current_grade_is_unknown()
+    {
+        // Nothing to compare against, so the must-differ rule cannot fire — but the grade must still
+        // be one the qualification offers.
+        Assert.Null(Validate("D1", Btec, null));
+        Assert.Equal(Required, Validate("9", Btec, null));
+    }
+
+    [Fact]
+    public void A_valid_grade_passes_when_the_current_grade_is_blank()
+        => Assert.Null(Validate("D1", Btec, "   "));
+
+    // ── The generic path is untouched ────────────────────────────────────────
+
+    [Fact]
+    public void The_generic_answer_validator_still_handles_other_question_types()
+    {
+        // Guards against the grade rules leaking into every question.
+        var freeText = new Question
+        {
+            Id = "q-cohort-count", Type = QuestionType.FreeText,
+            Title = "How many students?", ValidationFailure = "Enter how many students"
+        };
+
+        Assert.Equal("Enter how many students",
+            _sut.ValidateAnswer(freeText, new QuestionAnswer { TextValue = "" }, "How many students?", "Enter how many students"));
+        Assert.Null(
+            _sut.ValidateAnswer(freeText, new QuestionAnswer { TextValue = "10" }, "How many students?", "Enter how many students"));
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyViewModelBuilderEnquirySummaryTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/JourneyViewModelBuilderEnquirySummaryTests.cs
@@ -1,0 +1,309 @@
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.LandingPage;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Domain.Enums;
+using DfE.CheckPerformanceData.Web.Controllers.Journey;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#296648: the check-answers summary for a results enquiry.
+//
+// The row set is completely unlike an amendment's — it leads with the establishment and enquiry type
+// rather than "what pupil data would you like to change?" — so the summary branches on the journey.
+// Row ORDER is pinned because it is what the user reads before confirming, and the AC is that they
+// see everything they entered.
+public sealed class JourneyViewModelBuilderEnquirySummaryTests
+{
+    private static readonly Guid WindowId = Guid.Parse("6C2E1F4A-9B7D-4E38-8A15-3D9C2B4E7F01");
+
+    private readonly IQuestionFlowService _flowService = Substitute.For<IQuestionFlowService>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly JourneyViewModelBuilder _sut;
+
+    private static readonly Question CohortScope = new()
+    {
+        Id = "q-cohort-scope", Type = QuestionType.Radio, Title = "Does the incorrect grade affect the whole cohort?",
+        SummaryTitle = "Affects the whole cohort",
+        Options = [new QuestionOption { Value = "yes", Label = "Yes" }, new QuestionOption { Value = "no", Label = "No" }]
+    };
+
+    private static readonly Question CohortCount = new()
+    {
+        Id = "q-cohort-count", Type = QuestionType.FreeText,
+        Title = "Enter the number of students who have an incorrect grade for this qualification",
+        SummaryTitle = "Number of students in affected cohort"
+    };
+
+    private static readonly Question RevisedGrade = new()
+    {
+        Id = "q-revised-grade", Type = QuestionType.GradeSelect,
+        Title = "What should the revised grade be?", SummaryTitle = "Revised grade"
+    };
+
+    private static readonly Question AdditionalInfo = new()
+    {
+        Id = "q-additional-info", Type = QuestionType.TextArea, Optional = true,
+        Title = "Additional information (Optional)", SummaryTitle = "Additional information"
+    };
+
+    private static readonly JourneyPage CohortScopePage = new() { Id = "cohort-scope", Questions = [CohortScope] };
+    private static readonly JourneyPage CohortCountPage = new() { Id = "cohort-count", Questions = [CohortCount] };
+    private static readonly JourneyPage StudentCohortPage = new() { Id = "select-student-cohort", Type = PageType.PupilSearch, PupilKey = "primary" };
+    private static readonly JourneyPage StudentSinglePage = new() { Id = "select-student-single", Type = PageType.PupilSearch, PupilKey = "primary" };
+    private static readonly JourneyPage SelectResultPage = new() { Id = "select-result", Type = PageType.ResultSearch };
+    private static readonly JourneyPage GradeDetailsPage = new() { Id = "grade-details", Type = PageType.ResultDetails, Questions = [RevisedGrade] };
+    private static readonly JourneyPage AdditionalInfoPage = new() { Id = "additional-info", Questions = [AdditionalInfo] };
+
+    private static readonly QuestionFlowConfig Flow = new()
+    {
+        FirstPageId = "cohort-scope",
+        Pages =
+        [
+            CohortScopePage, CohortCountPage, StudentCohortPage, StudentSinglePage,
+            SelectResultPage, GradeDetailsPage, AdditionalInfoPage
+        ]
+    };
+
+    public JourneyViewModelBuilderEnquirySummaryTests()
+    {
+        _currentUser.OrganisationLaestab.Returns("860/4070");
+        foreach (var page in Flow.Pages)
+            _flowService.GetPage(Flow, page.Id).Returns(page);
+
+        _sut = new JourneyViewModelBuilder(
+            _flowService, new JourneyValidationService(),
+            Substitute.For<IOptionVisibilityService>(), _currentUser);
+    }
+
+    // The Figma fixture from the plan.
+    private static readonly StudentResultRecord ArtAndDesign = new()
+    {
+        CypmdId = "1596410810", Qan = "60180882", QualificationName = "GCSE (9-1) Art&Des : Fine Art",
+        SyllabusCode = "1AD0", Session = "S2024", Grade = "9", SourceFile = ResultsFileTags.Post16Main
+    };
+
+    private static PupilDto Billy() => new()
+    {
+        Id = Guid.NewGuid(), Firstname = "Billy", Surname = "B", Sex = "M",
+        DateOfBirth = "12/03/2007", Age = 19, Cypmd_Id = "1596410810", Identifier = "9900000001"
+    };
+
+    private RequestState CohortJourney() => new()
+    {
+        SelectedWhatToChange = WhatToChange.IncorrectGrade,
+        CheckingWindow = Window,
+        SelectedPupilId = Guid.NewGuid().ToString(),
+        SelectedPupil = Billy(),
+        SelectedResult = ArtAndDesign,
+        QuestionAnswers = new Dictionary<string, QuestionAnswer>
+        {
+            ["q-cohort-scope"] = new() { TextValue = "yes" },
+            ["q-cohort-count"] = new() { TextValue = "10" },
+            ["q-revised-grade"] = new() { TextValue = "U" },
+            ["q-additional-info"] = new() { TextValue = "The whole class was marked against the wrong paper." }
+        },
+        QuestionHistory =
+        [
+            "cohort-scope", "cohort-count", "select-student-cohort", "select-result",
+            "grade-details", "additional-info"
+        ]
+    };
+
+    private RequestState SingleJourney() => new()
+    {
+        SelectedWhatToChange = WhatToChange.IncorrectGrade,
+        CheckingWindow = Window,
+        SelectedPupilId = Guid.NewGuid().ToString(),
+        SelectedPupil = Billy(),
+        SelectedResult = ArtAndDesign,
+        QuestionAnswers = new Dictionary<string, QuestionAnswer>
+        {
+            ["q-cohort-scope"] = new() { TextValue = "no" },
+            ["q-revised-grade"] = new() { TextValue = "U" }
+        },
+        QuestionHistory =
+        [
+            "cohort-scope", "select-student-single", "select-result", "grade-details", "additional-info"
+        ]
+    };
+
+    private static CheckingWindowDto Window => new()
+    {
+        Title = "16 to 19 2026", KeyStage = KeyStages.Post16,
+        CheckingWindowType = CheckingWindowType.Post16,
+        StartDate = new DateTime(2026, 10, 1), EndDate = new DateTime(2027, 3, 31)
+    };
+
+    private IReadOnlyList<SummaryLine> Lines(RequestState journey) =>
+        _sut.BuildSummaryVm(WindowId, journey, Flow).Lines;
+
+    // ── The cohort branch ────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_cohort_branch_shows_every_row_in_the_pinned_order()
+    {
+        var lines = Lines(CohortJourney());
+
+        Assert.Equal(
+            [
+                "DfE number",
+                "Key stage",
+                "Enquiry type",
+                "Number of students in affected cohort",
+                "Name of a student in cohort",
+                "CYPMD ID",
+                "Qualification number (QAN)",
+                "Qualification name and subject",
+                "Session",
+                "Current grade",
+                "Revised grade",
+                "Additional information"
+            ],
+            lines.Select(l => l.Key).ToArray());
+    }
+
+    [Fact]
+    public void The_cohort_branch_shows_the_expected_values()
+    {
+        var lines = Lines(CohortJourney()).ToDictionary(l => l.Key, l => l.Value);
+
+        Assert.Equal("860/4070", lines["DfE number"]);
+        Assert.Equal("16 to 19", lines["Key stage"]);
+        Assert.Equal("Incorrect grade", lines["Enquiry type"]);
+        Assert.Equal("10", lines["Number of students in affected cohort"]);
+        Assert.Equal("Billy B", lines["Name of a student in cohort"]);
+        Assert.Equal("1596410810", lines["CYPMD ID"]);
+        Assert.Equal("60180882", lines["Qualification number (QAN)"]);
+        Assert.Equal("GCSE (9-1) Art&Des : Fine Art", lines["Qualification name and subject"]);
+        Assert.Equal("S2024", lines["Session"]);
+        Assert.Equal("9", lines["Current grade"]);
+        Assert.Equal("U", lines["Revised grade"]);
+        Assert.Equal("The whole class was marked against the wrong paper.", lines["Additional information"]);
+    }
+
+    // ── The single-pupil branch ──────────────────────────────────────────────
+
+    [Fact]
+    public void The_single_pupil_branch_omits_the_cohort_count_row()
+    {
+        var lines = Lines(SingleJourney());
+
+        Assert.DoesNotContain("Number of students in affected cohort", lines.Select(l => l.Key));
+    }
+
+    [Fact]
+    public void The_single_pupil_branch_labels_the_student_row_differently()
+    {
+        // The label is how the summary conveys the cohort answer, since the yes/no is not a row of
+        // its own.
+        var lines = Lines(SingleJourney()).ToDictionary(l => l.Key, l => l.Value);
+
+        Assert.Equal("Billy B", lines["Name of student"]);
+        Assert.DoesNotContain("Name of a student in cohort", lines.Keys);
+    }
+
+    [Fact]
+    public void The_single_pupil_branch_keeps_every_other_row_in_order()
+    {
+        var lines = Lines(SingleJourney());
+
+        Assert.Equal(
+            [
+                "DfE number", "Key stage", "Enquiry type", "Name of student", "CYPMD ID",
+                "Qualification number (QAN)", "Qualification name and subject", "Session",
+                "Current grade", "Revised grade", "Additional information"
+            ],
+            lines.Select(l => l.Key).ToArray());
+    }
+
+    [Fact]
+    public void An_unanswered_additional_information_row_is_still_shown_as_empty()
+    {
+        // "Given I have no comments to add, when I continue, then I proceed without entering any" —
+        // the row stays so the user can see there is nothing there, and can add something.
+        var lines = Lines(SingleJourney()).ToDictionary(l => l.Key, l => l.Value);
+
+        Assert.Equal(string.Empty, lines["Additional information"]);
+    }
+
+    // ── Change links ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Only_the_revised_grade_and_additional_information_can_be_changed()
+    {
+        // Figma-pinned: identity and result rows have no change link. Changing the student or the
+        // result means going back through the journey, because a different result invalidates the
+        // grade that was chosen for it.
+        var changeable = Lines(CohortJourney()).Where(l => l.HasChange).Select(l => l.Key).ToArray();
+
+        Assert.Equal(["Revised grade", "Additional information"], changeable);
+    }
+
+    [Fact]
+    public void The_change_links_target_the_pages_that_ask_those_questions()
+    {
+        var lines = Lines(CohortJourney()).ToDictionary(l => l.Key, l => l);
+
+        Assert.Equal("grade-details", lines["Revised grade"].ChangePageId);
+        Assert.True(lines["Revised grade"].IsPageChange);
+        Assert.Equal("additional-info", lines["Additional information"].ChangePageId);
+        Assert.True(lines["Additional information"].IsPageChange);
+    }
+
+    [Fact]
+    public void The_change_links_carry_visually_hidden_text()
+    {
+        // Two links both reading "Change" are indistinguishable to a screen reader without it.
+        foreach (var line in Lines(CohortJourney()).Where(l => l.HasChange))
+            Assert.False(string.IsNullOrWhiteSpace(line.ChangeHiddenText));
+    }
+
+    // ── The amendment summary is untouched ───────────────────────────────────
+
+    [Fact]
+    public void An_amendment_journey_still_gets_the_amendment_summary()
+    {
+        // The live KS4 journeys must be unaffected by this ticket.
+        var removal = new RequestState
+        {
+            SelectedWhatToChange = WhatToChange.Remove,
+            CheckingWindow = Window,
+            SelectedPupil = Billy(),
+            QuestionAnswers = new Dictionary<string, QuestionAnswer> { ["q-cohort-scope"] = new() { TextValue = "yes" } },
+            QuestionHistory = ["cohort-scope"]
+        };
+
+        var lines = _sut.BuildSummaryVm(WindowId, removal, Flow).Lines;
+
+        Assert.Equal("What pupil data would you like to change?", lines[0].Key);
+        Assert.DoesNotContain("DfE number", lines.Select(l => l.Key));
+    }
+
+    // ── Heading data ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_view_model_exposes_the_enquiry_shape_for_the_heading_and_actions()
+    {
+        var vm = _sut.BuildSummaryVm(WindowId, CohortJourney(), Flow);
+
+        Assert.True(vm.IsResultsEnquiry);
+        Assert.Equal("Billy B", vm.PupilName);
+    }
+
+    [Fact]
+    public void An_amendment_is_not_flagged_as_an_enquiry()
+    {
+        var removal = new RequestState
+        {
+            SelectedWhatToChange = WhatToChange.Remove,
+            CheckingWindow = Window,
+            SelectedPupil = Billy(),
+            QuestionHistory = ["cohort-scope"]
+        };
+
+        Assert.False(_sut.BuildSummaryVm(WindowId, removal, Flow).IsResultsEnquiry);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/PupilSearchJourneyTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/PupilSearchJourneyTests.cs
@@ -123,7 +123,11 @@ public class PupilSearchJourneyTests
 
         _sut = new JourneyController(_flowService, _journeyService, _fileStorageService,
             _requestService, _pupilDataService, viewModelBuilder, _analytics, _currentUserService,
-            _optionVisibilityService, _optionalityService, _languageCapture)
+            _optionVisibilityService, _optionalityService, _languageCapture,
+            Substitute.For<DfE.CheckPerformanceData.Application.ResultsEnquiry.IStudentResultsClient>(),
+            Substitute.For<DfE.CheckPerformanceData.Application.ResultsEnquiry.IGradeReferenceClient>(),
+            Substitute.For<DfE.CheckPerformanceData.Application.Notify.IRequestNotificationService>(),
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<JourneyController>.Instance)
         {
             ControllerContext = new ControllerContext { HttpContext = _httpContext },
             TempData = new TempDataDictionary(_httpContext, Substitute.For<ITempDataProvider>())

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/QuestionFlowValidatorAlignmentTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/QuestionFlowValidatorAlignmentTests.cs
@@ -211,6 +211,50 @@ public sealed class QuestionFlowValidatorAlignmentTests
             .ToHashSet(StringComparer.Ordinal);
     }
 
+    /// <summary>
+    /// A single-question page must NOT set a page-level <c>title</c>.
+    ///
+    /// <c>JourneyViewModelBuilder</c> sets <c>IsPageHeading = isSingleQuestion &amp;&amp;
+    /// string.IsNullOrEmpty(page.Title)</c>, and <c>Page.cshtml</c> renders its own <c>h1</c> only
+    /// when the page has MORE than one question. So a single-question page that also sets a page
+    /// title renders no <c>h1</c> at all — that title feeds only the browser title, and the
+    /// question's legend/label drops from <c>--l</c> to <c>--m</c>.
+    ///
+    /// A page with no heading is a WCAG 2.2 AA failure that nothing else notices: the page still
+    /// renders, still validates and still submits. Use <c>pageTitle</c> when the browser title needs
+    /// to differ from the question (e.g. to keep a pupil name out of it).
+    /// </summary>
+    [Fact]
+    public void SingleQuestionPages_LeaveThePageTitleEmpty_SoTheQuestionBecomesTheHeading()
+    {
+        foreach (var (file, page) in AllFlowPages())
+        {
+            if (page.Type != PageType.Question || page.Questions.Count != 1) continue;
+
+            Assert.True(string.IsNullOrEmpty(page.Title),
+                $"{file}: page '{page.Id}' has a single question but also sets a page-level title " +
+                $"('{page.Title}'), which suppresses IsPageHeading and leaves the page with no <h1>. " +
+                "Remove the page title; use 'pageTitle' if the browser title must differ.");
+        }
+    }
+
+    /// <summary>
+    /// An optional question's title must not spell out "(Optional)" — <c>JourneyViewModelBuilder</c>
+    /// appends it, so a title containing it renders "… (Optional) (Optional)".
+    /// </summary>
+    [Fact]
+    public void OptionalQuestions_DoNotRepeatTheOptionalSuffixInTheirTitle()
+    {
+        foreach (var (file, question) in AllFlowQuestions())
+        {
+            if (!question.Optional) continue;
+
+            Assert.False(question.Title.Contains("(Optional)", StringComparison.OrdinalIgnoreCase),
+                $"{file}: optional question '{question.Id}' spells out \"(Optional)\" in its title " +
+                $"('{question.Title}'). The view model appends it, so this renders it twice.");
+        }
+    }
+
     private static IEnumerable<(string File, Question Question)> AllFlowQuestions() =>
         AllFlowPages().SelectMany(p => p.Page.Questions.Select(q => (p.File, q)));
 

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/RequestServiceResultsEnquiryTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/RequestServiceResultsEnquiryTests.cs
@@ -1,0 +1,300 @@
+using System.Text.RegularExpressions;
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.LandingPage;
+using DfE.CheckPerformanceData.Application.Notify;
+using DfE.CheckPerformanceData.Application.Queue;
+using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Domain.Enums;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#296648: submitting a results enquiry.
+//
+// BA decision 2026-08-17: an enquiry drops into ChangeRequests and saves its journey JSON exactly as
+// a pupil change request does — and is NOT enqueued. It is ultimately bound for Zendesk, but how it
+// gets there is a separate story. The "never enqueues" assertions are the guard on that boundary:
+// if enqueueing ever appears here it must be a deliberate change, not a copy-paste from the
+// amendment path.
+public sealed class RequestServiceResultsEnquiryTests
+{
+    private static readonly Guid WindowId = Guid.Parse("6C2E1F4A-9B7D-4E38-8A15-3D9C2B4E7F01");
+    private static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid ChangeRequestId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private readonly IQuestionFlowService _flowService = Substitute.For<IQuestionFlowService>();
+    private readonly IRequestStateBlobClient _stateBlob = Substitute.For<IRequestStateBlobClient>();
+    private readonly IRequestRepository _repository = Substitute.For<IRequestRepository>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IQueueService _queue = Substitute.For<IQueueService>();
+    private readonly IRequestNotificationService _notifications = Substitute.For<IRequestNotificationService>();
+    private readonly ICheckYourPupilDataService _pupilData = Substitute.For<ICheckYourPupilDataService>();
+    private readonly RequestService _sut;
+
+    public RequestServiceResultsEnquiryTests()
+    {
+        _currentUser.UserId.Returns(UserId.ToString());
+        _currentUser.OrganisationUrn.Returns("142313");
+        _currentUser.OrganisationLaestab.Returns("860/4070");
+        _currentUser.DisplayName.Returns("Ada Editor");
+        _currentUser.Email.Returns("ada@school.test");
+        _repository.UpsertAsync(Arg.Any<ChangeRequestData>()).Returns(ChangeRequestId);
+
+        _sut = new RequestService(
+            _flowService, _stateBlob, _repository, _currentUser,
+            NullLogger<RequestService>.Instance, _queue, _notifications, _pupilData);
+    }
+
+    private static StudentResultRecord Result() => new()
+    {
+        CypmdId = "1596410810", Qan = "60180882", QualificationName = "GCSE (9-1) Art&Des : Fine Art",
+        SyllabusCode = "1AD0", Session = "S2024", Grade = "9", SourceFile = ResultsFileTags.Post16Main
+    };
+
+    private static RequestState Journey(bool cohortWide = true, string? additionalInfo = null) => new()
+    {
+        SelectedWhatToChange = WhatToChange.IncorrectGrade,
+        CheckingWindow = new CheckingWindowDto
+        {
+            Title = "16 to 19 2026", KeyStage = KeyStages.Post16,
+            CheckingWindowType = CheckingWindowType.Post16,
+            StartDate = new DateTime(2026, 10, 1), EndDate = new DateTime(2027, 3, 31)
+        },
+        ReferenceNumber = "CYPMD_16to19_RE_4F9C2A1",
+        SelectedPupilId = Guid.NewGuid().ToString(),
+        SelectedPupil = new PupilDto
+        {
+            Id = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+            Firstname = "Billy", Surname = "B", Sex = "M", DateOfBirth = "12/03/2007",
+            Age = 19, Cypmd_Id = "1596410810", Identifier = "9900000001"
+        },
+        SelectedResult = Result(),
+        QuestionAnswers = new Dictionary<string, QuestionAnswer>
+        {
+            ["q-cohort-scope"] = new() { TextValue = cohortWide ? "yes" : "no" },
+            ["q-cohort-count"] = new() { TextValue = cohortWide ? "10" : null },
+            ["q-revised-grade"] = new() { TextValue = "U" },
+            ["q-additional-info"] = new() { TextValue = additionalInfo }
+        },
+        QuestionHistory = ["cohort-scope", "select-result", "grade-details", "additional-info"]
+    };
+
+    // ── The reference number ─────────────────────────────────────────────────
+
+    [Fact]
+    public void The_enquiry_reference_follows_the_agreed_format()
+    {
+        // Decided: CYPMD_16to19_RE_{7 hex}. The mockup's "3014023_RE10005" was confirmed illustrative.
+        var reference = new JourneyValidationService().GenerateEnquiryReference();
+
+        Assert.Matches(new Regex("^CYPMD_16to19_RE_[0-9A-F]{7}$"), reference);
+    }
+
+    [Fact]
+    public void Enquiry_references_are_unique()
+    {
+        var service = new JourneyValidationService();
+
+        var references = Enumerable.Range(0, 200).Select(_ => service.GenerateEnquiryReference()).ToHashSet();
+
+        Assert.Equal(200, references.Count);
+    }
+
+    [Fact]
+    public void An_enquiry_reference_is_distinguishable_from_an_amendment_reference()
+    {
+        // Support staff read these aloud; "RE" is how they tell an enquiry from an amendment.
+        var service = new JourneyValidationService();
+
+        Assert.Contains("_RE_", service.GenerateEnquiryReference());
+        Assert.DoesNotContain("_RE_", service.GenerateReference(CheckingWindowType.Post16));
+    }
+
+    // ── Persistence ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Submitting_stores_a_results_enquiry_row()
+    {
+        await _sut.SubmitResultsEnquiryAsync(WindowId, Journey());
+
+        await _repository.Received(1).UpsertAsync(Arg.Is<ChangeRequestData>(d =>
+            d.WindowId == WindowId &&
+            d.ReferenceNumber == "CYPMD_16to19_RE_4F9C2A1" &&
+            d.RequestType == RequestType.ResultsEnquiry &&
+            d.AmendmentType == WhatToChange.IncorrectGrade &&
+            d.Status == RequestStatus.SubmittedUnCommitted));
+    }
+
+    [Fact]
+    public async Task The_row_carries_the_student_and_the_submitter()
+    {
+        await _sut.SubmitResultsEnquiryAsync(WindowId, Journey());
+
+        await _repository.Received(1).UpsertAsync(Arg.Is<ChangeRequestData>(d =>
+            d.PupilId == Guid.Parse("33333333-3333-3333-3333-333333333333") &&
+            d.PupilFirstname == "Billy" &&
+            d.PupilSurname == "B" &&
+            d.PupilUpn == "9900000001" &&
+            d.OrganisationUrn == 142313L &&
+            d.SubmittedById == UserId &&
+            d.SubmittedByName == "Ada Editor" &&
+            d.SubmittedByEmail == "ada@school.test"));
+    }
+
+    [Fact]
+    public async Task The_row_describes_the_enquiry_in_words()
+    {
+        // RequestTypeDescription is what the admin lists show.
+        await _sut.SubmitResultsEnquiryAsync(WindowId, Journey());
+
+        await _repository.Received(1).UpsertAsync(Arg.Is<ChangeRequestData>(d =>
+            d.RequestTypeDescription == "Results enquiry - Incorrect grade"));
+    }
+
+    [Fact]
+    public async Task The_timestamp_is_stored_as_the_wall_clock_kind_the_column_accepts()
+    {
+        // The column is `timestamp without time zone`; Npgsql rejects a Utc kind.
+        await _sut.SubmitResultsEnquiryAsync(WindowId, Journey());
+
+        await _repository.Received(1).UpsertAsync(
+            Arg.Is<ChangeRequestData>(d => d.Timestamp.Kind == DateTimeKind.Unspecified));
+    }
+
+    [Fact]
+    public async Task Submitting_saves_the_journey_json_so_the_enquiry_can_be_rebuilt()
+    {
+        var journey = Journey();
+
+        await _sut.SubmitResultsEnquiryAsync(WindowId, journey);
+
+        await _stateBlob.Received(1).SaveAsync(WindowId, "CYPMD_16to19_RE_4F9C2A1",
+            Arg.Is<RequestState>(s =>
+                s.SelectedResult!.Qan == "60180882" &&
+                s.SelectedResult.Grade == "9" &&
+                s.QuestionAnswers["q-revised-grade"].TextValue == "U"));
+    }
+
+    [Fact]
+    public async Task The_row_is_written_before_the_blob()
+    {
+        // The row is the record of truth; a blob with no row would be invisible to every admin view.
+        await _sut.SubmitResultsEnquiryAsync(WindowId, Journey());
+
+        Received.InOrder(() =>
+        {
+            _repository.UpsertAsync(Arg.Any<ChangeRequestData>());
+            _stateBlob.SaveAsync(WindowId, Arg.Any<string>(), Arg.Any<RequestState>());
+        });
+    }
+
+    [Fact]
+    public async Task Submitting_returns_the_reference_the_confirmation_page_shows()
+    {
+        var reference = await _sut.SubmitResultsEnquiryAsync(WindowId, Journey());
+
+        Assert.Equal("CYPMD_16to19_RE_4F9C2A1", reference);
+    }
+
+    // ── The parked boundary ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Submitting_never_enqueues_anything()
+    {
+        // BA decision: Zendesk dispatch is a separate story. Nothing here may enqueue until it lands.
+        await _sut.SubmitResultsEnquiryAsync(WindowId, Journey());
+
+        await _queue.DidNotReceiveWithAnyArgs().EnqueueAsync<object>(default!, default!);
+    }
+
+    [Fact]
+    public async Task Submitting_does_not_send_the_email_itself()
+    {
+        // The caller sends it, matching SubmitRequestAsync — so the journey controller can decide
+        // whether a failure to email should fail the submission (it must not).
+        await _sut.SubmitResultsEnquiryAsync(WindowId, Journey());
+
+        await _notifications.DidNotReceiveWithAnyArgs().NotifySubmissionConfirmedAsync(default, default, default!);
+    }
+
+    [Fact]
+    public async Task Submitting_does_not_run_the_duplicate_check()
+    {
+        // The spec allows several enquiries for the same pupil and result — a school may be reporting
+        // more than one thing about the same qualification.
+        await _sut.SubmitResultsEnquiryAsync(WindowId, Journey());
+
+        await _repository.DidNotReceiveWithAnyArgs()
+            .CheckForConflictAsync(default, default, default, default!, default);
+    }
+
+    [Fact]
+    public async Task Two_enquiries_for_the_same_result_both_persist()
+    {
+        var first = Journey();
+        var second = Journey();
+        second.ReferenceNumber = "CYPMD_16to19_RE_BBBBBB2";
+
+        await _sut.SubmitResultsEnquiryAsync(WindowId, first);
+        await _sut.SubmitResultsEnquiryAsync(WindowId, second);
+
+        await _repository.Received(2).UpsertAsync(Arg.Any<ChangeRequestData>());
+    }
+
+    // ── Guard rails ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("window")]
+    [InlineData("pupil")]
+    [InlineData("result")]
+    [InlineData("reference")]
+    public async Task An_incomplete_journey_is_refused_rather_than_half_written(string missing)
+    {
+        var journey = Journey();
+        switch (missing)
+        {
+            case "window": journey.CheckingWindow = null; break;
+            case "pupil": journey.SelectedPupil = null; break;
+            case "result": journey.SelectedResult = null; break;
+            case "reference": journey.ReferenceNumber = null; break;
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.SubmitResultsEnquiryAsync(WindowId, journey));
+        await _repository.DidNotReceiveWithAnyArgs().UpsertAsync(default!);
+        await _stateBlob.DidNotReceiveWithAnyArgs().SaveAsync(default, default!, default!);
+    }
+
+    [Fact]
+    public async Task A_journey_for_a_different_change_type_is_refused()
+    {
+        // This method is the enquiry path only; routing an amendment through it would store the wrong
+        // RequestType and silently bypass the rules engine.
+        var journey = Journey();
+        journey.SelectedWhatToChange = WhatToChange.Remove;
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.SubmitResultsEnquiryAsync(WindowId, journey));
+    }
+
+    [Fact]
+    public async Task The_single_pupil_branch_submits_without_a_cohort_count()
+    {
+        await _sut.SubmitResultsEnquiryAsync(WindowId, Journey(cohortWide: false));
+
+        await _repository.Received(1).UpsertAsync(Arg.Any<ChangeRequestData>());
+        await _stateBlob.Received(1).SaveAsync(WindowId, Arg.Any<string>(), Arg.Any<RequestState>());
+    }
+
+    [Fact]
+    public async Task Comments_are_optional()
+    {
+        await _sut.SubmitResultsEnquiryAsync(WindowId, Journey(additionalInfo: null));
+
+        await _stateBlob.Received(1).SaveAsync(WindowId, Arg.Any<string>(), Arg.Any<RequestState>());
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/ResultDetailsViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/ResultDetailsViewSourceTests.cs
@@ -1,0 +1,175 @@
+using System.Runtime.CompilerServices;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#296648 / AB#297130: pins the "Incorrect grade details" page and the grade picker partial.
+public sealed class ResultDetailsViewSourceTests
+{
+    private static string View(string name) =>
+        File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "DfE.CheckPerformanceData.Web", "Views", "Journey", name));
+
+    private static string Page() => View("ResultDetails.cshtml");
+    private static string Partial() => View("_GradeSelect.cshtml");
+
+    // ── The page ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_page_shows_which_result_is_being_corrected()
+    {
+        // The user is about to change a grade; they must be able to see it is the right one.
+        var view = Page();
+
+        foreach (var row in new[]
+                 {
+                     "Student name", "CYPMD ID", "Qualification number (QAN)",
+                     "Qualification name and subject", "Session", "Current grade"
+                 })
+        {
+            Assert.Contains($"<govuk-summary-list-row-key>{row}</govuk-summary-list-row-key>", view);
+        }
+    }
+
+    [Fact]
+    public void The_late_results_reminder_is_pinned_verbatim()
+    {
+        Assert.Contains(
+            "Before you report an incorrect grade, check the second late results (issued in November) to",
+            Page());
+        Assert.Contains("make sure the grade is not included there.", Page());
+    }
+
+    [Fact]
+    public void The_reminder_is_inset_text_after_the_picker_not_a_precondition()
+    {
+        var view = Page();
+
+        Assert.Contains("govuk-inset-text", view);
+        Assert.True(
+            view.IndexOf("_Question", StringComparison.Ordinal) < view.IndexOf("govuk-inset-text", StringComparison.Ordinal),
+            "The reminder must come after the grade picker, as the Figma screen shows.");
+    }
+
+    [Fact]
+    public void The_page_renders_an_error_summary_and_a_back_link()
+    {
+        var view = Page();
+
+        Assert.Contains("_JourneyErrorSummary", view);
+        Assert.Contains("_JourneyBackLink", view);
+    }
+
+    [Fact]
+    public void The_page_posts_to_the_generic_page_action()
+    {
+        // ResultDetails is a question page with a different view, so it reuses PagePost's answer
+        // handling rather than duplicating it.
+        var view = Page();
+
+        Assert.Contains("Url.Action(\"PagePost\", \"Journey\"", view);
+        Assert.Contains("@Html.AntiForgeryToken()", view);
+    }
+
+    // ── The grade picker ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_picker_is_a_real_select_so_the_page_works_without_javascript()
+    {
+        var view = Partial();
+
+        Assert.Contains("<select class=\"govuk-select", view);
+        Assert.Contains("@foreach (var option in Model.VisibleOptions)", view);
+    }
+
+    [Fact]
+    public void The_placeholder_option_has_an_empty_value_and_the_designs_text()
+    {
+        Assert.Contains("<option value=\"\">Select revised grade</option>", Partial());
+    }
+
+    [Fact]
+    public void Nothing_is_preselected_unless_the_user_already_chose_it()
+    {
+        Assert.Contains("selected=\"@(option.Value == Model.ExistingAnswer?.TextValue)\"", Partial());
+    }
+
+    [Fact]
+    public void The_field_name_follows_the_journey_convention()
+    {
+        // PagePost reads answers by q_{questionId with dashes as underscores}.
+        var view = Partial();
+
+        Assert.Contains("id=\"@Model.FieldName\" name=\"@Model.FieldName\"", view);
+    }
+
+    [Fact]
+    public void A_missing_grade_scale_is_explained_rather_than_shown_as_an_empty_control()
+    {
+        var view = Partial();
+
+        Assert.Contains("Model.GradeOptionsUnavailable", view);
+        Assert.Contains("We cannot list grades for this qualification yet", view);
+    }
+
+    [Fact]
+    public void The_describedby_chain_covers_hint_unavailable_and_error()
+    {
+        // Naming a missing element leaves a dangling reference, so each id is conditional on being
+        // rendered.
+        var view = Partial();
+
+        Assert.Contains("Model.Question.Hint is not null ? hintId : null", view);
+        Assert.Contains("Model.GradeOptionsUnavailable ? unavailableId : null", view);
+        Assert.Contains("Model.HasError ? errorId : null", view);
+    }
+
+    [Fact]
+    public void The_inline_error_carries_the_visually_hidden_error_prefix()
+    {
+        var view = Partial();
+
+        Assert.Contains("<span class=\"govuk-visually-hidden\">Error:</span>", view);
+        Assert.Contains("class=\"govuk-error-message\" id=\"@errorId\"", view);
+    }
+
+    [Fact]
+    public void The_select_is_enhanced_into_a_searchable_control()
+    {
+        // Some qualifications award 93 grades — far too many to scan in a plain dropdown.
+        var view = Partial();
+
+        Assert.Contains("accessibleAutocomplete.enhanceSelectElement({", view);
+        Assert.Contains("showAllValues: true", view);
+    }
+
+    [Fact]
+    public void The_enhancement_never_auto_picks_a_grade()
+    {
+        // 24F and 24D differ by one character; auto-selecting the first match could turn a fail into
+        // a pass without the user noticing.
+        var view = Partial();
+
+        Assert.Contains("autoselect: false", view);
+        Assert.Contains("confirmOnBlur: false", view);
+    }
+
+    [Fact]
+    public void The_enhancement_is_skipped_when_there_is_nothing_to_choose()
+    {
+        var view = Partial();
+
+        Assert.Contains("select.options.length <= 1", view);
+        Assert.Contains("typeof accessibleAutocomplete === 'undefined'", view);
+    }
+
+    private static string RepoRoot
+    {
+        get
+        {
+            var thisFile = ThisFilePath();
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+        }
+    }
+
+    private static string ThisFilePath([CallerFilePath] string path = "") => path;
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/ResultSearchViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/ResultSearchViewSourceTests.cs
@@ -1,0 +1,164 @@
+using System.Runtime.CompilerServices;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#296648: pins the ResultSearch page's markup (Figma p-147877 / p-147913).
+//
+// The property that matters most is that this page works with JavaScript off. CLAUDE.md makes
+// progressive enhancement mandatory, so the options are server-rendered into a real <select> that
+// accessible-autocomplete upgrades in place — not fetched, which would leave a script-less browser
+// with an empty control.
+public sealed class ResultSearchViewSourceTests
+{
+    private static string ViewSource() =>
+        File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "DfE.CheckPerformanceData.Web", "Views", "Journey", "ResultSearch.cshtml"));
+
+    [Fact]
+    public void The_control_is_a_real_select_so_the_page_works_without_javascript()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("<select class=\"govuk-select", view);
+        Assert.Contains("id=\"result-search\" name=\"selectedResultKey\"", view);
+        Assert.Contains("@foreach (var result in Model.AvailableResults)", view);
+    }
+
+    [Fact]
+    public void Each_option_carries_the_composite_key_as_its_value()
+    {
+        // The QAN alone cannot identify a result — the same qualification can appear in two sessions.
+        Assert.Contains("value=\"@result.CompositeKey\"", ViewSource());
+    }
+
+    [Fact]
+    public void Option_text_comes_from_the_shared_label_helper()
+    {
+        // Same helper the suggestions endpoint uses, so the enhanced and unenhanced views of this
+        // page cannot describe the same result differently.
+        Assert.Contains("ResultLabel.For(result)", ViewSource());
+    }
+
+    [Fact]
+    public void Nothing_is_preselected()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("<option value=\"\"></option>", view);
+        Assert.Contains("selected=\"@(result.CompositeKey == Model.SelectedResultKey)\"", view);
+    }
+
+    [Fact]
+    public void The_select_is_enhanced_rather_than_replaced()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("accessibleAutocomplete.enhanceSelectElement({", view);
+        Assert.Contains("selectElement: select", view);
+        // Guards against a regression to a fetch-only autocomplete, which would break the no-JS path.
+        Assert.DoesNotContain("/results/suggestions", view);
+    }
+
+    [Fact]
+    public void The_enhancement_never_auto_picks_a_result()
+    {
+        // Choosing the wrong result sends the DfE to check a grade the school never queried.
+        var view = ViewSource();
+
+        Assert.Contains("autoselect: false", view);
+        Assert.Contains("confirmOnBlur: false", view);
+    }
+
+    [Fact]
+    public void The_script_degrades_quietly_when_the_autocomplete_library_is_absent()
+    {
+        // Without this the page would throw and leave the (working) select in place but unstyled.
+        Assert.Contains("typeof accessibleAutocomplete === 'undefined'", ViewSource());
+    }
+
+    [Fact]
+    public void The_heading_labels_the_control()
+    {
+        // enhanceSelectElement moves the select's id onto the new input, so this label names
+        // whichever control is visible.
+        var view = ViewSource();
+
+        Assert.Contains("<label class=\"govuk-label govuk-label--l\" for=\"result-search\">@Model.Title</label>", view);
+        Assert.Contains("<h1 class=\"govuk-label-wrapper\">", view);
+    }
+
+    [Fact]
+    public void The_hint_matches_the_design()
+        => Assert.Contains("Start typing to search for results by subject or QAN", ViewSource());
+
+    [Fact]
+    public void The_error_summary_and_inline_error_both_target_the_control()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("<govuk-error-summary-item href=\"#result-search\">", view);
+        Assert.Contains("id=\"result-search-error\" class=\"govuk-error-message\"", view);
+        Assert.Contains("<span class=\"govuk-visually-hidden\">Error:</span>", view);
+    }
+
+    [Fact]
+    public void The_describedby_chain_covers_the_hint_and_the_error()
+    {
+        Assert.Contains(
+            "aria-describedby=\"result-search-hint @(hasError ? \"result-search-error\" : \"\")\"",
+            ViewSource());
+    }
+
+    [Fact]
+    public void The_browser_title_does_not_leak_the_student_name()
+    {
+        // Model.Title contains the student's name and the <title> reaches analytics.
+        var view = ViewSource();
+
+        Assert.Contains("ViewBag.Title = \"Which result is incorrect?\"", view);
+        Assert.DoesNotContain("ViewBag.Title = Model.Title", view);
+    }
+
+    [Fact]
+    public void The_selected_state_shows_the_confirmation_summary_rows()
+    {
+        // Figma p-147894: once a result is chosen the page proves which one, including the source
+        // file — the one thing the label itself cannot disambiguate.
+        var view = ViewSource();
+
+        foreach (var row in new[]
+                 {
+                     "Qualification name and subject", "Qualification number (QAN)",
+                     "Syllabus code", "Session", "Current Grade", "CSV file"
+                 })
+        {
+            Assert.Contains($"<govuk-summary-list-row-key>{row}</govuk-summary-list-row-key>", view);
+        }
+    }
+
+    [Fact]
+    public void The_form_posts_to_the_result_search_action_with_an_antiforgery_token()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("Url.Action(\"ResultSearchPost\", \"Journey\"", view);
+        Assert.Contains("@Html.AntiForgeryToken()", view);
+    }
+
+    [Fact]
+    public void The_back_link_uses_the_resolved_action_rather_than_guessing()
+    {
+        Assert.Contains("asp-action=\"@Model.BackPageAction\"", ViewSource());
+    }
+
+    private static string RepoRoot
+    {
+        get
+        {
+            var thisFile = ThisFilePath();
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", ".."));
+        }
+    }
+
+    private static string ThisFilePath([CallerFilePath] string path = "") => path;
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Journey/WholeNumberFormatValidatorTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Journey/WholeNumberFormatValidatorTests.cs
@@ -1,0 +1,62 @@
+using DfE.CheckPerformanceData.Application.Journey.Validators;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Journey;
+
+// AB#296648: the cohort-count question ("how many students have an incorrect grade for this
+// qualification?"). A count is a plain whole number — a decimal, a sign or a thousands separator is
+// a typo, not a quantity.
+public class WholeNumberFormatValidatorTests
+{
+    private readonly WholeNumberFormatValidator _sut = new();
+
+    [Fact]
+    public void Name_is_the_name_the_flow_config_references()
+    {
+        // The engine fails OPEN on an unresolved validator name — the format check is simply skipped
+        // — so this string is load-bearing and never silently wrong.
+        Assert.Equal("WholeNumber", _sut.Name);
+    }
+
+    [Fact]
+    public void The_failure_message_is_the_cohort_count_copy()
+    {
+        // The engine reports validator.FailureMessage, not the question's validationFailure, so the
+        // two must read identically or the user sees different copy for empty vs malformed.
+        Assert.Equal("Enter how many students have an incorrect grade for this qualification", _sut.FailureMessage);
+    }
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("10")]
+    [InlineData("9999")]
+    [InlineData(" 10 ")]      // surrounding whitespace is a typing artefact, not a different answer
+    public void A_whole_number_between_one_and_9999_is_valid(string value)
+        => Assert.True(_sut.IsValid(value));
+
+    [Theory]
+    [InlineData("0")]         // a cohort of nobody is not an enquiry
+    [InlineData("-3")]
+    [InlineData("+3")]
+    [InlineData("2.5")]
+    [InlineData("2,5")]
+    [InlineData("1 000")]     // internal whitespace
+    [InlineData("1,000")]     // thousands separator
+    [InlineData("ten")]
+    [InlineData("10a")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("10000")]     // above the cap
+    [InlineData("00")]        // zero however it is written
+    public void Anything_else_is_invalid(string value)
+        => Assert.False(_sut.IsValid(value));
+
+    [Theory]
+    [InlineData("01")]
+    [InlineData("0010")]
+    public void A_leading_zero_is_accepted_because_the_value_it_denotes_is_in_range(string value)
+        => Assert.True(_sut.IsValid(value));
+
+    [Fact]
+    public void A_number_far_beyond_int_range_is_invalid_rather_than_throwing()
+        => Assert.False(_sut.IsValid(new string('9', 40)));
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Notify/NotifyServiceResultsEnquiryTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Notify/NotifyServiceResultsEnquiryTests.cs
@@ -1,0 +1,151 @@
+using DfE.CheckPerformanceData.Application.Notify;
+using DfE.CheckPerformanceData.Infrastructure.Notify;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Notify;
+
+// AB#296648: the results-enquiry confirmation email.
+//
+// NotifyService resolves a template id from a switch whose default arm THROWS. Adding a
+// NotificationType member without a case here means the email silently never sends in a deployed
+// environment — the local DevConsoleNotifyService would still log it, so nothing would look wrong.
+// That is the gap these tests close.
+public sealed class NotifyServiceResultsEnquiryTests
+{
+    private const string EnquiryTemplateId = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb";
+
+    private readonly INotifyEmailClient _client = Substitute.For<INotifyEmailClient>();
+    private readonly ILogger<NotifyService> _logger = Substitute.For<ILogger<NotifyService>>();
+
+    private NotifyService Build(string? enquiryTemplateId = EnquiryTemplateId)
+    {
+        var settings = new NotifySettings
+        {
+            ApiKey = "test-key",
+            SubmissionNotificationTemplateId = "sub-template",
+            BulkSubmissionNotificationTemplateId = "bulk-template",
+            PupilDataCheckConfirmTemplateId = "confirm-template",
+            PupilDataCheckWithdrawTemplateId = "withdraw-check-template",
+            WithdrawNotificationTemplateId = "withdraw-template",
+            DlqThresholdTemplateId = "dlq-template",
+            ResultsEnquirySubmittedTemplateId = enquiryTemplateId!
+        };
+
+        return new NotifyService(_client, Options.Create(settings), _logger);
+    }
+
+    [Fact]
+    public async Task A_results_enquiry_notification_uses_its_configured_template()
+    {
+        // Without the switch case this throws ArgumentOutOfRangeException instead.
+        await Build().SendNotificationsAsync(
+            "CYPMD_16to19_RE_4F9C2A1", string.Empty, ["ada@school.test"],
+            NotificationType.ResultsEnquirySubmitted);
+
+        await _client.Received(1).SendEmailAsync(
+            "ada@school.test", EnquiryTemplateId, Arg.Any<Dictionary<string, object>>());
+    }
+
+    [Fact]
+    public async Task The_reference_number_reaches_the_template()
+    {
+        // The whole point of the email: the school needs the reference to quote back.
+        await Build().SendNotificationsAsync(
+            "CYPMD_16to19_RE_4F9C2A1", string.Empty, ["ada@school.test"],
+            NotificationType.ResultsEnquirySubmitted);
+
+        await _client.Received(1).SendEmailAsync(
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Is<Dictionary<string, object>>(p =>
+                (string)p["ref number"] == "CYPMD_16to19_RE_4F9C2A1" &&
+                (string)p["email address"] == "ada@school.test"));
+    }
+
+    [Fact]
+    public async Task Every_recipient_is_emailed()
+    {
+        await Build().SendNotificationsAsync(
+            "CYPMD_16to19_RE_4F9C2A1", string.Empty, ["one@school.test", "two@school.test"],
+            NotificationType.ResultsEnquirySubmitted);
+
+        await _client.Received(2).SendEmailAsync(
+            Arg.Any<string>(), EnquiryTemplateId, Arg.Any<Dictionary<string, object>>());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task An_unconfigured_template_logs_a_warning_and_sends_nothing(string? templateId)
+    {
+        // The template does not exist yet (an ops prerequisite). Until it does, the send must be a
+        // no-op with a warning — not an exception, and not a call to Notify with a blank template that
+        // would fail once per recipient.
+        await Build(templateId).SendNotificationsAsync(
+            "CYPMD_16to19_RE_4F9C2A1", string.Empty, ["ada@school.test"],
+            NotificationType.ResultsEnquirySubmitted);
+
+        await _client.DidNotReceiveWithAnyArgs()
+            .SendEmailAsync(default!, default!, default!);
+        _logger.Received().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task An_unconfigured_template_does_not_throw()
+    {
+        // Submission has already succeeded by the time this runs; an exception here must not be able
+        // to turn a successful enquiry into an error for the user.
+        var service = Build(enquiryTemplateId: null);
+
+        await service.SendNotificationsAsync(
+            "CYPMD_16to19_RE_4F9C2A1", string.Empty, ["ada@school.test"],
+            NotificationType.ResultsEnquirySubmitted);
+    }
+
+    [Fact]
+    public async Task A_send_failure_is_isolated_per_recipient()
+    {
+        // Existing behaviour that must survive: one bad address does not stop the others.
+        var service = Build();
+        _client.SendEmailAsync("bad@school.test", Arg.Any<string>(), Arg.Any<Dictionary<string, object>>())
+            .Returns<Task>(_ => throw new InvalidOperationException("Notify rejected it"));
+
+        await service.SendNotificationsAsync(
+            "CYPMD_16to19_RE_4F9C2A1", string.Empty, ["bad@school.test", "good@school.test"],
+            NotificationType.ResultsEnquirySubmitted);
+
+        await _client.Received(1).SendEmailAsync(
+            "good@school.test", EnquiryTemplateId, Arg.Any<Dictionary<string, object>>());
+    }
+
+    [Fact]
+    public async Task The_existing_notification_types_still_resolve_their_templates()
+    {
+        // Guards against the new case or the blank-template guard disturbing the live emails.
+        var service = Build();
+
+        foreach (var (type, expected) in new[]
+                 {
+                     (NotificationType.SubmissionConfirmed, "sub-template"),
+                     (NotificationType.BulkSubmissionConfirmed, "bulk-template"),
+                     (NotificationType.DataCheckConfirmed, "confirm-template"),
+                     (NotificationType.AmendmentWithdrawn, "withdraw-template"),
+                     (NotificationType.DataCheckWithdrawn, "withdraw-check-template"),
+                 })
+        {
+            _client.ClearReceivedCalls();
+
+            await service.SendNotificationsAsync("REF-1", "a deadline", ["ada@school.test"], type);
+
+            await _client.Received(1).SendEmailAsync(
+                "ada@school.test", expected, Arg.Any<Dictionary<string, object>>());
+        }
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Notify/RequestNotificationServiceEnquiryTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Notify/RequestNotificationServiceEnquiryTests.cs
@@ -1,0 +1,80 @@
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.Notify;
+using DfE.CheckPerformanceData.Infrastructure.Notify;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Notify;
+
+// AB#296648: what the producer side puts on the notification queue for a submitted results enquiry.
+//
+// Two choices are deliberate and worth pinning. There is no deadline — an enquiry is not something the
+// school must come back and finish before the window shuts — and it goes to the submitter only, since
+// nothing is being asked of the rest of the school.
+public sealed class RequestNotificationServiceEnquiryTests
+{
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IEmailLinkGenerator _linkGenerator = Substitute.For<IEmailLinkGenerator>();
+    private readonly INotificationDispatcher _dispatcher = Substitute.For<INotificationDispatcher>();
+    private readonly RequestNotificationService _sut;
+
+    public RequestNotificationServiceEnquiryTests()
+    {
+        _currentUser.Ukprn.Returns("10001234");
+        _currentUser.Email.Returns("ada@school.test");
+
+        _sut = new RequestNotificationService(
+            _currentUser, _linkGenerator, _dispatcher,
+            Options.Create(new NotifySettings { ApiKey = "test-key" }));
+    }
+
+    [Fact]
+    public async Task One_notification_is_queued_for_the_enquiry()
+    {
+        await _sut.NotifyResultsEnquirySubmittedAsync("CYPMD_16to19_RE_4F9C2A1");
+
+        await _dispatcher.Received(1).EnqueueAsync(Arg.Is<EmailNotification>(n =>
+            n.Type == NotificationType.ResultsEnquirySubmitted &&
+            n.ReferenceNumber == "CYPMD_16to19_RE_4F9C2A1"));
+    }
+
+    [Fact]
+    public async Task It_carries_the_submitter_and_their_organisation()
+    {
+        await _sut.NotifyResultsEnquirySubmittedAsync("CYPMD_16to19_RE_4F9C2A1");
+
+        await _dispatcher.Received(1).EnqueueAsync(Arg.Is<EmailNotification>(n =>
+            n.OriginatorEmail == "ada@school.test" && n.Ukprn == "10001234"));
+    }
+
+    [Fact]
+    public async Task It_goes_to_the_submitter_only()
+    {
+        // An enquiry asks nothing of the rest of the school, so copying every user would be noise.
+        await _sut.NotifyResultsEnquirySubmittedAsync("CYPMD_16to19_RE_4F9C2A1");
+
+        await _dispatcher.Received(1).EnqueueAsync(
+            Arg.Is<EmailNotification>(n => !n.IncludeOrganisationUsers));
+    }
+
+    [Fact]
+    public async Task It_carries_no_deadline()
+    {
+        // Unlike an amendment, there is nothing for the school to finish before the window closes —
+        // so a deadline in this email would be misleading.
+        await _sut.NotifyResultsEnquirySubmittedAsync("CYPMD_16to19_RE_4F9C2A1");
+
+        await _dispatcher.Received(1).EnqueueAsync(
+            Arg.Is<EmailNotification>(n => n.Deadline == string.Empty));
+    }
+
+    [Fact]
+    public async Task It_needs_no_link_generation()
+    {
+        // The submission email links back into the journey; this one does not, so it must not depend
+        // on HttpContext-backed link generation.
+        await _sut.NotifyResultsEnquirySubmittedAsync("CYPMD_16to19_RE_4F9C2A1");
+
+        _linkGenerator.DidNotReceiveWithAnyArgs().GenerateLink(default!, default!, default!, default!);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/EnumContractTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/EnumContractTests.cs
@@ -1,0 +1,54 @@
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Domain.Enums;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.ResultsEnquiry;
+
+// AB#296648: results-enquiry enum members must exist, serialize within the
+// ChangeRequest string-column limits (max 20), and be appended after existing
+// members so stored values are unmoved.
+public sealed class EnumContractTests
+{
+    [Fact]
+    public void ResultsEnquiry_request_type_exists_and_fits_column()
+    {
+        var name = RequestType.ResultsEnquiry.ToString();
+        Assert.Equal("ResultsEnquiry", name);
+        Assert.True(name.Length <= 20);
+        Assert.Equal(2, (int)RequestType.ResultsEnquiry); // appended after ConfirmCorrect
+    }
+
+    [Fact]
+    public void IncorrectGrade_what_to_change_exists_and_fits_column()
+    {
+        var name = WhatToChange.IncorrectGrade.ToString();
+        Assert.Equal("IncorrectGrade", name);
+        Assert.True(name.Length <= 20);
+        Assert.Equal(4, (int)WhatToChange.IncorrectGrade); // appended after Add
+    }
+
+    [Fact]
+    public void Journey_engine_enums_gain_results_enquiry_members()
+    {
+        Assert.Equal(4, (int)PageType.ResultSearch);
+        Assert.Equal(5, (int)PageType.ResultDetails);
+        Assert.Equal(6, (int)QuestionType.GradeSelect);
+        Assert.Equal(2, (int)NextSteps.ResultsEnquiry); // appended after Confirm
+    }
+
+    [Fact]
+    public void RequestState_carries_the_selected_result_label()
+    {
+        var state = new RequestState { SelectedResultLabel = "GCSE (9-1) French, QAN: 60181576" };
+
+        Assert.Equal("GCSE (9-1) French, QAN: 60181576", state.SelectedResultLabel);
+    }
+
+    [Theory]
+    [InlineData(WhatToChange.IncorrectGrade, "ResultsEnquiry")]
+    [InlineData(WhatToChange.Merge, "PupilData")]
+    [InlineData(WhatToChange.Remove, "PupilData")]
+    public void WhatToChange_maps_to_its_window_activity(WhatToChange change, string activity)
+        => Assert.Equal(activity, WhatToChangeActivityMap.ActivityFor(change));
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/GradeReferenceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/GradeReferenceTests.cs
@@ -1,0 +1,124 @@
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.ResultsEnquiry;
+
+// AB#297130: the AODC grade reference is what makes the revised-grade picker offer the right
+// options for a qualification. It is parsed from a checked-in seed file until the full AODC export
+// arrives, so these tests bind the SHIPPED file — a hand-edit that breaks the shape or reorders a
+// grade scale fails here rather than silently changing what schools can pick.
+public sealed class GradeReferenceTests
+{
+    private static GradeReferenceLookup ShippedSeed()
+        => GradeReferenceLookup.Parse(File.ReadAllText(LocateSeedFile()));
+
+    [Fact]
+    public void Pass_grades_render_before_fail_grades()
+    {
+        // The BTEC example from the ticket, pinned in full: this exact sequence is what the
+        // <select> renders, so a reordering in the seed file is a user-visible change.
+        var reference = ShippedSeed().Find("60370683");
+
+        Assert.NotNull(reference);
+        Assert.Equal(
+            ["*2", "P1", "P2", "M1", "M2", "D1", "D2", "F", "Q", "R", "U", "X"],
+            reference.AllGrades.ToArray());
+        Assert.Equal(["*2", "P1", "P2", "M1", "M2", "D1", "D2"], reference.PassGrades.ToArray());
+        Assert.Equal(["F", "Q", "R", "U", "X"], reference.FailGrades.ToArray());
+    }
+
+    [Fact]
+    public void Carries_the_qualification_title_and_awarding_organisation()
+    {
+        var reference = ShippedSeed().Find("10025480");
+
+        Assert.NotNull(reference);
+        Assert.Equal("OCR", reference.AwardingOrganisation);
+        Assert.Equal(["A", "B", "C", "D", "E", "Q", "R", "U", "X"], reference.AllGrades.ToArray());
+        Assert.NotEmpty(reference.QualificationTitle);
+    }
+
+    [Fact]
+    public void An_unknown_qan_returns_null_rather_than_throwing()
+        => Assert.Null(ShippedSeed().Find("00000000"));
+
+    [Fact]
+    public void A_null_or_blank_qan_returns_null()
+    {
+        var seed = ShippedSeed();
+
+        Assert.Null(seed.Find(null));
+        Assert.Null(seed.Find("   "));
+    }
+
+    [Fact]
+    public void Lookup_is_case_insensitive_and_trimmed_because_qans_can_end_in_a_letter()
+    {
+        // 6037116X is a real QAN shape — a supplier file could carry it lower-cased or padded.
+        var seed = ShippedSeed();
+
+        Assert.NotNull(seed.Find("6037116x"));
+        Assert.NotNull(seed.Find(" 6037116X "));
+    }
+
+    [Fact]
+    public void The_gcse_nine_to_one_scale_is_seeded_for_the_dev_qans()
+    {
+        var seed = ShippedSeed();
+
+        foreach (var qan in new[] { "6037116X", "60181576", "60180882" })
+        {
+            var reference = seed.Find(qan);
+            Assert.NotNull(reference);
+            Assert.Equal(["9", "8", "7", "6", "5", "4", "3", "2", "1"], reference.PassGrades.ToArray());
+            Assert.Equal(["U", "X"], reference.FailGrades.ToArray());
+        }
+    }
+
+    [Fact]
+    public void Every_seed_entrys_key_agrees_with_its_own_qan_field()
+    {
+        // The file is keyed by QAN and each record repeats it. A disagreement would make a
+        // qualification unreachable by the key the results blob actually carries.
+        foreach (var (key, reference) in ShippedSeed().Entries)
+            Assert.Equal(key, reference.Qan);
+    }
+
+    [Fact]
+    public void No_seed_entry_has_an_empty_grade_scale()
+    {
+        // An empty scale renders a picker with nothing to choose, which validation can never pass.
+        foreach (var (key, reference) in ShippedSeed().Entries)
+            Assert.True(reference.AllGrades.Count > 0, $"QAN {key} has no grades.");
+    }
+
+    [Fact]
+    public void No_grade_appears_in_both_the_pass_and_fail_list()
+    {
+        foreach (var (key, reference) in ShippedSeed().Entries)
+            Assert.Empty(reference.PassGrades.Intersect(reference.FailGrades, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void Malformed_json_throws_so_a_broken_seed_file_surfaces()
+        => Assert.Throws<System.Text.Json.JsonException>(() => GradeReferenceLookup.Parse("{not json"));
+
+    [Fact]
+    public void An_empty_document_parses_to_an_empty_lookup()
+        => Assert.Empty(GradeReferenceLookup.Parse("{}").Entries);
+
+    private static string LocateSeedFile()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName,
+                "src", "DfE.CheckPerformanceData.Web", "Data", "GradeReference", "grade-reference.json");
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException(
+            "Could not locate src/DfE.CheckPerformanceData.Web/Data/GradeReference/grade-reference.json from " +
+            AppContext.BaseDirectory);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/IncorrectGradeFlowTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/IncorrectGradeFlowTests.cs
@@ -1,0 +1,298 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.Journey.Validators;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.ResultsEnquiry;
+
+/// <summary>
+/// Pins the shipped <c>IncorrectGrade_Post16.json</c> flow. Page and question ids are a
+/// serialization contract — they are written into session state and into submitted request
+/// documents — so a rename after merge orphans stored data. The copy is pinned because it is what
+/// the user reads.
+/// </summary>
+public sealed class IncorrectGradeFlowTests
+{
+    // Mirrors QuestionFlowBlobClient's deserialization options.
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    private static readonly QuestionFlowConfig Flow = Load();
+
+    private static JourneyPage Page(string id) =>
+        Flow.Pages.SingleOrDefault(p => p.Id == id)
+        ?? throw new Xunit.Sdk.XunitException($"IncorrectGrade_Post16.json has no page '{id}'.");
+
+    private static Question Question(string pageId, string questionId) =>
+        Page(pageId).Questions.Single(q => q.Id == questionId);
+
+    [Fact]
+    public void The_journey_starts_at_the_cohort_scope_question()
+    {
+        // NOT the interstitial: whether the "check your second late results file" page is shown is a
+        // runtime decision (does the school hold any LR2 result?), so the controller enters it. Making
+        // it firstPageId would show it unconditionally.
+        Assert.Equal("cohort-scope", Flow.FirstPageId);
+    }
+
+    [Fact]
+    public void Every_page_id_is_present_exactly_once_and_none_have_been_renamed()
+    {
+        Assert.Equal(
+            [
+                "check-late-results", "cohort-scope", "cohort-count",
+                "select-student-cohort", "select-student-single",
+                "select-result", "grade-details", "additional-info"
+            ],
+            Flow.Pages.Select(p => p.Id).ToArray());
+    }
+
+    [Fact]
+    public void Every_next_page_target_resolves_to_a_real_page()
+    {
+        // A dangling nextPageId strands the user mid-journey with no way forward.
+        var ids = Flow.Pages.Select(p => p.Id).ToHashSet();
+
+        foreach (var page in Flow.Pages)
+        {
+            if (page.NextPageId is not null)
+                Assert.Contains(page.NextPageId, ids);
+
+            foreach (var option in page.Questions.SelectMany(q => q.Options ?? []))
+                if (option.NextPageId is not null)
+                    Assert.Contains(option.NextPageId, ids);
+        }
+
+        Assert.Contains(Flow.FirstPageId, ids);
+    }
+
+    // ── The interstitial ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_late_results_interstitial_informs_and_continues_into_the_journey()
+    {
+        // AB#296648: "The guidance informs the user. It does not stop the user continuing."
+        var page = Page("check-late-results");
+
+        Assert.Equal(PageType.Content, page.Type);
+        Assert.Equal("Check your second late results file before you report an incorrect grade", page.Title);
+        Assert.Equal(
+            "Nearly all incorrect grades are updated in the second late results file. " +
+            "We will email you in late November to let you know it's available.",
+            page.Content);
+        Assert.Equal("cohort-scope", page.NextPageId);
+        Assert.Empty(page.Questions);
+    }
+
+    // ── Cohort scope ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_cohort_scope_question_is_a_radio_with_the_pinned_copy()
+    {
+        var page = Page("cohort-scope");
+        var question = Question("cohort-scope", "q-cohort-scope");
+
+        Assert.Equal(PageType.Question, page.Type);
+        Assert.Equal("Does the incorrect grade affect the whole cohort?", page.Title);
+        Assert.Equal(QuestionType.Radio, question.Type);
+        Assert.Equal("Does the incorrect grade affect the whole cohort?", question.Title);
+        Assert.Equal("Select one option", question.Hint);
+        Assert.Equal("Select if the incorrect grade affects the whole cohort", question.ValidationFailure);
+    }
+
+    [Fact]
+    public void Yes_asks_for_a_count_and_no_goes_straight_to_one_student()
+    {
+        // The branch is the whole point of the question: a cohort-wide problem has one cause, so
+        // asking for every student would create duplicate enquiries.
+        var options = Question("cohort-scope", "q-cohort-scope").Options!;
+
+        Assert.Equal(2, options.Count);
+
+        Assert.Equal("yes", options[0].Value);
+        Assert.Equal("Yes", options[0].Label);
+        Assert.Equal("Provide an example of one student", options[0].SubLabel);
+        Assert.Equal("cohort-count", options[0].NextPageId);
+
+        Assert.Equal("no", options[1].Value);
+        Assert.Equal("No", options[1].Label);
+        Assert.Equal("Complete a separate enquiry for each student affected", options[1].SubLabel);
+        Assert.Equal("select-student-single", options[1].NextPageId);
+    }
+
+    [Fact]
+    public void Neither_cohort_option_is_conditionally_hidden()
+    {
+        Assert.All(Question("cohort-scope", "q-cohort-scope").Options!, o => Assert.Null(o.VisibleWhen));
+    }
+
+    // ── Cohort count ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_cohort_count_is_a_validated_whole_number()
+    {
+        var page = Page("cohort-count");
+        var question = Question("cohort-count", "q-cohort-count");
+
+        Assert.Equal("Enter the number of students who have an incorrect grade for this qualification", page.Title);
+        Assert.Equal("select-student-cohort", page.NextPageId);
+        Assert.Equal(QuestionType.FreeText, question.Type);
+        Assert.Equal("Enter the number of students", question.Hint);
+        // The engine fails OPEN on an unresolved validator name, so this string must match
+        // WholeNumberFormatValidator.Name exactly or the format check is silently skipped.
+        Assert.Equal("WholeNumber", question.Validator);
+        Assert.Equal("Enter how many students have an incorrect grade for this qualification", question.ValidationFailure);
+        Assert.Equal("Number of students in affected cohort", question.SummaryTitle);
+        Assert.False(question.Optional);
+    }
+
+    [Fact]
+    public void The_cohort_count_validator_name_resolves_to_the_registered_validator()
+    {
+        var validator = new WholeNumberFormatValidator();
+
+        Assert.Equal(validator.Name, Question("cohort-count", "q-cohort-count").Validator);
+        // Required-vs-malformed must read the same, or the field appears to have two rules.
+        Assert.Equal(validator.FailureMessage, Question("cohort-count", "q-cohort-count").ValidationFailure);
+    }
+
+    // ── Pupil search: both branches converge ─────────────────────────────────
+
+    [Theory]
+    [InlineData("select-student-cohort", "What is the name of one of the students from the affected cohort?")]
+    [InlineData("select-student-single", "What is the name of the student with an incorrect grade?")]
+    public void Both_student_search_pages_search_all_students_and_lead_to_the_result(string pageId, string title)
+    {
+        // "A pupil may be missing from the included data and still have a wrong grade", so both
+        // populations are searchable — PupilFilter.All, not Included.
+        var page = Page(pageId);
+
+        Assert.Equal(PageType.PupilSearch, page.Type);
+        Assert.Equal(title, page.Title);
+        Assert.Equal(PupilFilter.All, page.PupilFilter);
+        Assert.Equal(JourneyPage.PrimaryKey, page.PupilKey);
+        Assert.Equal("Enter the name of the student with an incorrect grade", page.ValidationFailure);
+        Assert.Equal("select-result", page.NextPageId);
+    }
+
+    // ── Result search ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_result_search_page_is_templated_on_the_selected_student()
+    {
+        var page = Page("select-result");
+
+        Assert.Equal(PageType.ResultSearch, page.Type);
+        Assert.Equal("Which of {pupilName}'s results is incorrect?", page.Title);
+        Assert.Equal("Enter which of {pupilName}'s results is incorrect", page.ValidationFailure);
+        Assert.Equal("grade-details", page.NextPageId);
+    }
+
+    [Fact]
+    public void The_result_search_browser_title_does_not_leak_the_student_name()
+    {
+        // The <title> reaches analytics, so a student name in it is a data-protection problem.
+        var page = Page("select-result");
+
+        var browserTitle = page.PageTitle ?? JourneyTemplate.Strip(page.Title!);
+        Assert.DoesNotContain("{pupilName}", browserTitle);
+    }
+
+    // ── Grade details ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_grade_details_page_asks_for_the_revised_grade()
+    {
+        var page = Page("grade-details");
+        var question = Question("grade-details", "q-revised-grade");
+
+        Assert.Equal(PageType.ResultDetails, page.Type);
+        Assert.Equal("Incorrect grade details", page.Title);
+        Assert.Equal("additional-info", page.NextPageId);
+        Assert.Equal(QuestionType.GradeSelect, question.Type);
+        Assert.Equal("What should the revised grade be?", question.Title);
+        Assert.Equal("Select the revised grade", question.ValidationFailure);
+        Assert.False(question.Optional);
+    }
+
+    // ── Additional information ───────────────────────────────────────────────
+
+    [Fact]
+    public void Additional_information_is_optional_and_capped()
+    {
+        // "Most enquiries need no explanation. The field is there for the ones that do."
+        var page = Page("additional-info");
+        var question = Question("additional-info", "q-additional-info");
+
+        Assert.Equal("Additional information (Optional)", page.Title);
+        Assert.Equal("Additional information", page.PageTitle);
+        Assert.Null(page.NextPageId); // the last page — Continue goes to the summary
+        Assert.Equal(QuestionType.TextArea, question.Type);
+        Assert.True(question.Optional);
+        Assert.Equal(250, question.CharacterLimit);
+        Assert.Equal(
+            "You can provide us with any additional information to support your query if you need to.",
+            question.Hint);
+        Assert.Equal("Additional information", question.SummaryTitle);
+    }
+
+    // ── Whole-flow invariants ────────────────────────────────────────────────
+
+    [Fact]
+    public void No_question_id_is_reused_across_the_flow()
+    {
+        // Answers are stored in one dictionary keyed by question id, so a duplicate silently
+        // overwrites another page's answer.
+        var ids = Flow.Pages.SelectMany(p => p.Questions).Select(q => q.Id).ToArray();
+
+        Assert.Equal(ids.Length, ids.Distinct().Count());
+    }
+
+    [Fact]
+    public void Only_the_additional_information_question_is_optional()
+    {
+        var optional = Flow.Pages.SelectMany(p => p.Questions).Where(q => q.Optional).Select(q => q.Id);
+
+        Assert.Equal(["q-additional-info"], optional.ToArray());
+    }
+
+    [Fact]
+    public void Every_question_has_validation_failure_copy_unless_it_is_optional()
+    {
+        // Without it the engine falls back to "{title} is required", which reads badly for a
+        // question whose title is a full sentence.
+        foreach (var question in Flow.Pages.SelectMany(p => p.Questions).Where(q => !q.Optional))
+            Assert.False(string.IsNullOrWhiteSpace(question.ValidationFailure), $"{question.Id} has no validationFailure.");
+    }
+
+    [Fact]
+    public void The_config_key_is_the_journey_and_window_type_this_flow_serves()
+    {
+        // QuestionFlowService resolves "{WhatToChange}_{CheckingWindowType}", so the file name is
+        // the lookup key — renaming the file unbinds the journey.
+        Assert.Equal(
+            "IncorrectGrade_Post16",
+            Path.GetFileNameWithoutExtension(LocateFlowFile()));
+    }
+
+    private static QuestionFlowConfig Load()
+        => JsonSerializer.Deserialize<QuestionFlowConfig>(File.ReadAllText(LocateFlowFile()), JsonOptions)!;
+
+    private static string LocateFlowFile()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName,
+                "src", "DfE.CheckPerformanceData.Web", "Data", "QuestionFlows", "IncorrectGrade_Post16.json");
+            if (File.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException(
+            "Could not locate IncorrectGrade_Post16.json from " + AppContext.BaseDirectory);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/IncorrectGradeFlowTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/IncorrectGradeFlowTests.cs
@@ -96,7 +96,8 @@ public sealed class IncorrectGradeFlowTests
         var question = Question("cohort-scope", "q-cohort-scope");
 
         Assert.Equal(PageType.Question, page.Type);
-        Assert.Equal("Does the incorrect grade affect the whole cohort?", page.Title);
+        // No page-level title — see Single_question_pages_leave_the_page_title_empty.
+        Assert.Null(page.Title);
         Assert.Equal(QuestionType.Radio, question.Type);
         Assert.Equal("Does the incorrect grade affect the whole cohort?", question.Title);
         Assert.Equal("Select one option", question.Hint);
@@ -137,7 +138,10 @@ public sealed class IncorrectGradeFlowTests
         var page = Page("cohort-count");
         var question = Question("cohort-count", "q-cohort-count");
 
-        Assert.Equal("Enter the number of students who have an incorrect grade for this qualification", page.Title);
+        Assert.Null(page.Title);
+        Assert.Equal(
+            "Enter the number of students who have an incorrect grade for this qualification",
+            question.Title);
         Assert.Equal("select-student-cohort", page.NextPageId);
         Assert.Equal(QuestionType.FreeText, question.Type);
         Assert.Equal("Enter the number of students", question.Hint);
@@ -227,8 +231,11 @@ public sealed class IncorrectGradeFlowTests
         var page = Page("additional-info");
         var question = Question("additional-info", "q-additional-info");
 
-        Assert.Equal("Additional information (Optional)", page.Title);
+        Assert.Null(page.Title);
         Assert.Equal("Additional information", page.PageTitle);
+        // "(Optional)" is appended by JourneyViewModelBuilder when Optional is true — putting it in
+        // the title too rendered "Additional information (Optional) (Optional)".
+        Assert.Equal("Additional information", question.Title);
         Assert.Null(page.NextPageId); // the last page — Continue goes to the summary
         Assert.Equal(QuestionType.TextArea, question.Type);
         Assert.True(question.Optional);

--- a/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/LateResultsAvailabilityTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/LateResultsAvailabilityTests.cs
@@ -1,0 +1,71 @@
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.ResultsEnquiry;
+
+// AB#296648: "the service works out whether the second late results file is available from data it
+// already holds" — it is never told separately. This is the one place that derivation lives, so the
+// interstitial and any future gating cannot disagree about it.
+public sealed class LateResultsAvailabilityTests
+{
+    private static readonly Guid WindowId = Guid.Parse("6C2E1F4A-9B7D-4E38-8A15-3D9C2B4E7F01");
+    private const string Laestab = "860/4070";
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Availability_mirrors_whether_the_school_holds_any_LR2_result(bool holdsLr2)
+    {
+        var results = Substitute.For<IStudentResultsClient>();
+        results.AnyForSourceAsync(WindowId, Laestab, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(holdsLr2);
+
+        var actual = await new LateResultsAvailability(results)
+            .IsSecondLateResultsAvailableAsync(WindowId, Laestab);
+
+        Assert.Equal(holdsLr2, actual);
+    }
+
+    [Fact]
+    public async Task It_asks_for_the_second_late_results_tag_specifically()
+    {
+        // The tag is the data contract with ingestion. Asking for the wrong one (LR1, Revised) would
+        // show or hide the interstitial on the strength of an unrelated file having landed.
+        var results = Substitute.For<IStudentResultsClient>();
+
+        await new LateResultsAvailability(results).IsSecondLateResultsAvailableAsync(WindowId, Laestab);
+
+        await results.Received(1).AnyForSourceAsync(
+            WindowId,
+            Laestab,
+            Arg.Is<string>(tag => tag == "16to19_LR2"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task It_passes_the_window_and_school_through_untouched()
+    {
+        // Normalising the laestab is the blob client's job; doing it here too would hide a
+        // disagreement between the two.
+        var results = Substitute.For<IStudentResultsClient>();
+        var otherWindow = Guid.NewGuid();
+
+        await new LateResultsAvailability(results).IsSecondLateResultsAvailableAsync(otherWindow, "9334290");
+
+        await results.Received(1).AnyForSourceAsync(
+            otherWindow, "9334290", ResultsFileTags.Post16LateResults2, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task The_cancellation_token_reaches_the_results_client()
+    {
+        var results = Substitute.For<IStudentResultsClient>();
+        using var cts = new CancellationTokenSource();
+
+        await new LateResultsAvailability(results)
+            .IsSecondLateResultsAvailableAsync(WindowId, Laestab, cts.Token);
+
+        await results.Received(1).AnyForSourceAsync(
+            WindowId, Laestab, ResultsFileTags.Post16LateResults2, cts.Token);
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/StudentResultRecordTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/ResultsEnquiry/StudentResultRecordTests.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Infrastructure.BlobStorage;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.ResultsEnquiry;
+
+// AB#296648 / AB#296999: the per-student result read model binds the ingestion JSON through the
+// same JsonSerializerOptions production uses, so a schema drift breaks here rather than in a
+// running service. Unknown fields are ignored (ingestion may add columns) and numeric-looking
+// values are tolerated whether the CSV-to-JSON step quoted them or not.
+public sealed class StudentResultRecordTests
+{
+    // Record 1 quotes every value; record 2 leaves the numeric-looking ones unquoted and adds an
+    // unknown "AWARDING_BODY" column — both must bind.
+    private const string SampleJson = """
+    [
+      {
+        "CYPMD_ID": "1606464434",
+        "QAN": "6037116X",
+        "QUAL_NAME": "GCSE (9-1) Bus. Studs:Single",
+        "SYLLABUS": "1BS0",
+        "SESSION": "S2024",
+        "GRADE": "5",
+        "SOURCE": "16to19_MAIN"
+      },
+      {
+        "CYPMD_ID": 1606464434,
+        "QAN": 60181576,
+        "QUAL_NAME": "GCSE (9-1) French",
+        "SYLLABUS": "1FR0",
+        "SESSION": "S2024",
+        "GRADE": 7,
+        "SOURCE": "16to19_LR1",
+        "AWARDING_BODY": "Pearson"
+      }
+    ]
+    """;
+
+    private static IReadOnlyList<StudentResultRecord> Deserialize()
+        => JsonSerializer.Deserialize<List<StudentResultRecord>>(SampleJson, StudentResultsBlobClient.JsonOptions)!;
+
+    [Fact]
+    public void Binds_every_field_from_the_ingestion_schema()
+    {
+        var record = Deserialize()[0];
+
+        Assert.Equal("1606464434", record.CypmdId);
+        Assert.Equal("6037116X", record.Qan);
+        Assert.Equal("GCSE (9-1) Bus. Studs:Single", record.QualificationName);
+        Assert.Equal("1BS0", record.SyllabusCode);
+        Assert.Equal("S2024", record.Session);
+        Assert.Equal("5", record.Grade);
+        Assert.Equal(ResultsFileTags.Post16Main, record.SourceFile);
+    }
+
+    [Fact]
+    public void Ignores_unknown_columns_so_ingestion_can_add_fields()
+    {
+        var records = Deserialize();
+
+        Assert.Equal(2, records.Count);
+        Assert.Equal("GCSE (9-1) French", records[1].QualificationName);
+    }
+
+    [Fact]
+    public void Tolerates_unquoted_numeric_values()
+    {
+        var record = Deserialize()[1];
+
+        Assert.Equal("1606464434", record.CypmdId);
+        Assert.Equal("60181576", record.Qan);
+        Assert.Equal("7", record.Grade);
+    }
+
+    [Fact]
+    public void Reads_a_null_string_as_empty_so_search_never_dereferences_null()
+    {
+        const string json = """[{ "CYPMD_ID": "1", "QAN": null, "GRADE": null }]""";
+
+        var record = JsonSerializer.Deserialize<List<StudentResultRecord>>(json, StudentResultsBlobClient.JsonOptions)![0];
+
+        Assert.Equal(string.Empty, record.Qan);
+        Assert.Equal(string.Empty, record.Grade);
+    }
+
+    [Fact]
+    public void Malformed_json_throws_so_a_corrupt_file_surfaces()
+        => Assert.Throws<JsonException>(() =>
+            JsonSerializer.Deserialize<List<StudentResultRecord>>("{not json", StudentResultsBlobClient.JsonOptions));
+
+    [Fact]
+    public void Source_tags_are_verbatim_from_the_ingestion_contract()
+    {
+        Assert.Equal("16to19_MAIN", ResultsFileTags.Post16Main);
+        Assert.Equal("16to19_LR1", ResultsFileTags.Post16LateResults1);
+        Assert.Equal("16to19_LR2", ResultsFileTags.Post16LateResults2);
+        Assert.Equal("16to19_Revised", ResultsFileTags.Post16Revised);
+        Assert.Equal("16to19_Retention", ResultsFileTags.Post16Retention);
+        Assert.Equal("KS4_MAIN", ResultsFileTags.Ks4Main);
+        Assert.Equal("KS4_LR1", ResultsFileTags.Ks4LateResults1);
+        Assert.Equal("KS4_LR2", ResultsFileTags.Ks4LateResults2);
+        Assert.Equal("KS4_Revised", ResultsFileTags.Ks4Revised);
+    }
+
+    [Fact]
+    public void Blob_path_is_scoped_to_the_results_enquiry_activity()
+    {
+        // docs/16-19-window-model.md consequence #2: each activity owns its blob prefix, so a
+        // per-activity ingress sweep cannot destroy another activity's output.
+        Assert.Equal("results-enquiry/data/", ResultsEnquiryBlobPaths.ResultsPrefix);
+        Assert.Equal("results-enquiry/data/9334070_results.json", ResultsEnquiryBlobPaths.ResultsBlobName("933/4070"));
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/QuestionFlowOutcomeKeyAlignmentTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/RulesEngine/QuestionFlowOutcomeKeyAlignmentTests.cs
@@ -36,6 +36,21 @@ public sealed class QuestionFlowOutcomeKeyAlignmentTests
         Assert.NotEmpty(Directory.GetFiles(LocateFlowsDirectory(), "*.json"));
     }
 
+    /// <summary>
+    /// Flow prefixes whose requests never reach the rules engine, so they have no outcome key and
+    /// must not be given a fake one — an entry here would make
+    /// <c>OutcomeDeletionPolicy.IsFormBound</c> protect a nonexistent outcome and would tell
+    /// <c>SeedRulesValidationTests</c> to expect rules that were deliberately not written.
+    ///
+    /// <c>IncorrectGrade</c> (AB#296648) is a 16-19 results enquiry: it is persisted as a
+    /// <c>RequestType.ResultsEnquiry</c> row plus a document blob, and is NOT enqueued. Whether it
+    /// ever gets rules-engine or Zendesk processing is a PARKED decision. When that is answered and
+    /// enqueueing is added, remove the prefix from here and add its real outcome key(s) to
+    /// <see cref="AnswerFieldMap.WhatToChangeToOutcomeKey"/> — this list going empty is the signal
+    /// that every flow routes.
+    /// </summary>
+    private static readonly string[] FlowPrefixesThatDoNotRouteToTheRulesEngine = ["IncorrectGrade"];
+
     [Theory]
     [MemberData(nameof(FlowFiles))]
     public void EveryContractString_RoutesToAnOutcomeKey(string fileName)
@@ -45,6 +60,14 @@ public sealed class QuestionFlowOutcomeKeyAlignmentTests
         Assert.NotNull(config);
 
         var prefix = fileName.Split('_')[0];
+
+        if (FlowPrefixesThatDoNotRouteToTheRulesEngine.Contains(prefix, StringComparer.Ordinal))
+        {
+            // Assert the *absence* too, so adding a speculative map entry fails here rather than
+            // quietly binding an enquiry journey to rules-engine routing nobody signed off.
+            AssertNotRoutable(prefix);
+            return;
+        }
 
         var flagged = config.Pages
             .SelectMany(p => p.Questions)
@@ -71,6 +94,12 @@ public sealed class QuestionFlowOutcomeKeyAlignmentTests
         Assert.True(AnswerFieldMap.WhatToChangeToOutcomeKey.ContainsKey(contract),
             $"WhatToChange '{contract}' has no entry in AnswerFieldMap.WhatToChangeToOutcomeKey — " +
             "every request for it would resolve to _unknown and fall to Scrutiny.");
+
+    private static void AssertNotRoutable(string contract) =>
+        Assert.False(AnswerFieldMap.WhatToChangeToOutcomeKey.ContainsKey(contract),
+            $"WhatToChange '{contract}' is listed as not routing to the rules engine, but it now has " +
+            "an entry in AnswerFieldMap.WhatToChangeToOutcomeKey. If downstream processing has been " +
+            "decided, remove it from FlowPrefixesThatDoNotRouteToTheRulesEngine.");
 
     // ── Question id / option value alignment ────────────────────────────────
 

--- a/tests/DfE.CheckPerformanceData.UnitTests/Startup/BlobStorageExtensionsTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Startup/BlobStorageExtensionsTests.cs
@@ -1,0 +1,58 @@
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Infrastructure.BlobStorage;
+using DfE.CheckPerformanceData.Web.Startup;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Startup;
+
+// Guards the web host's blob-client registrations.
+//
+// The web host does NOT call AddInfrastructureDependencies — it builds its own blob-client set in
+// AddCpdBlobStorage. So a client registered only in the Infrastructure DependencyManager resolves
+// in the worker and in tests but throws at web startup, and because the container is validated on
+// build the whole app crashloops rather than failing on one page. AB#296648 hit exactly that: the
+// dev-data seeding orchestrator took IStudentResultsClient and the app would not boot. These
+// assertions turn that class of failure back into a test failure.
+public class BlobStorageExtensionsTests
+{
+    private const string AzuriteConnection =
+        "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;" +
+        "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;" +
+        "BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
+
+    private static ServiceProvider BuildWebBlobServices()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:AzureStorage"] = AzuriteConnection
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMemoryCache();
+        services.AddCpdBlobStorage(configuration);
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+
+    [Theory]
+    [InlineData(typeof(IPupilDataBlobClient))]
+    [InlineData(typeof(IStudentResultsClient))]
+    [InlineData(typeof(IGradeReferenceClient))]
+    [InlineData(typeof(GradeReferenceBlobClient))]
+    [InlineData(typeof(IRequestBlobClient))]
+    [InlineData(typeof(IRequestStateBlobClient))]
+    [InlineData(typeof(IQuestionFlowBlobClient))]
+    public void Every_blob_client_the_web_host_needs_resolves(Type serviceType)
+    {
+        using var provider = BuildWebBlobServices();
+        using var scope = provider.CreateScope();
+
+        Assert.NotNull(scope.ServiceProvider.GetRequiredService(serviceType));
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/UncommittedRequests/AdminRequestsServiceEnquiryGuardTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/UncommittedRequests/AdminRequestsServiceEnquiryGuardTests.cs
@@ -1,0 +1,176 @@
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.LandingPage;
+using DfE.CheckPerformanceData.Application.Queue;
+using DfE.CheckPerformanceData.Application.RequestSubmission;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Application.UncommittedRequests;
+using DfE.CheckPerformanceData.Domain.Enums;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.UncommittedRequests;
+
+// AB#296648: the window-close Zendesk replay must skip results enquiries.
+//
+// This path rebuilds a PUPIL AMENDMENT ticket from a journey blob. An enquiry's QAN, session, current
+// and revised grade have no place in that shape, so replaying one would create a malformed ticket —
+// and worse, would flip the row from SubmittedUnCommitted to SubmittedCommitted, so the real
+// enquiry-to-Zendesk dispatch (a separate story) could never find it again.
+public sealed class AdminRequestsServiceEnquiryGuardTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 11, 19, 9, 0, 0, TimeSpan.Zero);
+    private static readonly Guid WindowId = Guid.Parse("6C2E1F4A-9B7D-4E38-8A15-3D9C2B4E7F01");
+    private static readonly Guid AmendmentRowId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid EnquiryRowId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private readonly IUncommittedRequestsRepository _repository = Substitute.For<IUncommittedRequestsRepository>();
+    private readonly IRequestStateBlobClient _stateBlob = Substitute.For<IRequestStateBlobClient>();
+    private readonly IQuestionFlowService _flowService = Substitute.For<IQuestionFlowService>();
+    private readonly IQueueService _queueService = Substitute.For<IQueueService>();
+    private readonly AdminRequestsService _sut;
+
+    private sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now.ToUniversalTime();
+        public override TimeZoneInfo LocalTimeZone => TimeZoneInfo.Utc;
+    }
+
+    private static readonly QuestionFlowConfig Flow = new()
+    {
+        FirstPageId = "page-1",
+        Pages = [new JourneyPage { Id = "page-1" }]
+    };
+
+    public AdminRequestsServiceEnquiryGuardTests()
+    {
+        _flowService.GetConfigAsync(Arg.Any<WhatToChange>(), Arg.Any<CheckingWindowType>()).Returns(Flow);
+        _flowService.ResolveRequestType(Arg.Any<QuestionFlowConfig>(), Arg.Any<RequestState>()).Returns("Remove");
+
+        _sut = new AdminRequestsService(
+            _repository, _stateBlob, _flowService, _queueService, new FakeTimeProvider(Now));
+    }
+
+    private static ReplayRequestRow Row(Guid id, string reference) => new()
+    {
+        ChangeRequestId = id,
+        WindowId = WindowId,
+        ReferenceNumber = reference,
+        OrganisationUrn = 142313,
+        SubmittedById = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+        SubmittedByName = "Ada Editor"
+    };
+
+    private static PupilDto Pupil() => new()
+    {
+        Id = Guid.NewGuid(), Firstname = "Billy", Surname = "B", Sex = "M",
+        DateOfBirth = "12/03/2007", Age = 19, Cypmd_Id = "500001", Identifier = "9900000001"
+    };
+
+    private static CheckingWindowDto Window => new()
+    {
+        Title = "16 to 19 2026", KeyStage = KeyStages.Post16,
+        CheckingWindowType = CheckingWindowType.Post16,
+        StartDate = new DateTime(2026, 10, 1), EndDate = new DateTime(2027, 3, 31)
+    };
+
+    private static RequestState Journey(WhatToChange change) => new()
+    {
+        SelectedWhatToChange = change,
+        CheckingWindow = Window,
+        SelectedPupil = Pupil(),
+        SelectedResult = change == WhatToChange.IncorrectGrade
+            ? new StudentResultRecord { Qan = "60180882", Grade = "9", Session = "S2024" }
+            : null,
+        QuestionAnswers = [],
+        QuestionHistory = ["page-1"]
+    };
+
+    private void Seed(params (ReplayRequestRow Row, WhatToChange Change)[] rows)
+    {
+        _repository.GetRequestsForOpenWindowsAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
+            .Returns(rows.Select(r => r.Row).ToList());
+        foreach (var (row, change) in rows)
+            _stateBlob.GetAsync(WindowId, row.ReferenceNumber).Returns(Journey(change));
+    }
+
+    [Fact]
+    public async Task An_amendment_is_replayed()
+    {
+        Seed((Row(AmendmentRowId, "CYPMD_Post16_AAAAAA1"), WhatToChange.Remove));
+
+        var count = await _sut.ProcessCloseWindowEvent(CancellationToken.None);
+
+        Assert.Equal(1, count);
+        await _queueService.Received(1).EnqueueAsync(
+            QueueOptions.ZendeskQueue, Arg.Any<object>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task A_results_enquiry_is_not_replayed()
+    {
+        Seed((Row(EnquiryRowId, "CYPMD_16to19_RE_BBBBBB2"), WhatToChange.IncorrectGrade));
+
+        var count = await _sut.ProcessCloseWindowEvent(CancellationToken.None);
+
+        Assert.Equal(0, count);
+        await _queueService.DidNotReceiveWithAnyArgs()
+            .EnqueueAsync(default!, default(object)!, default);
+    }
+
+    [Fact]
+    public async Task A_results_enquiry_row_keeps_its_uncommitted_status()
+    {
+        // The important half: committing it would hide the enquiry from the dispatch that is
+        // supposed to send it.
+        Seed((Row(EnquiryRowId, "CYPMD_16to19_RE_BBBBBB2"), WhatToChange.IncorrectGrade));
+
+        await _sut.ProcessCloseWindowEvent(CancellationToken.None);
+
+        await _repository.DidNotReceive().SetStatusAsync(
+            EnquiryRowId, Arg.Any<RequestStatus>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task A_mixed_batch_replays_only_the_amendment()
+    {
+        Seed(
+            (Row(AmendmentRowId, "CYPMD_Post16_AAAAAA1"), WhatToChange.Remove),
+            (Row(EnquiryRowId, "CYPMD_16to19_RE_BBBBBB2"), WhatToChange.IncorrectGrade));
+
+        var count = await _sut.ProcessCloseWindowEvent(CancellationToken.None);
+
+        Assert.Equal(1, count);
+        await _repository.Received(1).SetStatusAsync(
+            AmendmentRowId, RequestStatus.SubmittedCommitted, Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().SetStatusAsync(
+            EnquiryRowId, Arg.Any<RequestStatus>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task An_enquiry_does_not_stop_a_later_amendment_being_replayed()
+    {
+        // Ordering matters: a `continue` skips one row, but a `return`/`break` would silently drop
+        // every amendment queued behind an enquiry.
+        Seed(
+            (Row(EnquiryRowId, "CYPMD_16to19_RE_BBBBBB2"), WhatToChange.IncorrectGrade),
+            (Row(AmendmentRowId, "CYPMD_Post16_AAAAAA1"), WhatToChange.Remove));
+
+        var count = await _sut.ProcessCloseWindowEvent(CancellationToken.None);
+
+        Assert.Equal(1, count);
+        await _repository.Received(1).SetStatusAsync(
+            AmendmentRowId, RequestStatus.SubmittedCommitted, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Drafts_are_still_marked_not_submitted()
+    {
+        // The guard must not short-circuit the rest of the close-window work.
+        Seed((Row(EnquiryRowId, "CYPMD_16to19_RE_BBBBBB2"), WhatToChange.IncorrectGrade));
+
+        await _sut.ProcessCloseWindowEvent(CancellationToken.None);
+
+        await _repository.Received(1).MarkDraftsNotSubmittedForOpenWindowsAsync(
+            Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/CheckYourPupilDataResultsEnquiryOptionTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/CheckYourPupilDataResultsEnquiryOptionTests.cs
@@ -1,0 +1,236 @@
+using DfE.CheckPerformanceData.Application.Analytics;
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.CheckYourPupilData.Columns;
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.LandingPage;
+using DfE.CheckPerformanceData.Domain.Enums;
+using DfE.CheckPerformanceData.Web.Controllers.CheckYourPupilData;
+using DfE.CheckPerformanceData.Web.Session;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Web;
+
+// AB#296648: the way in to the enquiry journey.
+//
+// Per the agreed decision in docs/16-19-window-model.md, the check-your-pupil-data page's existing
+// "what would you like to do?" radios gain a third option for 16-19 windows. Enquiries are 16-19 only
+// in this ticket, so a KS4 window must neither show the option nor accept it if posted.
+public sealed class CheckYourPupilDataResultsEnquiryOptionTests
+{
+    private static readonly Guid WindowId = Guid.Parse("6C2E1F4A-9B7D-4E38-8A15-3D9C2B4E7F01");
+
+    private readonly ICheckYourPupilDataService _service = Substitute.For<ICheckYourPupilDataService>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IAnalyticsService _analytics = Substitute.For<IAnalyticsService>();
+    private readonly FakeSession _session = new();
+    private readonly CheckYourPupilDataController _sut;
+
+    public CheckYourPupilDataResultsEnquiryOptionTests()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(_session));
+
+        _service.GetPupilTableAsync(WindowId, Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<int>(), Arg.Any<int>())
+            .Returns((PupilTable.Empty, 0));
+
+        _sut = new CheckYourPupilDataController(_service, TimeProvider.System, _currentUser, _analytics)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+    }
+
+    private void Window(CheckingWindowType type, bool open = true)
+    {
+        var now = DateTime.UtcNow;
+        _service.GetCheckingWindowAsync(WindowId).Returns(new CheckingWindowDto
+        {
+            Title = type == CheckingWindowType.Post16 ? "16 to 19 2026" : "KS4 June 2026",
+            KeyStage = type == CheckingWindowType.Post16 ? KeyStages.Post16 : KeyStages.KS4,
+            CheckingWindowType = type,
+            StartDate = open ? now.AddDays(-5) : now.AddDays(-40),
+            EndDate = open ? now.AddDays(5) : now.AddDays(-10)
+        });
+    }
+
+    private async Task<CheckYourPupilDataViewModel> IndexModel()
+    {
+        var view = Assert.IsType<ViewResult>(await _sut.Index(WindowId));
+        return Assert.IsType<CheckYourPupilDataViewModel>(view.Model);
+    }
+
+    // ── Visibility ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task A_16_to_19_window_offers_the_results_enquiry_option()
+    {
+        Window(CheckingWindowType.Post16);
+
+        Assert.True((await IndexModel()).ShowResultsEnquiryOption);
+    }
+
+    [Theory]
+    [InlineData(CheckingWindowType.KS4June)]
+    [InlineData(CheckingWindowType.KS4Autumn)]
+    [InlineData(CheckingWindowType.KS2)]
+    public async Task Other_window_types_do_not_offer_it(CheckingWindowType type)
+    {
+        // Enquiries are 16-19 only in this ticket; the other key stages have no results data and no
+        // flow config, so the option would dead-end.
+        Window(type);
+
+        Assert.False((await IndexModel()).ShowResultsEnquiryOption);
+    }
+
+    [Fact]
+    public async Task A_closed_window_offers_nothing_at_all()
+    {
+        // The whole radio group is already hidden when the window is shut; the new option must not
+        // reintroduce a way in. PARKED: per-activity visibility replaces this when the window-model
+        // activity dates land.
+        Window(CheckingWindowType.Post16, open: false);
+
+        var model = await IndexModel();
+        Assert.False(model.IsWindowOpen);
+    }
+
+    // ── Routing ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Choosing_it_routes_to_the_result_issue_page()
+    {
+        Window(CheckingWindowType.Post16);
+
+        var result = await _sut.NextStep(WindowId, new CheckYourPupilDataViewModel
+        {
+            WindowId = WindowId.ToString(),
+            SelectedNextStep = NextSteps.ResultsEnquiry,
+            WindowEndDate = "", WindowEndTime = "", WindowTitle = "", Sections = [],
+            SectionsAsTabs = false, IsWindowOpen = true, OrganisationName = ""
+        });
+
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("ResultIssue", redirect.ControllerName);
+        Assert.Equal("Index", redirect.ActionName);
+        Assert.Equal(WindowId, redirect.RouteValues!["windowId"]);
+    }
+
+    [Fact]
+    public async Task The_existing_options_still_route_where_they_did()
+    {
+        Window(CheckingWindowType.Post16);
+
+        CheckYourPupilDataViewModel Vm(NextSteps step) => new()
+        {
+            WindowId = WindowId.ToString(),
+            SelectedNextStep = step,
+            WindowEndDate = "", WindowEndTime = "", WindowTitle = "", Sections = [],
+            SectionsAsTabs = false, IsWindowOpen = true, OrganisationName = ""
+        };
+
+        var change = Assert.IsType<RedirectToActionResult>(await _sut.NextStep(WindowId, Vm(NextSteps.RequestChange)));
+        Assert.Equal("WhatToChange", change.ControllerName);
+
+        var confirm = Assert.IsType<RedirectToActionResult>(await _sut.NextStep(WindowId, Vm(NextSteps.Confirm)));
+        Assert.Equal("ConfirmCorrect", confirm.ControllerName);
+    }
+
+    // ── The KS4 exclusion is enforced server-side ────────────────────────────
+
+    [Theory]
+    [InlineData(CheckingWindowType.KS4June)]
+    [InlineData(CheckingWindowType.KS4Autumn)]
+    [InlineData(CheckingWindowType.KS2)]
+    public async Task Posting_it_on_a_window_that_does_not_offer_it_is_rejected_as_unanswered(
+        CheckingWindowType type)
+    {
+        // Not rendering the option is not enough — a hand-crafted post must not start a journey that
+        // has no results data behind it. Same fail-closed rule as the hidden-radio rejection.
+        Window(type);
+
+        var result = await _sut.NextStep(WindowId, new CheckYourPupilDataViewModel
+        {
+            WindowId = WindowId.ToString(),
+            SelectedNextStep = NextSteps.ResultsEnquiry,
+            WindowEndDate = "", WindowEndTime = "", WindowTitle = "", Sections = [],
+            SectionsAsTabs = false, IsWindowOpen = true, OrganisationName = ""
+        });
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Equal("Index", view.ViewName);
+        Assert.Equal(
+            "Select what you would like to do",
+            _sut.ModelState[nameof(CheckYourPupilDataViewModel.SelectedNextStep)]!.Errors[0].ErrorMessage);
+    }
+
+    [Fact]
+    public async Task A_rejected_post_does_not_record_the_choice_in_session()
+    {
+        Window(CheckingWindowType.KS4June);
+
+        await _sut.NextStep(WindowId, new CheckYourPupilDataViewModel
+        {
+            WindowId = WindowId.ToString(),
+            SelectedNextStep = NextSteps.ResultsEnquiry,
+            WindowEndDate = "", WindowEndTime = "", WindowTitle = "", Sections = [],
+            SectionsAsTabs = false, IsWindowOpen = true, OrganisationName = ""
+        });
+
+        Assert.Null(_session.GetRequestState(WindowId).SelectedNextStep);
+    }
+
+    [Fact]
+    public async Task A_rejected_post_reports_a_coded_validation_error()
+    {
+        Window(CheckingWindowType.KS4June);
+
+        await _sut.NextStep(WindowId, new CheckYourPupilDataViewModel
+        {
+            WindowId = WindowId.ToString(),
+            SelectedNextStep = NextSteps.ResultsEnquiry,
+            WindowEndDate = "", WindowEndTime = "", WindowTitle = "", Sections = [],
+            SectionsAsTabs = false, IsWindowOpen = true, OrganisationName = ""
+        });
+
+        await _analytics.Received(1).TrackSafeAsync(Arg.Is<ValidationErrorEvent>(e =>
+            e.ErrorCodes.Contains("no_selection")));
+    }
+
+    [Fact]
+    public async Task Choosing_it_records_the_choice_in_session()
+    {
+        Window(CheckingWindowType.Post16);
+
+        await _sut.NextStep(WindowId, new CheckYourPupilDataViewModel
+        {
+            WindowId = WindowId.ToString(),
+            SelectedNextStep = NextSteps.ResultsEnquiry,
+            WindowEndDate = "", WindowEndTime = "", WindowTitle = "", Sections = [],
+            SectionsAsTabs = false, IsWindowOpen = true, OrganisationName = ""
+        });
+
+        Assert.Equal(NextSteps.ResultsEnquiry, _session.GetRequestState(WindowId).SelectedNextStep);
+    }
+
+    private sealed class FakeSession : ISession
+    {
+        private readonly Dictionary<string, byte[]> _store = new();
+
+        public bool TryGetValue(string key, out byte[] value) => _store.TryGetValue(key, out value!);
+        public void Set(string key, byte[] value) => _store[key] = value;
+        public void Remove(string key) => _store.Remove(key);
+        public void Clear() => _store.Clear();
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public bool IsAvailable => true;
+        public string Id => "test-session";
+        public IEnumerable<string> Keys => _store.Keys;
+    }
+
+    private sealed class TestSessionFeature(ISession session) : ISessionFeature
+    {
+        public ISession Session { get; set; } = session;
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/ResultIssueControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/ResultIssueControllerTests.cs
@@ -1,0 +1,434 @@
+using System.Reflection;
+using DfE.CheckPerformanceData.Application.Analytics;
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.LandingPage;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Domain.Enums;
+using DfE.CheckPerformanceData.Web.Controllers;
+using DfE.CheckPerformanceData.Web.Session;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Web.Controllers;
+
+// AB#296648: the way in to the incorrect-grade enquiry.
+//
+// Two behaviours carry most of the risk here. First, the late-results guidance: the ticket is
+// explicit that it "informs the user. It does not stop the user continuing" — CONFIRMED by the BA on
+// 2026-08-17 in preference to the Figma frame that greys the option out. Second, starting an enquiry
+// must wipe the previous one: "when I start another, then none of my previous answers are carried
+// over".
+public sealed class ResultIssueControllerTests
+{
+    private static readonly Guid WindowId = Guid.Parse("6C2E1F4A-9B7D-4E38-8A15-3D9C2B4E7F01");
+    private const string Laestab = "860/4070";
+
+    private readonly ICheckYourPupilDataService _service = Substitute.For<ICheckYourPupilDataService>();
+    private readonly IQuestionFlowService _flowService = Substitute.For<IQuestionFlowService>();
+    private readonly ILateResultsAvailability _lateResults = Substitute.For<ILateResultsAvailability>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly IAnalyticsService _analytics = Substitute.For<IAnalyticsService>();
+    private readonly FakeSession _session = new();
+    private readonly ResultIssueController _sut;
+
+    private static readonly CheckingWindowDto Post16Window = new()
+    {
+        Title = "16 to 19 2026",
+        KeyStage = KeyStages.Post16,
+        CheckingWindowType = CheckingWindowType.Post16,
+        StartDate = new DateTime(2026, 10, 1),
+        EndDate = new DateTime(2027, 3, 31)
+    };
+
+    private static readonly QuestionFlowConfig Flow = new()
+    {
+        FirstPageId = "cohort-scope",
+        Pages = [new JourneyPage { Id = "cohort-scope" }, new JourneyPage { Id = "check-late-results" }]
+    };
+
+    public ResultIssueControllerTests()
+    {
+        _currentUser.OrganisationLaestab.Returns(Laestab);
+        _service.GetCheckingWindowAsync(WindowId).Returns(Post16Window);
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16).Returns(Flow);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(_session));
+
+        _sut = new ResultIssueController(_service, _flowService, _lateResults, _currentUser, _analytics)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+    }
+
+    private void SecondLateResultsAvailable(bool available) =>
+        _lateResults.IsSecondLateResultsAvailableAsync(WindowId, Laestab, Arg.Any<CancellationToken>())
+            .Returns(available);
+
+    private static RedirectToActionResult AssertJourneyRedirect(IActionResult result, string pageId)
+    {
+        var redirect = Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("Journey", redirect.ControllerName);
+        Assert.Equal("Page", redirect.ActionName);
+        Assert.Equal(WindowId, redirect.RouteValues!["windowId"]);
+        Assert.Equal(pageId, redirect.RouteValues!["pageId"]);
+        return redirect;
+    }
+
+    // ── GET ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Get_returns_the_view_with_the_window()
+    {
+        var result = _sut.Index(WindowId);
+
+        var view = Assert.IsType<ViewResult>(result);
+        var model = Assert.IsType<ResultIssueViewModel>(view.Model);
+        Assert.Equal(WindowId, model.WindowId);
+        Assert.Null(model.IssueType);
+    }
+
+    [Fact]
+    public void Get_does_not_preselect_an_option_even_when_a_journey_is_already_in_session()
+    {
+        // The confirmation page's "Report another issue with an exam result" link comes back here,
+        // and the AC says nothing carries over — a preselected radio would be exactly that.
+        _session.SetRequestState(WindowId, new RequestState
+        {
+            SelectedWhatToChange = WhatToChange.IncorrectGrade,
+            QuestionAnswers = { ["q-cohort-scope"] = new QuestionAnswer { TextValue = "yes" } }
+        });
+
+        var view = Assert.IsType<ViewResult>(_sut.Index(WindowId));
+
+        Assert.Null(Assert.IsType<ResultIssueViewModel>(view.Model).IssueType);
+    }
+
+    // ── POST: validation ─────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Post_without_a_selection_redisplays_the_page_with_the_pinned_error(string? issueType)
+    {
+        var result = await _sut.Confirm(WindowId, new ResultIssueViewModel { WindowId = WindowId, IssueType = issueType });
+
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.Equal("Index", view.ViewName);
+        Assert.Equal(
+            "Select what issue with the results you need to report",
+            _sut.ModelState[nameof(ResultIssueViewModel.IssueType)]!.Errors[0].ErrorMessage);
+        await _flowService.DidNotReceiveWithAnyArgs().GetConfigAsync(default, default);
+    }
+
+    [Fact]
+    public async Task Post_without_a_selection_does_not_touch_the_journey_state()
+    {
+        var existing = new RequestState { SelectedWhatToChange = WhatToChange.Merge };
+        _session.SetRequestState(WindowId, existing);
+
+        await _sut.Confirm(WindowId, new ResultIssueViewModel { WindowId = WindowId, IssueType = null });
+
+        Assert.Equal(WhatToChange.Merge, _session.GetRequestState(WindowId).SelectedWhatToChange);
+    }
+
+    [Fact]
+    public async Task Post_without_a_selection_reports_a_coded_validation_error()
+    {
+        await _sut.Confirm(WindowId, new ResultIssueViewModel { WindowId = WindowId, IssueType = null });
+
+        await _analytics.Received(1).TrackSafeAsync(Arg.Is<ValidationErrorEvent>(e =>
+            e.ErrorCount == 1 &&
+            e.ErrorCodes.Contains("no_selection") &&
+            e.ErrorFields.Contains(nameof(ResultIssueViewModel.IssueType))));
+    }
+
+    [Fact]
+    public async Task Post_with_an_unrecognised_option_is_rejected_as_unanswered()
+    {
+        // This ticket renders only the incorrect-grade option. A posted value for a sibling ticket's
+        // option (or a forged one) must not start a journey there is no flow for.
+        var result = await _sut.Confirm(WindowId, new ResultIssueViewModel { WindowId = WindowId, IssueType = "missing-qualification" });
+
+        Assert.IsType<ViewResult>(result);
+        await _flowService.DidNotReceiveWithAnyArgs().GetConfigAsync(default, default);
+    }
+
+    // ── POST: the late-results branch ────────────────────────────────────────
+
+    [Fact]
+    public async Task When_the_second_late_results_file_is_missing_the_user_is_told_to_check_it_first()
+    {
+        SecondLateResultsAvailable(false);
+
+        var result = await _sut.Confirm(WindowId, ValidPost());
+
+        AssertJourneyRedirect(result, "check-late-results");
+    }
+
+    [Fact]
+    public async Task When_the_second_late_results_file_has_landed_the_guidance_is_skipped()
+    {
+        SecondLateResultsAvailable(true);
+
+        var result = await _sut.Confirm(WindowId, ValidPost());
+
+        AssertJourneyRedirect(result, "cohort-scope");
+    }
+
+    [Fact]
+    public async Task The_first_page_after_the_guidance_comes_from_the_flow_config_not_a_hardcoded_id()
+    {
+        // If the flow's firstPageId is ever renamed, the controller must follow it rather than
+        // redirecting to a page that no longer exists.
+        SecondLateResultsAvailable(true);
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16)
+            .Returns(new QuestionFlowConfig { FirstPageId = "renamed-first-page", Pages = [] });
+
+        var result = await _sut.Confirm(WindowId, ValidPost());
+
+        AssertJourneyRedirect(result, "renamed-first-page");
+    }
+
+    [Fact]
+    public async Task The_guidance_page_is_seeded_into_the_history_so_the_engine_lets_the_user_see_it()
+    {
+        // The flow's firstPageId is cohort-scope, so without seeding, the journey engine's
+        // out-of-sequence guard bounces the user straight past the guidance — and the AC "then I am
+        // told to check that file first" silently never happens. This was a real defect caught by
+        // walking the journey; it is not reproducible from the redirect assertion alone.
+        SecondLateResultsAvailable(false);
+
+        await _sut.Confirm(WindowId, ValidPost());
+
+        Assert.Equal(["check-late-results"], _session.GetRequestState(WindowId).QuestionHistory);
+    }
+
+    [Fact]
+    public async Task No_page_is_seeded_when_the_guidance_is_skipped()
+    {
+        // cohort-scope IS the flow's firstPageId, so an empty history is what the guard expects.
+        SecondLateResultsAvailable(true);
+
+        await _sut.Confirm(WindowId, ValidPost());
+
+        Assert.Empty(_session.GetRequestState(WindowId).QuestionHistory);
+    }
+
+    [Theory]
+    [InlineData(false, true)]  // no LR2 -> guidance shown
+    [InlineData(true, false)]  // LR2 present -> guidance skipped
+    public async Task Starting_an_enquiry_records_whether_the_guidance_was_shown(
+        bool lateResultsAvailable, bool expectedGuidanceShown)
+    {
+        // This flag is how we find out whether the interstitial is doing its job — stopping enquiries
+        // that the November file would have fixed anyway.
+        SecondLateResultsAvailable(lateResultsAvailable);
+
+        await _sut.Confirm(WindowId, ValidPost());
+
+        await _analytics.Received(1).TrackSafeAsync(Arg.Is<ResultsEnquiryStartedEvent>(e =>
+            e.EnquiryType == "incorrect-grade" &&
+            e.CheckingWindowType == "Post16" &&
+            e.LateResultsGuidanceShown == expectedGuidanceShown));
+    }
+
+    [Fact]
+    public async Task A_rejected_selection_does_not_record_a_started_enquiry()
+    {
+        // Nothing was started, so counting it would inflate the funnel's top.
+        await _sut.Confirm(WindowId, new ResultIssueViewModel { WindowId = WindowId, IssueType = null });
+
+        await _analytics.DidNotReceive().TrackSafeAsync(Arg.Any<ResultsEnquiryStartedEvent>());
+    }
+
+    [Fact]
+    public async Task An_analytics_failure_does_not_stop_the_enquiry_starting()
+    {
+        // TrackSafeAsync is meant to swallow, but the journey must not depend on that.
+        SecondLateResultsAvailable(true);
+        _analytics.TrackSafeAsync(Arg.Any<ResultsEnquiryStartedEvent>())
+            .Returns(_ => throw new InvalidOperationException("BigQuery is down"));
+
+        var result = await _sut.Confirm(WindowId, ValidPost());
+
+        Assert.IsType<RedirectToActionResult>(result);
+    }
+
+    [Fact]
+    public async Task Availability_is_asked_for_the_signed_in_school_and_this_window()
+    {
+        SecondLateResultsAvailable(true);
+
+        await _sut.Confirm(WindowId, ValidPost());
+
+        await _lateResults.Received(1)
+            .IsSecondLateResultsAvailableAsync(WindowId, Laestab, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task The_option_is_always_selectable_regardless_of_late_results()
+    {
+        // The BA's decision: warn, never block. Both states must reach the journey — only the entry
+        // page differs. A regression to blocking would show up as a ViewResult here.
+        foreach (var available in new[] { true, false })
+        {
+            SecondLateResultsAvailable(available);
+
+            var result = await _sut.Confirm(WindowId, ValidPost());
+
+            Assert.IsType<RedirectToActionResult>(result);
+        }
+    }
+
+    [Fact]
+    public async Task A_missing_flow_config_falls_back_to_the_pupil_data_page_rather_than_a_dead_link()
+    {
+        SecondLateResultsAvailable(true);
+        _flowService.GetConfigAsync(WhatToChange.IncorrectGrade, CheckingWindowType.Post16)
+            .Returns((QuestionFlowConfig?)null);
+
+        var redirect = Assert.IsType<RedirectToActionResult>(await _sut.Confirm(WindowId, ValidPost()));
+
+        Assert.Equal("CheckYourPupilData", redirect.ControllerName);
+        Assert.Equal("Index", redirect.ActionName);
+    }
+
+    // ── POST: state reset ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Starting_an_enquiry_clears_every_answer_from_the_previous_one()
+    {
+        // AC: "Given I have submitted an enquiry, when I start another, then none of my previous
+        // answers are carried over."
+        SecondLateResultsAvailable(true);
+        _session.SetRequestState(WindowId, new RequestState
+        {
+            SelectedWhatToChange = WhatToChange.Remove,
+            SelectedPupilId = Guid.NewGuid().ToString(),
+            SelectedPupilLabel = "Smith, Jane",
+            SelectedResultLabel = "GCSE (9-1) French, QAN: 60181576, Session: S2024",
+            SelectedResult = new StudentResultRecord { Qan = "60181576", Grade = "6" },
+            ReferenceNumber = "CYPMD_16to19_RE_ABCDEF1",
+            OriginCountryCode = "FR",
+            QuestionAnswers = { ["q-revised-grade"] = new QuestionAnswer { TextValue = "5" } },
+            QuestionHistory = { "select-result", "grade-details" }
+        });
+
+        await _sut.Confirm(WindowId, ValidPost());
+
+        var state = _session.GetRequestState(WindowId);
+        Assert.Equal(WhatToChange.IncorrectGrade, state.SelectedWhatToChange);
+        Assert.Null(state.SelectedPupilId);
+        Assert.DoesNotContain("grade-details", state.QuestionHistory);
+        Assert.Null(state.SelectedPupilLabel);
+        Assert.Null(state.SelectedPupil);
+        Assert.Null(state.SelectedResult);
+        Assert.Null(state.SelectedResultLabel);
+        Assert.Null(state.ReferenceNumber);
+        Assert.Null(state.OriginCountryCode);
+        Assert.Empty(state.QuestionAnswers);
+    }
+
+    [Fact]
+    public async Task Starting_an_enquiry_stamps_the_journey_with_the_window()
+    {
+        SecondLateResultsAvailable(true);
+
+        await _sut.Confirm(WindowId, ValidPost());
+
+        var state = _session.GetRequestState(WindowId);
+        Assert.NotNull(state.CheckingWindow);
+        Assert.Equal(CheckingWindowType.Post16, state.CheckingWindow.CheckingWindowType);
+    }
+
+    [Fact]
+    public async Task Starting_an_enquiry_leaves_another_windows_journey_alone()
+    {
+        // Journey state is per-window; resetting this window must not wipe a half-finished KS4 one.
+        SecondLateResultsAvailable(true);
+        var otherWindow = Guid.NewGuid();
+        _session.SetRequestState(otherWindow, new RequestState { SelectedWhatToChange = WhatToChange.Merge });
+
+        await _sut.Confirm(WindowId, ValidPost());
+
+        Assert.Equal(WhatToChange.Merge, _session.GetRequestState(otherWindow).SelectedWhatToChange);
+    }
+
+    [Fact]
+    public async Task Starting_an_enquiry_clears_the_bulk_and_single_edit_modes()
+    {
+        // A fresh enquiry is never an edit of an existing request; leaving the flag set would make
+        // the summary link back to the amendment-requests page.
+        SecondLateResultsAvailable(true);
+        _session.SetBulkEditMode(WindowId);
+        _session.SetSingleEditMode(WindowId);
+
+        await _sut.Confirm(WindowId, ValidPost());
+
+        Assert.False(_session.IsBulkEditMode(WindowId));
+        Assert.False(_session.IsSingleEditMode(WindowId));
+    }
+
+    // ── Attribute pins ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_get_route_is_scoped_to_a_window()
+    {
+        var route = typeof(ResultIssueController)
+            .GetMethod(nameof(ResultIssueController.Index))!
+            .GetCustomAttribute<RouteAttribute>();
+
+        Assert.Equal("/{windowId:guid}/ResultIssue", route?.Template);
+    }
+
+    [Fact]
+    public void The_post_is_antiforgery_protected_and_shares_the_route()
+    {
+        var method = typeof(ResultIssueController).GetMethod(nameof(ResultIssueController.Confirm))!;
+
+        Assert.NotNull(method.GetCustomAttribute<HttpPostAttribute>());
+        Assert.NotNull(method.GetCustomAttribute<ValidateAntiForgeryTokenAttribute>());
+        Assert.Equal("/{windowId:guid}/ResultIssue", method.GetCustomAttribute<RouteAttribute>()?.Template);
+    }
+
+    [Fact]
+    public void The_controller_does_not_opt_out_of_authorisation()
+    {
+        // A school's results are not public. The global fallback policy authorises; an
+        // [AllowAnonymous] anywhere here would silently opt this page out of it.
+        Assert.Null(typeof(ResultIssueController).GetCustomAttribute<AllowAnonymousAttribute>());
+        Assert.All(
+            typeof(ResultIssueController).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+            m => Assert.Null(m.GetCustomAttribute<AllowAnonymousAttribute>()));
+    }
+
+    private static ResultIssueViewModel ValidPost() =>
+        new() { WindowId = WindowId, IssueType = ResultIssueViewModel.IncorrectGrade };
+
+    private sealed class FakeSession : ISession
+    {
+        private readonly Dictionary<string, byte[]> _store = new();
+
+        public bool TryGetValue(string key, out byte[] value) => _store.TryGetValue(key, out value!);
+        public void Set(string key, byte[] value) => _store[key] = value;
+        public void Remove(string key) => _store.Remove(key);
+        public void Clear() => _store.Clear();
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public bool IsAvailable => true;
+        public string Id => "test-session";
+        public IEnumerable<string> Keys => _store.Keys;
+    }
+
+    private sealed class TestSessionFeature(ISession session) : ISessionFeature
+    {
+        public ISession Session { get; set; } = session;
+    }
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/ResultIssueViewSourceTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/ResultIssueViewSourceTests.cs
@@ -1,0 +1,137 @@
+using System.Runtime.CompilerServices;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Web.Controllers;
+
+// AB#296648: pins the entry page's markup and copy against the Figma frames (p-147621 / p-147638).
+// Every string here is what a school reads, so a change should be a deliberate content decision
+// rather than an accident.
+public sealed class ResultIssueViewSourceTests
+{
+    private static string ViewSource()
+        => File.ReadAllText(Path.Combine(
+            RepoRoot, "src", "DfE.CheckPerformanceData.Web", "Views", "ResultIssue", "Index.cshtml"));
+
+    [Fact]
+    public void The_heading_is_the_radio_legend_so_there_is_exactly_one_h1()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("is-page-heading=\"true\"", view);
+        Assert.Contains("What issue with the results do you need to report?", view);
+        // A separate <h1> alongside a page-heading legend would give the page two.
+        Assert.DoesNotContain("<h1", view);
+    }
+
+    [Fact]
+    public void It_uses_the_govuk_radios_component()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("<govuk-radios for=\"IssueType\">", view);
+        Assert.Contains("<govuk-radios-fieldset>", view);
+    }
+
+    [Fact]
+    public void The_hint_matches_the_design()
+    {
+        Assert.Contains("<govuk-radios-hint>\r\n                Select one option\r\n            </govuk-radios-hint>".Replace("\r\n", "\n"),
+            ViewSource().Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void The_incorrect_grade_label_is_pinned_verbatim()
+    {
+        Assert.Contains(
+            "Incorrect grade (once you have checked your second late results file in late November)",
+            ViewSource());
+    }
+
+    [Fact]
+    public void Only_the_incorrect_grade_option_is_rendered()
+    {
+        // Sibling tickets own the other two options on the Figma screen. Rendering them here without
+        // a journey behind them would dead-end the user.
+        var view = ViewSource();
+
+        Assert.Equal(1, view.Split("<govuk-radios-item").Length - 1);
+        Assert.DoesNotContain("Missing qualification", view);
+        Assert.DoesNotContain("Result does not belong to pupil", view);
+    }
+
+    [Fact]
+    public void The_error_summary_anchors_the_radio_group()
+    {
+        // The GDS pattern: the summary link must move focus to the first control in the group.
+        var view = ViewSource();
+
+        Assert.Contains("<govuk-error-summary-item href=\"#issueType\">", view);
+        Assert.Contains("<govuk-error-summary-title>There is a problem</govuk-error-summary-title>", view);
+        // The anchor only resolves because the id is set explicitly rather than generated.
+        Assert.Contains("id=\"issueType\"", view);
+    }
+
+    [Fact]
+    public void An_inline_error_message_accompanies_the_summary()
+    {
+        // GDS requires both: the summary at the top and the message beside the field.
+        Assert.Contains("<govuk-radios-error-message>", ViewSource());
+    }
+
+    [Fact]
+    public void The_late_results_expander_is_present_with_the_designs_summary_text()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("<details class=\"govuk-details\" data-module=\"govuk-details\">", view);
+        Assert.Contains(
+            "<span class=\"govuk-details__summary-text\">Have you checked your second late results file?</span>",
+            view);
+    }
+
+    [Fact]
+    public void The_expander_sits_after_continue_so_it_reads_as_guidance_not_a_gate()
+    {
+        var view = ViewSource();
+
+        Assert.True(
+            view.IndexOf("<govuk-button type=\"submit\">Continue</govuk-button>", StringComparison.Ordinal)
+            < view.IndexOf("<details class=\"govuk-details\"", StringComparison.Ordinal),
+            "The details expander must come after the Continue button, as the Figma screen shows.");
+    }
+
+    [Fact]
+    public void The_form_posts_to_the_confirm_action_with_an_antiforgery_token()
+    {
+        var view = ViewSource();
+
+        Assert.Contains("method=\"post\"", view);
+        Assert.Contains("Url.Action(\"Confirm\", \"ResultIssue\"", view);
+        Assert.Contains("@Html.AntiForgeryToken()", view);
+    }
+
+    [Fact]
+    public void The_back_link_returns_to_the_pupil_data_page()
+    {
+        Assert.Contains(
+            "<a asp-action=\"Index\" asp-controller=\"CheckYourPupilData\" asp-route-windowId=\"@Model.WindowId\" class=\"govuk-back-link\">Back</a>",
+            ViewSource());
+    }
+
+    [Fact]
+    public void The_page_works_without_javascript()
+    {
+        // Progressive enhancement is mandatory: radios plus a submit button, no script.
+        Assert.DoesNotContain("<script", ViewSource());
+    }
+
+    private static string RepoRoot
+    {
+        get
+        {
+            var thisFile = ThisFilePath();
+            return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(thisFile)!, "..", "..", "..", ".."));
+        }
+    }
+
+    private static string ThisFilePath([CallerFilePath] string path = "") => path;
+}

--- a/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/ResultSuggestionsControllerTests.cs
+++ b/tests/DfE.CheckPerformanceData.UnitTests/Web/Controllers/ResultSuggestionsControllerTests.cs
@@ -1,0 +1,298 @@
+using System.Reflection;
+using System.Text.Json;
+using DfE.CheckPerformanceData.Application.CheckYourPupilData;
+using DfE.CheckPerformanceData.Application.CurrentUser;
+using DfE.CheckPerformanceData.Application.Journey;
+using DfE.CheckPerformanceData.Application.ResultsEnquiry;
+using DfE.CheckPerformanceData.Web.Controllers;
+using DfE.CheckPerformanceData.Web.Session;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+
+namespace DfE.CheckPerformanceData.Application.UnitTests.Web.Controllers;
+
+// AB#296648 / AB#296999: the autocomplete source behind the "which of {pupil}'s results is
+// incorrect?" page. The pupil is taken from the SESSION, never from the query string — a caller
+// must not be able to enumerate another pupil's results by guessing an id.
+public sealed class ResultSuggestionsControllerTests
+{
+    private static readonly Guid WindowId = Guid.Parse("6C2E1F4A-9B7D-4E38-8A15-3D9C2B4E7F01");
+    private const string Laestab = "860/4070";
+    private const string CypmdId = "500001";
+
+    private readonly IStudentResultsClient _results = Substitute.For<IStudentResultsClient>();
+    private readonly ICurrentUserService _currentUser = Substitute.For<ICurrentUserService>();
+    private readonly FakeSession _session = new();
+    private readonly ResultSuggestionsController _sut;
+
+    public ResultSuggestionsControllerTests()
+    {
+        _currentUser.OrganisationLaestab.Returns(Laestab);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(_session));
+
+        _sut = new ResultSuggestionsController(_results, _currentUser)
+        {
+            ControllerContext = new ControllerContext { HttpContext = httpContext }
+        };
+    }
+
+    private static StudentResultRecord Result(
+        string qan, string qualName, string session = "S2024", string grade = "5",
+        string source = ResultsFileTags.Post16Main, string cypmdId = CypmdId) => new()
+        {
+            CypmdId = cypmdId,
+            Qan = qan,
+            QualificationName = qualName,
+            SyllabusCode = "1BS0",
+            Session = session,
+            Grade = grade,
+            SourceFile = source
+        };
+
+    private static readonly StudentResultRecord[] BillysResults =
+    [
+        Result("6037116X", "GCSE (9-1) Bus. Studs:Single"),
+        Result("60181576", "GCSE (9-1) French", source: ResultsFileTags.Post16LateResults1),
+        Result("60370683", "Pearson BTEC L1/L2 Tech Award in Sport")
+    ];
+
+    private static PupilDto Pupil(string cypmdId) => new()
+    {
+        Id = Guid.NewGuid(),
+        Firstname = "Billy",
+        Surname = "B",
+        Sex = "M",
+        DateOfBirth = "12/03/2007",
+        Age = 19,
+        Cypmd_Id = cypmdId,
+        Identifier = "9900000001"
+    };
+
+    private void SelectPupil(string cypmdId = CypmdId) =>
+        _session.SetRequestState(WindowId, new RequestState
+        {
+            SelectedPupilId = Guid.NewGuid().ToString(),
+            SelectedPupil = Pupil(cypmdId)
+        });
+
+    private void HasResults(params StudentResultRecord[] results) =>
+        _results.GetResultsAsync(WindowId, Laestab, CypmdId, Arg.Any<CancellationToken>())
+            .Returns(results);
+
+    // Reads the anonymous-object JSON payload back as (value, label) pairs.
+    private static (string Value, string Label)[] Payload(IActionResult result)
+    {
+        var json = Assert.IsType<JsonResult>(result);
+        var doc = JsonSerializer.SerializeToElement(json.Value);
+        return [.. doc.EnumerateArray().Select(e =>
+            (e.GetProperty("value").GetString()!, e.GetProperty("label").GetString()!))];
+    }
+
+    [Fact]
+    public async Task Matching_by_subject_returns_the_pinned_label_and_composite_value()
+    {
+        SelectPupil();
+        HasResults(BillysResults);
+
+        var payload = Payload(await _sut.Suggestions(WindowId, "GCSE", default));
+
+        Assert.Equal(
+            [
+                ("6037116X|S2024|16to19_MAIN", "GCSE (9-1) Bus. Studs:Single, QAN: 6037116X, Session: S2024"),
+                ("60181576|S2024|16to19_LR1", "GCSE (9-1) French, QAN: 60181576, Session: S2024")
+            ],
+            payload);
+    }
+
+    [Fact]
+    public async Task Subject_matching_is_case_insensitive_and_matches_mid_string()
+    {
+        SelectPupil();
+        HasResults(BillysResults);
+
+        var payload = Payload(await _sut.Suggestions(WindowId, "french", default));
+
+        Assert.Equal([("60181576|S2024|16to19_LR1", "GCSE (9-1) French, QAN: 60181576, Session: S2024")], payload);
+    }
+
+    [Fact]
+    public async Task A_qan_prefix_matches()
+    {
+        SelectPupil();
+        HasResults(BillysResults);
+
+        var payload = Payload(await _sut.Suggestions(WindowId, "6037", default));
+
+        // 6037116X matches by QAN prefix; 60370683 does too.
+        Assert.Equal(
+            ["6037116X|S2024|16to19_MAIN", "60370683|S2024|16to19_MAIN"],
+            payload.Select(p => p.Value).ToArray());
+    }
+
+    [Fact]
+    public async Task A_qan_substring_that_is_not_a_prefix_does_not_match()
+    {
+        // Prefix-only on QAN: a substring match would make almost every numeric query match
+        // everything, which is noise rather than help.
+        SelectPupil();
+        HasResults(BillysResults);
+
+        Assert.Empty(Payload(await _sut.Suggestions(WindowId, "116X", default)));
+    }
+
+    [Fact]
+    public async Task Same_qualification_in_two_sessions_is_distinguishable_by_label_and_by_value()
+    {
+        // AB#296648: "each result shows enough detail for me to identify the right one". Distinct
+        // VALUES alone are not enough — the user reads the labels, so those must differ too.
+        SelectPupil();
+        HasResults(
+            Result("6037116X", "GCSE (9-1) Bus. Studs:Single", session: "S2024"),
+            Result("6037116X", "GCSE (9-1) Bus. Studs:Single", session: "S2023"));
+
+        var payload = Payload(await _sut.Suggestions(WindowId, "Bus", default));
+
+        Assert.Equal(
+            ["6037116X|S2024|16to19_MAIN", "6037116X|S2023|16to19_MAIN"],
+            payload.Select(p => p.Value).ToArray());
+        Assert.Equal(
+            [
+                "GCSE (9-1) Bus. Studs:Single, QAN: 6037116X, Session: S2024",
+                "GCSE (9-1) Bus. Studs:Single, QAN: 6037116X, Session: S2023"
+            ],
+            payload.Select(p => p.Label).ToArray());
+    }
+
+    [Fact]
+    public async Task Same_qualification_in_two_source_files_yields_distinct_values()
+    {
+        SelectPupil();
+        HasResults(
+            Result("6037116X", "GCSE (9-1) Bus. Studs:Single", source: ResultsFileTags.Post16Main),
+            Result("6037116X", "GCSE (9-1) Bus. Studs:Single", source: ResultsFileTags.Post16Revised));
+
+        var payload = Payload(await _sut.Suggestions(WindowId, "Bus", default));
+
+        Assert.Equal(
+            ["6037116X|S2024|16to19_MAIN", "6037116X|S2024|16to19_Revised"],
+            payload.Select(p => p.Value).ToArray());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("G")]
+    public async Task A_query_shorter_than_two_characters_returns_nothing_and_never_reads_results(string? query)
+    {
+        SelectPupil();
+
+        Assert.Empty(Payload(await _sut.Suggestions(WindowId, query, default)));
+        await _results.DidNotReceiveWithAnyArgs().GetResultsAsync(default, default!, default!);
+    }
+
+    [Fact]
+    public async Task A_query_over_a_hundred_characters_returns_nothing()
+    {
+        SelectPupil();
+
+        Assert.Empty(Payload(await _sut.Suggestions(WindowId, new string('x', 101), default)));
+        await _results.DidNotReceiveWithAnyArgs().GetResultsAsync(default, default!, default!);
+    }
+
+    [Fact]
+    public async Task With_no_pupil_in_session_it_returns_nothing_and_never_reads_results()
+    {
+        // Fail closed: without a session pupil there is no authorised scope to search within.
+        Assert.Empty(Payload(await _sut.Suggestions(WindowId, "GCSE", default)));
+        await _results.DidNotReceiveWithAnyArgs().GetResultsAsync(default, default!, default!);
+    }
+
+    [Fact]
+    public async Task A_session_pupil_with_no_cypmd_id_returns_nothing()
+    {
+        _session.SetRequestState(WindowId, new RequestState
+        {
+            SelectedPupilId = Guid.NewGuid().ToString(),
+            SelectedPupil = Pupil(string.Empty)
+        });
+
+        Assert.Empty(Payload(await _sut.Suggestions(WindowId, "GCSE", default)));
+        await _results.DidNotReceiveWithAnyArgs().GetResultsAsync(default, default!, default!);
+    }
+
+    [Fact]
+    public async Task The_search_is_scoped_to_the_session_pupil_and_the_signed_in_school()
+    {
+        SelectPupil("500009");
+        _results.GetResultsAsync(WindowId, Laestab, "500009", Arg.Any<CancellationToken>()).Returns([]);
+
+        await _sut.Suggestions(WindowId, "GCSE", default);
+
+        await _results.Received(1).GetResultsAsync(WindowId, Laestab, "500009", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Session_state_is_read_per_window_so_another_windows_pupil_is_not_used()
+    {
+        _session.SetRequestState(Guid.NewGuid(), new RequestState
+        {
+            SelectedPupilId = Guid.NewGuid().ToString(),
+            SelectedPupil = Pupil(CypmdId)
+        });
+
+        Assert.Empty(Payload(await _sut.Suggestions(WindowId, "GCSE", default)));
+    }
+
+    [Fact]
+    public async Task No_match_returns_an_empty_array_rather_than_an_error()
+    {
+        SelectPupil();
+        HasResults(BillysResults);
+
+        Assert.Empty(Payload(await _sut.Suggestions(WindowId, "Latin", default)));
+    }
+
+    [Fact]
+    public void The_route_is_pinned_and_the_action_is_get_only()
+    {
+        var method = typeof(ResultSuggestionsController).GetMethod(nameof(ResultSuggestionsController.Suggestions))!;
+
+        var route = method.GetCustomAttribute<RouteAttribute>();
+        Assert.Equal("/results/suggestions", route?.Template);
+        Assert.NotNull(method.GetCustomAttribute<HttpGetAttribute>());
+    }
+
+    [Fact]
+    public void The_controller_is_not_anonymous()
+    {
+        // A school's result data must never be readable without signing in. The global fallback
+        // policy authorises; an [AllowAnonymous] here would silently opt out of it.
+        Assert.Null(typeof(ResultSuggestionsController)
+            .GetCustomAttribute<Microsoft.AspNetCore.Authorization.AllowAnonymousAttribute>());
+    }
+
+    private sealed class FakeSession : ISession
+    {
+        private readonly Dictionary<string, byte[]> _store = new();
+
+        public bool TryGetValue(string key, out byte[] value) => _store.TryGetValue(key, out value!);
+        public void Set(string key, byte[] value) => _store[key] = value;
+        public void Remove(string key) => _store.Remove(key);
+        public void Clear() => _store.Clear();
+        public Task LoadAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task CommitAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public bool IsAvailable => true;
+        public string Id => "test-session";
+        public IEnumerable<string> Keys => _store.Keys;
+    }
+
+    private sealed class TestSessionFeature(ISession session) : ISessionFeature
+    {
+        public ISession Session { get; set; } = session;
+    }
+}


### PR DESCRIPTION
A school can report an incorrect exam grade for a 16-19 student, from choosing the enquiry type
through to a reference number on screen and by email.

**Please read `docs/results-enquiry.md` first** — it documents the journey, the data seams and the
decisions, so this description stays short.

## The journey

Late-results guidance → cohort scope → cohort count → student search → result search → revised
grade → optional comments → check answers → submit → confirmation.

Entry point: the check-your-student-data page gains a **Report an issue with an exam result** radio
for 16-19 windows, routed to the new `ResultIssueController`. The issue page renders only the
*Incorrect grade* option; the other two on the Figma screen belong to sibling tickets, and posting
their values is rejected rather than starting a journey with no flow behind it.

## Decisions taken with the BA (2026-08-17)

- **The late-results guidance informs, it never blocks.** A Figma frame greying the option out was
  considered and not chosen — it contradicts the ticket's own acceptance criteria.
- **An enquiry drops into `ChangeRequests` and saves its journey JSON, exactly as a pupil change
  request does, and is NOT enqueued.** It is ultimately bound for Zendesk, but that dispatch is a
  separate story. When it lands, the enqueue belongs in `SubmitResultsEnquiryAsync` and nowhere else,
  and the exclusion in `AdminRequestsService.ProcessCloseWindowEvent` comes out at the same time.

## Worth a reviewer's attention

Four defects were found by walking the journey in a browser; none were visible to unit tests, because
each lived in the seams between components:

1. `IStudentResultsClient` was registered only in Infrastructure's `DependencyManager`. The web host
   builds its blob clients in `Web/Startup/BlobStorageExtensions.cs` and never calls that, so the app
   crashlooped on container validation. A DI-resolution guard test now covers this.
2. The guidance page was unreachable — the flow's `firstPageId` is `cohort-scope`, so the journey
   engine's out-of-sequence guard bounced straight past it and an AC silently never happened. The
   controller now seeds `QuestionHistory` with the guidance page id.
3. `PupilSearchPost` cleared **every** answer when a primary pupil was chosen. That is right when the
   pupil page is first (the amendment journeys) but wiped this journey's cohort scope and count, and
   the summary then presented a cohort-wide enquiry as a single-student one. It now keeps answers from
   earlier pages and discards only later ones, plus `SelectedResult`.
4. `RequestRepository`'s one-request-per-pupil rule blocked an enquiry and an amendment from coexisting
   for the same pupil. That rule guards two competing *amendments*; an enquiry changes no pupil data,
   so `ResultsEnquiry` rows are excluded from both `UpsertAsync`'s block and `CheckForConflictAsync`'s
   warning. **This touches the live KS4 journeys** — please review it closely. Three integration tests
   cover both directions plus the amendment-vs-amendment case the exclusion must not weaken.

A second, browser-driven verification pass then found two more, fixed in `d772acb7`: three
single-question pages rendered **no `<h1>`** (a WCAG 2.2 AA failure) because they set a page-level
title, which suppresses `IsPageHeading`; and `additional-info` read "Additional information (Optional)
(Optional)". Both were config errors in the flow JSON. Cross-flow guards now enforce both conventions
over every flow file.

## Deviations from the plan, deliberate

- **Progressive enhancement.** Both pickers are server-rendered GOV.UK `<select>`s that
  accessible-autocomplete upgrades in place, so the result and grade pages work with JavaScript off.
  The plan specified a fetch-based autocomplete, which would not have. `/results/suggestions` is
  consequently unused by the result page — kept and tested pending a decision on the sibling tickets.
  **Reviewer question: keep it or delete it?**
- **The result label carries the exam session.** The Figma format made a resit indistinguishable from
  the original sitting, which fails the AC that each result show enough detail to identify the right
  one. Signed off by the BA.
- **No breadcrumb.** The designs show one, but no journey view in the service renders a breadcrumb, so
  adding it to a single page would look broken. Worth doing across the whole 16-19 journey at once.

## Not merged-ready without these

- **The GOV.UK Notify template does not exist**, so `Notify:ResultsEnquirySubmittedTemplateId` is empty
  in every environment and **no confirmation email sends**. AC15's "and by email" half is unmet.
  `NotifyService` logs a warning and skips rather than throwing, so the journey still completes.
- **Copy sign-off:** the must-differ message, "We cannot list grades for this qualification yet", the
  issue page's expander body (never captured in Figma), and the appended session on the result label.
- **The full AODC export** replaces the seeded `grade-reference.json` (three ticket examples plus the
  dev QANs, including the IB Diploma's 93-grade scale derived from [AB#297130](https://dfe-gov-uk.visualstudio.com/b947688b-53a4-4c90-9c43-5a5db31e313d/_workitems/edit/297130)).

## Alignment with the 16-19 window model

Per `docs/16-19-window-model.md`, without building any of the activity model: plural `ResultsEnquiry`
naming, journey→activity via Option A (`WhatToChangeActivityMap`), an activity-scoped blob prefix
(`results-enquiry/data/`), and `// PARKED` comments where visibility moves to
`IWindowActivityService.OpenActivities`.

## Testing

4,041 unit · 658 integration · 110 E2E (12 new Playwright specs driving the real enhanced
autocompletes) · Release build clean. 15 of 16 acceptance criteria fully met; AC15 is half-met pending
the Notify template.

Two pre-existing quirks noticed, not addressed here: `dotnet test` at the repo root finds nothing (the
solution is `src/DfE.CheckPerformanceData.slnx`), and the CI filter `FullyQualifiedName!~E2ETests`
silently excludes `SearchCanonicalisationE2ETests` and `SearchTelemetryE2ETests` — 13 integration tests
that never run in CI.
